### PR TITLE
Fix close event completely closed

### DIFF
--- a/Sources/Helium/HeliumCore/BuildConstants.swift
+++ b/Sources/Helium/HeliumCore/BuildConstants.swift
@@ -8,5 +8,5 @@
  */
 public struct BuildConstants {
     /// Current SDK version
-    public static let version = "2.0.14"
+    public static let version = "2.0.15"
 }

--- a/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
@@ -207,10 +207,7 @@ public class HeliumActionsDelegate: BaseActionsDelegate, ObservableObject {
     }
     
     public func logClosure() {
-        let closeEvent: HeliumPaywallEvent = .paywallClose(triggerName: trigger, paywallTemplateName: paywallInfo.paywallTemplateName)
-        DispatchQueue.main.async {
-            HeliumPaywallDelegateWrapper.shared.onHeliumPaywallEvent(event: closeEvent)
-        }
+        HeliumPaywallDelegateWrapper.shared.onHeliumPaywallEvent(event: .paywallClose(triggerName: trigger, paywallTemplateName: paywallInfo.paywallTemplateName))
     }
 }
 

--- a/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
@@ -207,7 +207,10 @@ public class HeliumActionsDelegate: BaseActionsDelegate, ObservableObject {
     }
     
     public func logClosure() {
-        HeliumPaywallDelegateWrapper.shared.onHeliumPaywallEvent(event: .paywallClose(triggerName: trigger, paywallTemplateName: paywallInfo.paywallTemplateName))
+        let closeEvent: HeliumPaywallEvent = .paywallClose(triggerName: trigger, paywallTemplateName: paywallInfo.paywallTemplateName)
+        DispatchQueue.main.async {
+            HeliumPaywallDelegateWrapper.shared.onHeliumPaywallEvent(event: closeEvent)
+        }
     }
 }
 

--- a/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
+++ b/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
@@ -75,6 +75,9 @@ public struct DynamicBaseTemplateView: BaseTemplateView {
             presentationState.handleOnDisappear()
         }
         .onReceive(presentationState.$isOpen) { newIsOpen in
+            if presentationState.viewType == .presented {
+                return
+            }
             if newIsOpen {
                 actionsDelegateWrapper.logImpression(viewType: presentationState.viewType)
             } else {

--- a/Sources/Helium/HeliumCore/HeliumFallbackViewWrapper.swift
+++ b/Sources/Helium/HeliumCore/HeliumFallbackViewWrapper.swift
@@ -37,6 +37,9 @@ public struct HeliumFallbackViewWrapper<Content: View>: View {
                 presentationState.handleOnDisappear()
             }
             .onReceive(presentationState.$isOpen) { newIsOpen in
+                if presentationState.viewType == .presented {
+                    return
+                }
                 HeliumPaywallDelegateWrapper.shared.onFallbackOpenCloseEvent(trigger: trigger, isOpen: newIsOpen, viewType: presentationState.viewType.rawValue)
             }
     }

--- a/Sources/Helium/HeliumUIKitViewController.swift
+++ b/Sources/Helium/HeliumUIKitViewController.swift
@@ -76,10 +76,12 @@ extension EnvironmentValues {
 }
 
 class HeliumViewController: UIViewController {
+    let trigger: String
     private let contentView: AnyView
     let presentationState = HeliumPaywallPresentationState(viewType: .presented)
     
-    init(contentView: AnyView) {
+    init(trigger: String, contentView: AnyView) {
+        self.trigger = trigger
         self.contentView = AnyView(contentView
             .environment(\.paywallPresentationState, presentationState))
         super.init(nibName: nil, bundle: nil)


### PR DESCRIPTION
The isOpen logic was just a tick ahead of full dismissal for the normal presentUpsell flow. This should take care of it by relying on the dismiss completion handler. It results in a bit of duplicate logic for open/close events but this is arguably easier to follow for the presentUpsell flow.

https://linear.app/tryhelium/issue/HEL-1297/fix-paywallclose-event-delay