### PR TITLE
Explicit second_try trigger

### DIFF
--- a/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
@@ -141,11 +141,16 @@ public class HeliumActionsDelegate: BaseActionsDelegate, ObservableObject {
     
     public func showSecondaryPaywall(uuid: String) {
         if (!isLoading) {
-            if let trigger = HeliumFetchedConfigManager.shared.getTriggerFromPaywallUuid(uuid) {
-                HeliumPaywallPresenter.shared.presentUpsell(trigger: trigger)
+            let secondTryTrigger = "\(trigger)_second_try"
+            // use explicit second try trigger if possible
+            if Helium.shared.getPaywallInfo(trigger: secondTryTrigger) != nil {
+                HeliumPaywallPresenter.shared.presentUpsell(trigger: secondTryTrigger)
+            } // otherwise look for a paywall that matches the uuid
+            else if let foundTrigger = HeliumFetchedConfigManager.shared.getTriggerFromPaywallUuid(uuid) {
+                HeliumPaywallPresenter.shared.presentUpsell(trigger: foundTrigger)
             } else {
                 HeliumPaywallDelegateWrapper.shared.onHeliumPaywallEvent(
-                    event: .paywallOpenFailed(triggerName: "\(trigger)_secondTry", paywallTemplateName: "unknown")
+                    event: .paywallOpenFailed(triggerName: secondTryTrigger, paywallTemplateName: "unknown")
                 )
             }
         }

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -278,7 +278,8 @@ public class HeliumFetchedConfigManager: ObservableObject {
         return fetchedConfig?.triggerToPaywalls[trigger]
     }
     
-    public func getTriggerFromPaywallUuid(_ uuid: String) -> String? {
+    // Be careful with this as there can be multiple triggers using the same paywall (and associated uuid.)
+    func getTriggerFromPaywallUuid(_ uuid: String) -> String? {
         return fetchedConfig?.triggerToPaywalls
             .first { $1.paywallUUID == uuid }?.key
     }


### PR DESCRIPTION
The same paywall can be used for multiple triggers, so just using explicit trigger_second_try which is what server sends for second try paywalls.