### PR TITLE
add an initialize option with product ids

### DIFF
--- a/Sources/HeliumRevenueCat/HeliumRevenueCat.swift
+++ b/Sources/HeliumRevenueCat/HeliumRevenueCat.swift
@@ -13,8 +13,13 @@ import Foundation
 /// in-app purchases & subscriptions. Do not use if you don't plan on configuring your purchases with RevenueCat.
 open class RevenueCatDelegate: HeliumPaywallDelegate {
     
-    let entitlementId: String
-    var offerings: Offerings?
+    public let entitlementId: String
+    private var offerings: Offerings?
+    private var products: [StoreProduct]?
+    
+    private func configureRevenueCat(revenueCatApiKey: String) {
+        Purchases.configure(withAPIKey: revenueCatApiKey, appUserID: HeliumIdentityManager.shared.getHeliumPersistentId())
+    }
     
     /// Initialize the delegate.
     ///
@@ -27,7 +32,7 @@ open class RevenueCatDelegate: HeliumPaywallDelegate {
         self.entitlementId = entitlementId
         
         if let revenueCatApiKey {
-            Purchases.configure(withAPIKey: revenueCatApiKey, appUserID: HeliumIdentityManager.shared.getHeliumPersistentId())
+            configureRevenueCat(revenueCatApiKey: revenueCatApiKey)
         }
         
         Task {
@@ -39,31 +44,70 @@ open class RevenueCatDelegate: HeliumPaywallDelegate {
         }
     }
     
+    /// Initialize the delegate.
+    ///
+    /// - Parameter entitlementId: The id of the [entitlement](https://www.revenuecat.com/docs/getting-started/entitlements) that you have configured with RevenueCat.
+    /// - Parameter productIds: A list of product IDs, configured in the App Store, that can be purchased via a Helium paywall.
+    /// - Parameter revenueCatApiKey: (Optional). Only set if you want Helium to handle RevenueCat initialization for you. Otherwise make sure to [initialize RevenueCat](https://www.revenuecat.com/docs/getting-started/quickstart#initialize-and-configure-the-sdk) before initializing Helium.
+    public init(
+        entitlementId: String,
+        productIds: [String],
+        revenueCatApiKey: String? = nil
+    ) {
+        self.entitlementId = entitlementId
+        
+        if let revenueCatApiKey {
+            configureRevenueCat(revenueCatApiKey: revenueCatApiKey)
+        }
+        
+        Task {
+            do {
+                products = try await Purchases.shared.products(productIds)
+            } catch {
+                print("[Helium] RevenueCatDelegate - Failed to load RevenueCat products: \(error.localizedDescription)")
+            }
+        }
+    }
+    
     open func makePurchase(productId: String) async -> HeliumPaywallTransactionStatus {
         do {
-            guard let offerings = self.offerings else {
-                return .failed(RevenueCatDelegateError.couldNotLoadProducts)
-            }
+            var result: PurchaseResultData? = nil
             
-            var packageToPurchase: Package? = nil
-            
-            for (_, offering) in offerings.all {
-                for package in offering.availablePackages {
-                    if package.storeProduct.productIdentifier == productId {
-                        packageToPurchase = package
+            if let offerings {
+                var packageToPurchase: Package? = nil
+                
+                for (_, offering) in offerings.all {
+                    for package in offering.availablePackages {
+                        if package.storeProduct.productIdentifier == productId {
+                            packageToPurchase = package
+                            break
+                        }
+                    }
+                    if packageToPurchase != nil {
                         break
                     }
                 }
-                if packageToPurchase != nil {
-                    break
+                
+                guard let package = packageToPurchase else {
+                    return .failed(RevenueCatDelegateError.cannotFindProductViaOffering)
                 }
+                
+                result = try await Purchases.shared.purchase(package: package)
             }
             
-            guard let package = packageToPurchase else {
-                return .failed(RevenueCatDelegateError.cannotFindProduct)
+            if let products {
+                let productToPurchase = products.first { $0.productIdentifier == productId }
+                guard let product = productToPurchase else {
+                    return .failed(RevenueCatDelegateError.cannotFindProduct)
+                }
+                
+                result = try await Purchases.shared.purchase(product: product)
             }
             
-            let result = try await Purchases.shared.purchase(package: package)
+            guard let result else {
+                return .failed(RevenueCatDelegateError.unexpected)
+            }
+            
             if result.userCancelled {
                 return .cancelled
             }
@@ -93,18 +137,21 @@ open class RevenueCatDelegate: HeliumPaywallDelegate {
 }
 
 public enum RevenueCatDelegateError: LocalizedError {
-    case couldNotLoadProducts
     case cannotFindProduct
+    case cannotFindProductViaOffering
     case purchaseNotVerified
+    case unexpected
 
     public var errorDescription: String? {
         switch self {
-        case .couldNotLoadProducts:
-            return "Could not load products. Make sure RevenueCat has products configured."
         case .cannotFindProduct:
             return "Could not find product. Please ensure products are properly configured."
+        case .cannotFindProductViaOffering:
+            return "Could not find product. Please ensure offering is properly configured or initialize with productIds instead."
         case .purchaseNotVerified:
             return "Entitlement could not be verified as active."
+        case .unexpected:
+            return "Unexpected RevenueCatDelegateError."
         }
     }
 }

--- a/Sources/HeliumRevenueCat/HeliumRevenueCat.swift
+++ b/Sources/HeliumRevenueCat/HeliumRevenueCat.swift
@@ -95,7 +95,7 @@ open class RevenueCatDelegate: HeliumPaywallDelegate {
                 result = try await Purchases.shared.purchase(package: package)
             }
             
-            if let products {
+            if let products, result == nil {
                 let productToPurchase = products.first { $0.productIdentifier == productId }
                 guard let product = productToPurchase else {
                     return .failed(RevenueCatDelegateError.cannotFindProduct)


### PR DESCRIPTION
https://linear.app/tryhelium/issue/HEL-1205/swiftrn-consider-different-non-offering-options-for-revenuecat

This adds a way to initialize with product ids instead of an offering. So it's one or the other. Avoiding both seems quite difficult unless we somehow pass product IDs to the mobile apps via backend. The backend should already have access to App Store Connect API, so theoretically we could pass in product IDs during initialize or create a new endpoint for this.