### PR TITLE
Test via deep link

### DIFF
--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -211,6 +211,28 @@ public class Helium {
     public func setAppAttributionToken(_ token: UUID) {
         HeliumIdentityManager.shared.setCustomAppAttributionToken(token)
     }
+    
+    public func handleDeepLink(_ url: URL) -> Bool {
+        // Only "test paywall" deep links handled at this time.
+        guard url.host == "helium-test" else {
+            return false
+        }
+        
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let queryItems = components.queryItems else {
+            print("[Helium] Invalid test URL format: \(url)")
+            return false
+        }
+        
+        guard let trigger = queryItems.first(where: { $0.name == "trigger" })?.value else {
+            print("[Helium] Missing 'trigger' parameter in test URL: \(url)")
+            return false
+        }
+        
+        presentUpsell(trigger: trigger)
+        return true
+    }
+    
 }
 
 @available(iOS 15.0, *)

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -221,12 +221,22 @@ public class Helium {
         
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               let queryItems = components.queryItems else {
-            print("[Helium] Invalid test URL format: \(url)")
+            print("[Helium] handleDeepLink - Invalid test URL format: \(url)")
             return false
         }
         
         guard let trigger = queryItems.first(where: { $0.name == "trigger" })?.value else {
-            print("[Helium] Missing 'trigger' parameter in test URL: \(url)")
+            print("[Helium] handleDeepLink - Missing 'trigger' parameter in test URL: \(url)")
+            return false
+        }
+        
+        // Do not show fallbacks... check to see if the needed bundle is available
+        if !paywallsLoaded() {
+            print("[Helium] handleDeepLink - Helium has not successfully completed initialization.")
+            return false
+        }
+        if getPaywallInfo(trigger: trigger) == nil {
+            print("[Helium] handleDeepLink - Bundle is not available for this trigger.")
             return false
         }
         

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -212,6 +212,7 @@ public class Helium {
         HeliumIdentityManager.shared.setCustomAppAttributionToken(token)
     }
     
+    @discardableResult
     public func handleDeepLink(_ url: URL) -> Bool {
         // Only "test paywall" deep links handled at this time.
         guard url.host == "helium-test" else {
@@ -228,6 +229,9 @@ public class Helium {
             print("[Helium] Missing 'trigger' parameter in test URL: \(url)")
             return false
         }
+        
+        // hide any existing upsells
+        hideAllUpsells()
         
         presentUpsell(trigger: trigger)
         return true


### PR DESCRIPTION
For now it will accept either a `trigger` or `puid` (paywall UUID) in the url. It simply clears any existing paywall and displays the new one.

Important notes:
1. Helium must be initialized before opening a deep link or this will not work.
2. If you then update a paywall and want the latest, you have to restart your app so `initialize` runs again to grab the latest! Two ways we could improve this: 1) implement [HEL-1558](https://linear.app/tryhelium/issue/HEL-1558/dont-fallback-if-initial-download-in-progress) and always call `initialize` in `handleDeepLink` before displaying or 2) build a new server endpoint that simply fetches paywall via trigger and/or paywall UUID.
3. If the app is not already open upon scan, paywall will not open ([HEL-1558](https://linear.app/tryhelium/issue/HEL-1558/dont-fallback-if-initial-download-in-progress)?)
4. Initial sketch of QR generation here https://github.com/cloudcaptainai/content-manager-lite/pull/85/files
5. A future enhancement could be simply refreshing any existing test display upon QR scan rather than closing and presenting a new one. (I can create a linear task for this)
6. Docs are drafted out; will link to that once can publish on Mintlify again.
