### PR TITLE
Fallback addendum (after server implemented)

### DIFF
--- a/Helium.podspec
+++ b/Helium.podspec
@@ -16,7 +16,6 @@ Pod::Spec.new do |s|
   
   s.source_files = ['Sources/Helium/**/*']
 
-  s.dependency 'Kingfisher', '~> 8.0'
   s.dependency 'AnyCodable-FlightSchool', '~> 0.6.0'
   s.dependency 'AnalyticsSwiftCocoapod', '~> 1.7'
   s.dependency 'SwiftyJSON', '~> 5.0.2'

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1a2b54b1be94d06ccf70d5f768d8581846d43db8852e11dd3f9d5fbfe8c3b63e",
+  "originHash" : "87b4e430fab410e6dd33e9c6733673533eac1649632d28e229a855f71d89de8d",
   "pins" : [
     {
       "identity" : "analytics-swift",
@@ -35,15 +35,6 @@
       "state" : {
         "revision" : "af6a8b360984085e36c6341b21ecb35c12f47ebd",
         "version" : "2.0.0"
-      }
-    },
-    {
-      "identity" : "kingfisher",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/onevcat/Kingfisher.git",
-      "state" : {
-        "revision" : "7deda23bbdca612076c5c315003d8638a08ed0f1",
-        "version" : "8.3.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,6 @@ let package = Package(
             targets: ["HeliumRevenueCat", "Helium"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/onevcat/Kingfisher.git", .upToNextMajor(from: "8.0.0")),
         .package(url: "https://github.com/Flight-School/AnyCodable", .upToNextMajor(from: "0.6.0")),
         .package(url: "https://github.com/segmentio/analytics-swift", .upToNextMajor(from: "1.5.11")),
         .package(url: "https://github.com/SwiftyJSON/SwiftyJSON.git", .upToNextMajor(from: "5.0.2")),
@@ -31,7 +30,6 @@ let package = Package(
         .target(
             name: "Helium",
             dependencies: [
-                .product(name: "Kingfisher", package: "Kingfisher"),
                 .product(name: "Segment", package: "analytics-swift"),
                 .product(name: "AnyCodable", package: "AnyCodable"),
                 .product(name: "SwiftyJSON", package: "SwiftyJSON"),

--- a/Sources/Helium/HeliumCore/Components/DynamicImage.swift
+++ b/Sources/Helium/HeliumCore/Components/DynamicImage.swift
@@ -1,10 +1,10 @@
 import Foundation
 import SwiftUI
-import Kingfisher
 import SwiftyJSON
 
 
 
+@available(iOS 15.0, *)
 public struct DynamicImage: View {
     private let imageSource: ImageSource
     private let tintColor: ColorConfig?
@@ -47,11 +47,10 @@ public struct DynamicImage: View {
             switch imageSource {
             case .url(let urlString):
                 if (isResizable) {
-                    KFImage(URL(string: urlString))
-                        .resizable()
+                    AsyncImage(url: URL(string: urlString))
                         .aspectRatioIfNeeded(aspectRatio)
                 } else {
-                    KFImage(URL(string: urlString))
+                    AsyncImage(url: URL(string: urlString))
                         .aspectRatioIfNeeded(aspectRatio)
                 }
             case .system(let name):
@@ -123,16 +122,6 @@ extension View {
 }
 
 extension Image {
-    func resizable(_ isResizable: Bool) -> some View {
-        if isResizable {
-            return AnyView(self.resizable())
-        } else {
-            return AnyView(self)
-        }
-    }
-}
-
-extension KFImage {
     func resizable(_ isResizable: Bool) -> some View {
         if isResizable {
             return AnyView(self.resizable())

--- a/Sources/Helium/HeliumCore/Components/DynamicPositionedComponent.swift
+++ b/Sources/Helium/HeliumCore/Components/DynamicPositionedComponent.swift
@@ -77,7 +77,11 @@ public struct DynamicPositionedComponent: View {
         case .linearGradient(let props):
             DynamicLinearGradient(json: props)
         case .image(let props):
-            DynamicImage(json: props)
+            if #available(iOS 15.0, *) {
+                DynamicImage(json: props)
+            } else {
+                Text("img")
+            }
         case .rectangle(let props):
             DynamicRectangle(json: props)
         case .roundedRectangle(let props):

--- a/Sources/Helium/HeliumCore/HeliumAssetManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumAssetManager.swift
@@ -1,6 +1,5 @@
 import Foundation
 import SwiftyJSON
-import Kingfisher
 import Combine
 
 public enum HeliumAssetDownloadStatus: String, Codable {

--- a/Sources/Helium/HeliumCore/HeliumFallbackViewManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumFallbackViewManager.swift
@@ -38,7 +38,7 @@ public class HeliumFallbackViewManager {
                 let data = try Data(contentsOf: fallbackBundleURL)
                 let decodedConfig = try JSONDecoder().decode(HeliumFetchedConfig.self, from: data)
                 
-                loadedConfig = massageFallbackConfig(decodedConfig)
+                loadedConfig = decodedConfig
                 if let json = try? JSON(data: data) {
                     loadedConfigJSON = json
                 }
@@ -75,36 +75,10 @@ public class HeliumFallbackViewManager {
     }
     
     public func getFallbackInfo(trigger: String) -> HeliumPaywallInfo? {
-        var result = loadedConfig?.triggerToPaywalls[trigger]
-        if let paywallUUID = result?.paywallUUID {
-            // make events easily identifiable as fallback events
-            result?.paywallTemplateName = "fallback_\(paywallUUID)"
-        }
-        return result
+        return loadedConfig?.triggerToPaywalls[trigger]
     }
     public func getResolvedConfigJSONForTrigger(_ trigger: String) -> JSON? {
-        return massageResolvedConfigJSON(loadedConfigJSON?["triggerToPaywalls"][trigger]["resolvedConfig"])
-    }
-    
-    private func massageFallbackConfig(_ config: HeliumFetchedConfig) -> HeliumFetchedConfig {
-        var newConfig = config
-        newConfig.bundles = [:]
-        for (bundleId, content) in (config.bundles ?? [:]) {
-            let fallbackBundleId = bundleId.starts(with: "flbk_") ? bundleId : "flbk_\(bundleId)"
-            newConfig.bundles![fallbackBundleId] = content
-        }
-        return newConfig
-    }
-    private func massageResolvedConfigJSON(_ json: JSON?) -> JSON? {
-        guard let json else { return nil }
-        guard let providedURL = json["baseStack"]["componentProps"]["bundleURL"].string else {
-            return json
-        }
-        var newJSON = json
-        if let newBundleURL = JSON(rawValue: providedURL.replacingOccurrences(of: "/bundle_", with: "/bundle_flbk_")) {
-            newJSON["baseStack"]["componentProps"]["bundleURL"] = newBundleURL
-        }
-        return newJSON
+        return loadedConfigJSON?["triggerToPaywalls"][trigger]["resolvedConfig"]
     }
     
 }

--- a/Sources/Helium/HeliumCore/HeliumFallbackViewManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumFallbackViewManager.swift
@@ -81,4 +81,8 @@ public class HeliumFallbackViewManager {
         return loadedConfigJSON?["triggerToPaywalls"][trigger]["resolvedConfig"]
     }
     
+    public func getConfig() -> HeliumFetchedConfig? {
+        return loadedConfig
+    }
+    
 }


### PR DESCRIPTION
- Remove `Kingfisher` dependency
  - RN doesn't like version Kingfisher 8.0 but figured we might as well just remove it... it's only used for `DynamicImage` which I don't believe is actually used at all?
- Remove fallback bundle data massaging since it'll be done on server
- If no analytics available (`Helium.initialize` was not successful) try using the data provided by fallback bundle so can still potentially log helium paywall events.
  - Is it safe to store analytics key/endpoint in the bundle? We could definitely strip if so. But I thought theoretically it might be useful to still try and log with fallback bundle values.

server piece here
https://github.com/cloudcaptainai/content-manager-lite/pull/96