### PR TITLE
subspecs to allow optional RC delegate import!

### DIFF
--- a/Helium.podspec
+++ b/Helium.podspec
@@ -14,10 +14,21 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '14.0'
   s.swift_version = '5.0'
   
-  s.source_files = ['Sources/Helium/**/*']
-
-  s.dependency 'AnyCodable-FlightSchool', '~> 0.6.0'
-  s.dependency 'AnalyticsSwiftCocoapod', '~> 1.7'
-  s.dependency 'SwiftyJSON', '~> 5.0.2'
-  s.dependency 'DeviceKit', '~> 4.0.0'
+  s.default_subspec = 'Core'
+  
+  # Core subspec - base Helium functionality without RevenueCat
+  s.subspec 'Core' do |core|
+    core.source_files = 'Sources/Helium/**/*'
+    core.dependency 'AnyCodable-FlightSchool', '~> 0.6.0'
+    core.dependency 'SwiftyJSON', '~> 5.0.2'
+    core.dependency 'DeviceKit', '~> 4.0.0'
+  end
+  
+  # RevenueCat subspec - adds RevenueCat integration
+  s.subspec 'RevenueCat' do |rc|
+    rc.source_files = 'Sources/HeliumRevenueCat/**/*'
+    rc.module_name = 'HeliumRevenueCat'
+    rc.dependency 'Helium/Core'
+    rc.dependency 'RevenueCat', '~> 5.0.0'
+  end
 end


### PR DESCRIPTION
RevenueCat users can install

`pod 'Helium/RevenueCat'`

instead of 

`pod 'Helium'`

And it'll function the same as the swift package they just need to `import HeliumRevenueCat` to use the delegate!

Existing users will get Helium/Core with `pod 'Helium'` since that is the default subspec!