### PR TITLE
Apple sign-in dialog issue

### DIFF
--- a/Sources/Helium/HeliumCore/AppReceiptsHelper.swift
+++ b/Sources/Helium/HeliumCore/AppReceiptsHelper.swift
@@ -19,6 +19,13 @@ class AppReceiptsHelper {
             return
         }
         setupCompleted = true
+        if Bundle.main.appStoreReceiptURL != nil {
+            // Just rely on appStoreReceiptURL if available, even though it is deprecated.
+            // AppTransaction.shared can trigger Apple account sign-in dialog in debug/sandbox
+            // if not signed into a sandbox account, which is annoying for sdk integrators.
+            return
+        }
+#if !DEBUG
         if #available(iOS 16.0, *) {
             Task {
                 let verificationResult = try? await AppTransaction.shared
@@ -46,12 +53,13 @@ class AppReceiptsHelper {
                 }
             }
         }
+#endif
     }
     
     func getEnvironment() -> String {
-        #if DEBUG
+#if DEBUG
         return "debug"
-        #else
+#else
         if let appTransactionEnvironment {
             return appTransactionEnvironment
         }
@@ -68,7 +76,7 @@ class AppReceiptsHelper {
             return "production"
             #endif
         }
-        #endif
+#endif
     }
     
 }


### PR DESCRIPTION
Minimize chances of Apple sign-in dialog showing by considering DEBUG early and seeing if `appStoreReceiptURL` is available.

I have one concern with this though. I worry the prompt may still show if in sandbox (testflight) and you aren't logged in to a sandbox account. Maybe we should just not check `AppTransaction.shared` even though `appStoreReceiptURL` is deprecated and Apple docs recommend using `AppTransaction.shared`?

The RevenueCat code looks like this:
```
var isSandbox: Bool {
    guard !self.isRunningInSimulator else {
        return true
    }

    guard let path = self.bundle.value.appStoreReceiptURL?.path else {
        return false
    }

    return path.contains("sandboxReceipt")
}
```