### PR TITLE
Intro offer eligibility

### DIFF
--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -230,9 +230,10 @@ public class HeliumFetchedConfigManager: ObservableObject {
             
             // Fetch prices for all products in one shot
             if #available(iOS 15.0, *) {
+                // StoreKit 2 available
                 self.localizedPriceMap = await PriceFetcher.localizedPricing(for: Array(allProductIds))
             } else {
-                // Fallback for older iOS versions
+                // Fallback for older iOS versions (StoreKit 1)
                 await withCheckedContinuation { continuation in
                     PriceFetcher.localizedPricing(for: Array(allProductIds)) { prices in
                         self.localizedPriceMap = prices
@@ -240,8 +241,6 @@ public class HeliumFetchedConfigManager: ObservableObject {
                     }
                 }
             }
-        } catch {
-            print("Error fetching localized prices");
         }
     }
     

--- a/Sources/Helium/HeliumCore/PriceFetcher.swift
+++ b/Sources/Helium/HeliumCore/PriceFetcher.swift
@@ -13,7 +13,8 @@ public struct BasePriceInfo: Codable {
 
 // Subscription specific info
 public struct SubscriptionInfo: Codable {
-    public let period: String
+    public let periodUnit: String
+    public let periodValue: Int
     public let introOfferEligible: Bool
     public let introOffer: SubscriptionOffer?
 }
@@ -130,8 +131,6 @@ public class PriceFetcher {
                 
                 // Handle different product types
                 if let sub = product.subscription {
-                    let unitString: String = formatSubscriptionPeriod(sub.subscriptionPeriod.unit)
-                    
                     var introOfferData: SubscriptionOffer? = nil
                     if let introOffer = sub.introductoryOffer {
                         introOfferData = SubscriptionOffer(
@@ -146,7 +145,8 @@ public class PriceFetcher {
                     }
                     
                     subscriptionInfo = SubscriptionInfo(
-                        period: unitString,
+                        periodUnit: formatSubscriptionPeriod(sub.subscriptionPeriod.unit),
+                        periodValue: sub.subscriptionPeriod.value,
                         introOfferEligible: await checkIntroOfferEligibility(for: product),
                         introOffer: introOfferData
                     )
@@ -278,7 +278,8 @@ private class StoreKit1Delegate: NSObject, SKProductsRequestDelegate {
                     productTypeString = "autoRenewable"
                     // Create subscription info if available
                     subscriptionInfo = SubscriptionInfo(
-                        period: "unknown",
+                        periodUnit: "unknown",
+                        periodValue: 1,
                         introOfferEligible: false,
                         introOffer: nil
                     )

--- a/Sources/Helium/HeliumCore/PriceFetcher.swift
+++ b/Sources/Helium/HeliumCore/PriceFetcher.swift
@@ -90,7 +90,7 @@ public class PriceFetcher {
     /// Fetches the localized price for multiple SKUs using async/await
     /// - Parameter skus: Array of product identifiers
     /// - Returns: Dictionary mapping SKUs to their localized price information
-    @available(iOS 15.0, *)
+    @available(iOS 15.0, *) // StoreKit 2 is iOS 15+
     public static func localizedPricing(for skus: [String]) async -> [String: LocalizedPrice] {
         var priceMap: [String: LocalizedPrice] = [:]
         do {
@@ -169,52 +169,12 @@ public class PriceFetcher {
         return priceMap
     }
     
-    /// Fetches the localized price for a specific set of product IDs
-    /// - Parameters:
-    ///   - skus: Array of product identifiers
-    ///   - productFilter: Specific product IDs to include
-    /// - Returns: Dictionary with only the filtered product IDs
-    @available(iOS 15.0, *)
-    public static func localizedPricing(for skus: [String], filteredBy productFilter: [String]) async -> [String: LocalizedPrice] {
-        let allPrices = await localizedPricing(for: skus)
-        // Filter to only include products in productFilter
-        return allPrices.filter { productFilter.contains($0.key) }
-    }
-    
-    /// Fetches the localized price for a single SKU using async/await
-    /// - Parameter sku: The product identifier
-    /// - Returns: The localized price information or nil if not found
-    @available(iOS 15.0, *)
-    public static func localizedPricing(for sku: String) async -> LocalizedPrice? {
-        let prices = await localizedPricing(for: [sku])
-        return prices[sku]
-    }
-    
     /// Fetches the localized price for multiple SKUs using completion handler
     /// - Parameters:
     ///   - skus: Array of product identifiers
     ///   - completion: A closure that returns a dictionary mapping SKUs to their localized price information
     public static func localizedPricing(for skus: [String], completion: @escaping ([String: LocalizedPrice]) -> Void) {
-        if #available(iOS 15.0, *) {
-            Task {
-                let prices = await localizedPricing(for: skus)
-                DispatchQueue.main.async {
-                    completion(prices)
-                }
-            }
-        } else {
-            fallbackToStoreKit1(for: skus, completion: completion)
-        }
-    }
-    
-    /// Fetches the localized price for a single SKU using completion handler
-    /// - Parameters:
-    ///   - sku: The product identifier
-    ///   - completion: A closure that returns the localized price information or nil if not found
-    public static func localizedPricing(for sku: String, completion: @escaping (LocalizedPrice?) -> Void) {
-        localizedPricing(for: [sku]) { prices in
-            completion(prices[sku])
-        }
+        fallbackToStoreKit1(for: skus, completion: completion)
     }
     
     /// Fallback method using StoreKit 1

--- a/Sources/Helium/HeliumCore/PriceFetcher.swift
+++ b/Sources/Helium/HeliumCore/PriceFetcher.swift
@@ -22,7 +22,8 @@ public struct SubscriptionOffer: Codable {
     public let type: String
     public let price: Decimal
     public let displayPrice: String
-    public let period: String
+    public let periodUnit: String
+    public let periodValue: Int
     public let periodCount: Int
     public let paymentMode: String
 }
@@ -80,7 +81,8 @@ public struct LocalizedPrice: Codable {
                     "type": introOffer.type,
                     "price": introOffer.price,
                     "displayPrice": introOffer.displayPrice,
-                    "period": introOffer.period,
+                    "periodUnit": introOffer.periodUnit,
+                    "periodValue": introOffer.periodValue,
                     "periodCount": introOffer.periodCount,
                     "paymentMode": introOffer.paymentMode,
                 ]
@@ -136,7 +138,8 @@ public class PriceFetcher {
                             type: introOffer.type.rawValue,
                             price: introOffer.price,
                             displayPrice: introOffer.displayPrice,
-                            period: formatSubscriptionPeriod(introOffer.period.unit),
+                            periodUnit: formatSubscriptionPeriod(introOffer.period.unit),
+                            periodValue: introOffer.period.value,
                             periodCount: introOffer.periodCount,
                             paymentMode: introOffer.paymentMode.rawValue
                         )


### PR DESCRIPTION
Utilize PriceFetcher and pass along both intro offer eligibility and offer details if available.

From there I'm thinking the bundler service could use this data to determine whether to show intro offer pricing & details.

**NOTE** Store Kit 1 is not yet implemented. I have some claude-assisted WIP for this but it is quite complicated as we need to validate receipt and use that to see if user has previously had a subscription in this subscription group in the past.