### PR TITLE
Only one paywall presented at a time

### DIFF
--- a/Sources/Helium/HeliumCore/Models.swift
+++ b/Sources/Helium/HeliumCore/Models.swift
@@ -345,7 +345,6 @@ public enum HeliumPaywallEvent: Codable {
         }
     }
     
-    // Note - this is used by Expo SDK
     public func toDictionary() -> [String: Any] {
         var dict: [String: Any] = [
             "type": self.caseString()

--- a/Sources/Helium/HeliumPaywallPresenter.swift
+++ b/Sources/Helium/HeliumPaywallPresenter.swift
@@ -24,15 +24,19 @@ class HeliumPaywallPresenter {
     }
     
     func presentUpsellWithLoadingBudget(trigger: String, from viewController: UIViewController? = nil) {
+        if !paywallsDisplayed.isEmpty {
+            // Only allow one paywall to be presented at a time. (Exception being second try paywalls.)
+            print("[Helium] A paywall is already being presented.")
+            HeliumPaywallDelegateWrapper.shared.fireEvent(
+                PaywallSkippedEvent(triggerName: trigger)
+            )
+            return
+        }
+        
         Task { @MainActor in
             // Check if paywall is ready
             if Helium.shared.paywallsLoaded() {
                 presentUpsell(trigger: trigger, from: viewController)
-                return
-            }
-            
-            // Check if any loading paywall is already in progress
-            if paywallsDisplayed.contains(where: { $0.isLoading }) {
                 return
             }
             

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -15,13 +15,12 @@ public class Helium {
     
     public static let shared = Helium()
     
-    public func presentUpsell(trigger: String, from viewController: UIViewController? = nil, eventHandlers: PaywallEventHandlers? = nil, customPaywallTraits: [String: Any]? = nil) {
-        // Configure presentation context (always set both to ensure proper reset)
-        HeliumPaywallDelegateWrapper.shared.configurePresentationContext(
-            eventService: eventHandlers,
-            customPaywallTraits: customPaywallTraits
-        )
-        
+    public func presentUpsell(
+        trigger: String,
+        from viewController: UIViewController? = nil,
+        eventHandlers: PaywallEventHandlers? = nil,
+        customPaywallTraits: [String: Any]? = nil
+    ) {
         let paywallInfo = HeliumFetchedConfigManager.shared.getPaywallInfoForTrigger(trigger)
         if paywallInfo?.shouldShow == false {
             HeliumPaywallDelegateWrapper.shared.fireEvent(
@@ -30,14 +29,17 @@ public class Helium {
             return
         }
         
-        // Use loading budget approach if configured for this trigger
-        // Default to false if fallbackConfig is nil (backward compatibility with deprecated init)
-        let useLoadingForTrigger = fallbackConfig?.useLoadingState(for: trigger) ?? false
-        if useLoadingForTrigger {
-            HeliumPaywallPresenter.shared.presentUpsellWithLoadingBudget(trigger: trigger, from: viewController)
-        } else {
-            HeliumPaywallPresenter.shared.presentUpsell(trigger: trigger, from: viewController)
-        }
+        // Configure presentation context (always set both to ensure proper reset)
+        HeliumPaywallDelegateWrapper.shared.configurePresentationContext(
+            eventService: eventHandlers,
+            customPaywallTraits: customPaywallTraits
+        )
+        
+        HeliumPaywallPresenter.shared.presentUpsellWithLoadingBudget(trigger: trigger, from: viewController)
+    }
+    
+    public func loadingStateEnabledFor(trigger: String) -> Bool {
+        return fallbackConfig?.useLoadingState(for: trigger) ?? false
     }
     
     public func getDownloadStatus() -> HeliumFetchedConfigStatus {


### PR DESCRIPTION
PaywallEventHandlers rely on there being only one paywall presented at a time, plus it doesn't make sense to display more than one (aside from second try flow).