### PR TITLE
More fallback safety / PaywallOpenFailedEvent dispatch

### DIFF
--- a/Sources/Helium/HeliumCore/HeliumFallbackViewManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumFallbackViewManager.swift
@@ -67,7 +67,7 @@ public class HeliumFallbackViewManager {
     }
     
     
-    public func getFallbackForTrigger(trigger: String) -> AnyView {
+    public func getFallbackForTrigger(trigger: String) -> AnyView? {
         if let fallbackView = triggerToFallbackView[trigger] {
             return fallbackView
         }
@@ -75,8 +75,7 @@ public class HeliumFallbackViewManager {
         if let defaultFallback = defaultFallback {
             return defaultFallback
         }
-        // Return empty view if no fallback is configured
-        return AnyView(EmptyView())
+        return nil
     }
     
     public func getFallbackInfo(trigger: String) -> HeliumPaywallInfo? {


### PR DESCRIPTION
While rare, it is possible for there to be no fallback available. In this situation, I suggest we ensure PaywallOpenFailedEvent is fired and hide the presented paywall display if presented as opposed to showing an EmptyView().

For example:
- If a RN/Expo paywall is displayed while bundles still downloading, and then after successful download the trigger does not have a bundle available, and no fallback bundle provided. (I plan to make it so that RN `onFallback` will be called whenever PaywallOpenFailedEvent fires)
- Fallback tries to find paywall in `triggerToFallbackView` but no mapping exists and there are no other fallback options configured.