### PR TITLE
Safer webview preload

### DIFF
--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -297,20 +297,20 @@ class WebViewManager {
     
     static let shared: WebViewManager = WebViewManager()
     
-    private var preloadWebViewBundle: PaywallWebViewBundle? = nil
-    private(set) var preparedWebViewBundles: [PaywallWebViewBundle] = []
+    private var preloadWebViewHolder: PaywallWebViewHolder? = nil
+    private(set) var preparedWebViewHolders: [PaywallWebViewHolder] = []
     
     func preCreateFirstWebView() {
         Task {
             // Just use this one for preloading purposes
-            preloadWebViewBundle = await createWebViewBundle(filePath: nil)
+            preloadWebViewHolder = await createWebViewHolder(filePath: nil)
             // Speed things up slightly by having first one ready for use
-            let initialEmptyBundle = await createWebViewBundle(filePath: nil)
-            preparedWebViewBundles.append(initialEmptyBundle)
+            let initialWebViewHolder = await createWebViewHolder(filePath: nil)
+            preparedWebViewHolders.append(initialWebViewHolder)
         }
     }
     
-    fileprivate func createWebViewBundle(filePath: String? = nil) async -> PaywallWebViewBundle {
+    fileprivate func createWebViewHolder(filePath: String? = nil) async -> PaywallWebViewHolder {
         let messageHandler = WebViewMessageHandler()
         
         let config = WKWebViewConfiguration()
@@ -339,7 +339,7 @@ class WebViewManager {
         let webView = await WKWebView(frame: .zero, configuration: config)
         await webView.configuration.preferences.javaScriptEnabled = true
         
-        return PaywallWebViewBundle(
+        return PaywallWebViewHolder(
             filePath: filePath, webView: webView, msgHandler: messageHandler
         )
     }
@@ -351,24 +351,24 @@ class WebViewManager {
         delegateWrapper: ActionsDelegateWrapper,
         heliumViewController: HeliumViewController?
     ) async -> WKWebView? {
-        var webViewBundle = preparedWebViewBundles.first { $0.filePath == filePath && !$0.isInUse }
-        if webViewBundle == nil {
-            webViewBundle = preparedWebViewBundles.first { $0.filePath == nil } // see if there's one available
-            if let webViewBundle {
-                webViewBundle.filePath = filePath
+        var webViewHolder = preparedWebViewHolders.first { $0.filePath == filePath && !$0.isInUse }
+        if webViewHolder == nil {
+            webViewHolder = preparedWebViewHolders.first { $0.filePath == nil } // see if there's one available
+            if let webViewHolder {
+                webViewHolder.filePath = filePath
             } else {
-                let newBundle = await createWebViewBundle(filePath: filePath)
-                preparedWebViewBundles.append(newBundle)
-                webViewBundle = newBundle
+                let newWebViewHolder = await createWebViewHolder(filePath: filePath)
+                preparedWebViewHolders.append(newWebViewHolder)
+                webViewHolder = newWebViewHolder
             }
         }
-        guard let webViewBundle else { return nil }
-        webViewBundle.heliumViewController = heliumViewController
-        webViewBundle.messageHandler.setActionsDelegate(delegateWrapper: delegateWrapper)
+        guard let webViewHolder else { return nil }
+        webViewHolder.heliumViewController = heliumViewController
+        webViewHolder.messageHandler.setActionsDelegate(delegateWrapper: delegateWrapper)
         
-        let webView = webViewBundle.preparedWebView
+        let webView = webViewHolder.preparedWebView
         
-        webView.navigationDelegate = webViewBundle.messageHandler
+        webView.navigationDelegate = webViewHolder.messageHandler
         webView.contentMode = .scaleToFill
         webView.backgroundColor = .clear
         webView.isOpaque = false
@@ -403,7 +403,7 @@ class WebViewManager {
     
     @MainActor
     fileprivate func preloadFilePath(_ filePath: String) {
-        guard let webView = preloadWebViewBundle?.preparedWebView else {
+        guard let webView = preloadWebViewHolder?.preparedWebView else {
             return
         }
         try? loadFilePath(filePath, toWebView: webView)
@@ -424,7 +424,7 @@ class WebViewManager {
     
 }
 
-class PaywallWebViewBundle {
+class PaywallWebViewHolder {
     var filePath: String? = nil
     let preparedWebView: WKWebView
     let messageHandler: WebViewMessageHandler

--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -297,14 +297,16 @@ class WebViewManager {
     
     static let shared: WebViewManager = WebViewManager()
     
+    private var preloadWebViewBundle: PaywallWebViewBundle? = nil
     private(set) var preparedWebViewBundles: [PaywallWebViewBundle] = []
     
     func preCreateFirstWebView() {
         Task {
-            let bundle = await createWebViewBundle(filePath: nil)
-            preparedWebViewBundles.append(
-                bundle
-            )
+            // Just use this one for preloading purposes
+            preloadWebViewBundle = await createWebViewBundle(filePath: nil)
+            // Speed things up slightly by having first one ready for use
+            let initialEmptyBundle = await createWebViewBundle(filePath: nil)
+            preparedWebViewBundles.append(initialEmptyBundle)
         }
     }
     
@@ -401,9 +403,7 @@ class WebViewManager {
     
     @MainActor
     fileprivate func preloadFilePath(_ filePath: String) {
-        // can use any webview for preloading
-        var webViewBundle: PaywallWebViewBundle? = preparedWebViewBundles.first
-        guard let webView = webViewBundle?.preparedWebView else {
+        guard let webView = preloadWebViewBundle?.preparedWebView else {
             return
         }
         try? loadFilePath(filePath, toWebView: webView)


### PR DESCRIPTION
This is mainly refactoring extracted from #61. The impetus is to address a theoretical scenario where a webview is mid-preloading when an actual paywall bundle attempts to load into the same webview. I don't think that it's actually possible with current code though due to @MainActor usage.