### PR TITLE
Entitlements

### DIFF
--- a/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
@@ -7,28 +7,72 @@
 
 import StoreKit
 
-class HeliumEntitlementsManager {
+actor HeliumEntitlementsManager {
     
     static let shared = HeliumEntitlementsManager()
     
-    // does not include consumables
-    public func hasAnyActiveSubscription(includeNonRenewing: Bool = true) async -> Bool {
-        for await result in Transaction.currentEntitlements {
-            if case .verified(let transaction) = result {
-                if transaction.productType == .autoRenewable {
-                    return true
-                } else if includeNonRenewing && transaction.productType == .nonRenewable {
-                    return true
-                }
-            }
-        }
-        return false
+    // MARK: - Cache Structure
+    private struct EntitlementsCache {
+        var transactions: [Transaction] = []
+        var subscriptionStatuses: [String: Product.SubscriptionInfo.Status] = [:] // productID -> status
+        var isLoaded: Bool = false
     }
     
-    // does not include consumables
-    public func hasAnyEntitlement() async -> Bool {
+    private var cache = EntitlementsCache()
+    private var updateListenerTask: Task<Void, Never>?
+    
+    deinit {
+        updateListenerTask?.cancel()
+    }
+    
+    // MARK: - Transaction Update Listener
+    private func startTransactionListener() {
+        updateListenerTask = Task {
+            for await _ in Transaction.updates {
+                clearCache()
+            }
+        }
+    }
+    
+    // MARK: - Cache Management
+    private func clearCache() {
+        cache = EntitlementsCache()
+    }
+    
+    public func configure() async {
+        startTransactionListener()
+        await loadEntitlementsIfNeeded()
+    }
+    
+    private func loadEntitlementsIfNeeded() async {
+        guard !cache.isLoaded else { return }
+        
+        var transactions: [Transaction] = []
         for await result in Transaction.currentEntitlements {
             if case .verified(let transaction) = result {
+                transactions.append(transaction)
+            }
+        }
+        
+        cache.transactions = transactions
+        cache.isLoaded = true
+    }
+    
+    private func getCachedEntitlements() async -> [Transaction] {
+        await loadEntitlementsIfNeeded()
+        return cache.transactions
+    }
+    
+    // MARK: - Public Methods
+    
+    // does not include consumables
+    public func hasAnyActiveSubscription(includeNonRenewing: Bool = true) async -> Bool {
+        let entitlements = await getCachedEntitlements()
+        
+        for transaction in entitlements {
+            if transaction.productType == .autoRenewable {
+                return true
+            } else if includeNonRenewing && transaction.productType == .nonRenewable {
                 return true
             }
         }
@@ -36,57 +80,53 @@ class HeliumEntitlementsManager {
     }
     
     // does not include consumables
+    public func hasAnyEntitlement() async -> Bool {
+        let entitlements = await getCachedEntitlements()
+        return !entitlements.isEmpty
+    }
+    
+    // does not include consumables
     public func purchasedProductIds() async -> [String] {
-        var ids: [String] = []
-        for await result in Transaction.currentEntitlements {
-            if case .verified(let transaction) = result {
-                ids.append(transaction.productID)
-            }
-        }
-        return ids
+        let entitlements = await getCachedEntitlements()
+        return entitlements.map { $0.productID }
     }
     
     public func hasActiveEntitlementFor(subscriptionGroupID: String) async -> Bool {
-        let subcriptionState = await subscriptionStatusFor(subscriptionGroupID: subscriptionGroupID)?.state
-        return subcriptionState != .expired && subcriptionState != .revoked
+        let subscriptionState = await subscriptionStatusFor(subscriptionGroupID: subscriptionGroupID)?.state
+        return subscriptionState != .expired && subscriptionState != .revoked
     }
     
     public func subscriptionStatusFor(subscriptionGroupID: String) async -> Product.SubscriptionInfo.Status? {
-        for await result in Transaction.currentEntitlements {
-            if case .verified(let transaction) = result,
-               transaction.productType == .autoRenewable {
-                if let product = try? await ProductsCache.shared.getProduct(id: transaction.productID),
-                   let status = try? await product.subscription?.status.first {
-                    if product.subscription?.subscriptionGroupID == subscriptionGroupID {
-                        return status
-                    }
-                }
+        let entitlements = await getCachedEntitlements()
+        
+        for transaction in entitlements where transaction.productType == .autoRenewable {
+            if let product = try? await ProductsCache.shared.getProduct(id: transaction.productID),
+               product.subscription?.subscriptionGroupID == subscriptionGroupID {
+                // Get status from cache or load it
+                let status = await getSubscriptionStatus(for: transaction.productID)
+                return status
             }
         }
         return nil
     }
     
     public func hasActiveEntitlementFor(productId: String) async -> Bool {
-        let subcriptionState = await subscriptionStatusFor(productId: productId)?.state
-        return subcriptionState != .expired && subcriptionState != .revoked
+        let subscriptionState = await subscriptionStatusFor(productId: productId)?.state
+        return subscriptionState != .expired && subscriptionState != .revoked
     }
     
     public func subscriptionStatusFor(productId: String) async -> Product.SubscriptionInfo.Status? {
-        guard let product = try? await ProductsCache.shared.getProduct(id: productId),
-              let status = try? await product.subscription?.status.first else {
-            return nil
-        }
-        return status
+        return await getSubscriptionStatus(for: productId)
     }
     
-    public func activeSubscriptions() async -> [String: Product.SubscriptionInfo.Status] {
+    public func activeSubscriptions(includeNonRenewing: Bool = true) async -> [String: Product.SubscriptionInfo.Status] {
+        let entitlements = await getCachedEntitlements()
         var subscriptions: [String: Product.SubscriptionInfo.Status] = [:]
         
-        for await result in Transaction.currentEntitlements {
-            if case .verified(let transaction) = result,
-               transaction.productType == .autoRenewable {
-                if let product = try? await ProductsCache.shared.getProduct(id: transaction.productID),
-                   let status = try? await product.subscription?.status.first {
+        for transaction in entitlements {
+            if transaction.productType == .autoRenewable ||
+                (includeNonRenewing && transaction.productType == .nonRenewable) {
+                if let status = await getSubscriptionStatus(for: transaction.productID) {
                     subscriptions[transaction.productID] = status
                 }
             }
@@ -95,5 +135,22 @@ class HeliumEntitlementsManager {
         return subscriptions
     }
     
+    // MARK: - Private Helper for Lazy Loading Subscription Status
+    private func getSubscriptionStatus(for productId: String) async -> Product.SubscriptionInfo.Status? {
+        // Check cache first
+        if let cachedStatus = cache.subscriptionStatuses[productId] {
+            return cachedStatus
+        }
+        
+        // Load and cache if not found
+        guard let product = try? await ProductsCache.shared.getProduct(id: productId),
+              let status = try? await product.subscription?.status.first else {
+            return nil
+        }
+        
+        // Cache the status
+        cache.subscriptionStatuses[productId] = status
+        return status
+    }
 }
 

--- a/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
@@ -101,7 +101,7 @@ actor HeliumEntitlementsManager {
     
     // MARK: - Public Methods
     
-    public func hasAnyActiveSubscription(includeNonRenewing: Bool) async -> Bool {
+    func hasAnyActiveSubscription(includeNonRenewing: Bool) async -> Bool {
         let entitlements = await getCachedEntitlements()
         
         for transaction in entitlements {
@@ -114,22 +114,22 @@ actor HeliumEntitlementsManager {
         return false
     }
     
-    public func hasAnyEntitlement() async -> Bool {
+    func hasAnyEntitlement() async -> Bool {
         let entitlements = await getCachedEntitlements()
         return !entitlements.isEmpty
     }
     
-    public func purchasedProductIds() async -> [String] {
+    func purchasedProductIds() async -> [String] {
         let entitlements = await getCachedEntitlements()
         return entitlements.map { $0.productID }
     }
     
-    public func hasActiveSubscriptionFor(subscriptionGroupID: String) async -> Bool {
+    func hasActiveSubscriptionFor(subscriptionGroupID: String) async -> Bool {
         let status = await subscriptionStatusFor(subscriptionGroupID: subscriptionGroupID)
         return isSubscriptionStateActive(status?.state)
     }
     
-    public func subscriptionStatusFor(subscriptionGroupID: String) async -> Product.SubscriptionInfo.Status? {
+    func subscriptionStatusFor(subscriptionGroupID: String) async -> Product.SubscriptionInfo.Status? {
         let entitlements = await getCachedEntitlements()
         
         for transaction in entitlements where transaction.productType == .autoRenewable {
@@ -143,7 +143,7 @@ actor HeliumEntitlementsManager {
         return nil
     }
     
-    public func hasActiveEntitlementFor(productId: String) async -> Bool {
+    func hasActiveEntitlementFor(productId: String) async -> Bool {
         let entitlements = await getCachedEntitlements()
         for transaction in entitlements {
             if transaction.productType != .autoRenewable && transaction.productID == productId {
@@ -153,16 +153,16 @@ actor HeliumEntitlementsManager {
         return await hasActiveSubscriptionFor(productId: productId)
     }
     
-    public func hasActiveSubscriptionFor(productId: String) async -> Bool {
+    func hasActiveSubscriptionFor(productId: String) async -> Bool {
         let status = await subscriptionStatusFor(productId: productId)
         return isSubscriptionStateActive(status?.state)
     }
     
-    public func subscriptionStatusFor(productId: String) async -> Product.SubscriptionInfo.Status? {
+    func subscriptionStatusFor(productId: String) async -> Product.SubscriptionInfo.Status? {
         return await getSubscriptionStatus(for: productId)
     }
     
-    public func activeSubscriptions(includeNonRenewing: Bool) async -> [String: Product.SubscriptionInfo.Status] {
+    func activeSubscriptions(includeNonRenewing: Bool) async -> [String: Product.SubscriptionInfo.Status] {
         let entitlements = await getCachedEntitlements()
         var subscriptions: [String: Product.SubscriptionInfo.Status] = [:]
         
@@ -179,7 +179,7 @@ actor HeliumEntitlementsManager {
     }
     
     /// Clears all cached data and forces a refresh on the next access.
-    public func invalidateCache() async {
+    func invalidateCache() async {
         clearCache()
     }
     

--- a/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
@@ -1,0 +1,99 @@
+//
+//  HeliumEntitlementsManager.swift
+//  helium-swift
+//
+//  Created by Kyle Gorlick on 9/24/25.
+//
+
+import StoreKit
+
+class HeliumEntitlementsManager {
+    
+    static let shared = HeliumEntitlementsManager()
+    
+    // does not include consumables
+    public func hasAnyActiveSubscription(includeNonRenewing: Bool = true) async -> Bool {
+        for await result in Transaction.currentEntitlements {
+            if case .verified(let transaction) = result {
+                if transaction.productType == .autoRenewable {
+                    return true
+                } else if includeNonRenewing && transaction.productType == .nonRenewable {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+    
+    // does not include consumables
+    public func hasAnyEntitlement() async -> Bool {
+        for await result in Transaction.currentEntitlements {
+            if case .verified(let transaction) = result {
+                return true
+            }
+        }
+        return false
+    }
+    
+    // does not include consumables
+    public func purchasedProductIds() async -> [String] {
+        var ids: [String] = []
+        for await result in Transaction.currentEntitlements {
+            if case .verified(let transaction) = result {
+                ids.append(transaction.productID)
+            }
+        }
+        return ids
+    }
+    
+    public func hasActiveEntitlementFor(subscriptionGroupID: String) async -> Bool {
+        let subcriptionState = await subscriptionStatusFor(subscriptionGroupID: subscriptionGroupID)?.state
+        return subcriptionState != .expired && subcriptionState != .revoked
+    }
+    
+    public func subscriptionStatusFor(subscriptionGroupID: String) async -> Product.SubscriptionInfo.Status? {
+        for await result in Transaction.currentEntitlements {
+            if case .verified(let transaction) = result,
+               transaction.productType == .autoRenewable {
+                if let product = try? await ProductsCache.shared.getProduct(id: transaction.productID),
+                   let status = try? await product.subscription?.status.first {
+                    if product.subscription?.subscriptionGroupID == subscriptionGroupID {
+                        return status
+                    }
+                }
+            }
+        }
+        return nil
+    }
+    
+    public func hasActiveEntitlementFor(productId: String) async -> Bool {
+        let subcriptionState = await subscriptionStatusFor(productId: productId)?.state
+        return subcriptionState != .expired && subcriptionState != .revoked
+    }
+    
+    public func subscriptionStatusFor(productId: String) async -> Product.SubscriptionInfo.Status? {
+        guard let product = try? await ProductsCache.shared.getProduct(id: productId),
+              let status = try? await product.subscription?.status.first else {
+            return nil
+        }
+        return status
+    }
+    
+    public func activeSubscriptions() async -> [String: Product.SubscriptionInfo.Status] {
+        var subscriptions: [String: Product.SubscriptionInfo.Status] = [:]
+        
+        for await result in Transaction.currentEntitlements {
+            if case .verified(let transaction) = result,
+               transaction.productType == .autoRenewable {
+                if let product = try? await ProductsCache.shared.getProduct(id: transaction.productID),
+                   let status = try? await product.subscription?.status.first {
+                    subscriptions[transaction.productID] = status
+                }
+            }
+        }
+        
+        return subscriptions
+    }
+    
+}
+

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -88,7 +88,7 @@ public class HeliumPaywallDelegateWrapper: ObservableObject {
     
     private var eventService: PaywallEventHandlers?
     private var customPaywallTraits: [String: Any] = [:]
-    private(set) var skipIfAlreadyEntitled: Bool = false
+    private(set) var dontShowIfAlreadyEntitled: Bool = false
     
     public func setDelegate(_ delegate: HeliumPaywallDelegate) {
         self.delegate = delegate
@@ -98,19 +98,19 @@ public class HeliumPaywallDelegateWrapper: ObservableObject {
     public func configurePresentationContext(
         eventService: PaywallEventHandlers?,
         customPaywallTraits: [String: Any]?,
-        skipIfAlreadyEntitled: Bool = false,
+        dontShowIfAlreadyEntitled: Bool = false,
     ) {
         // Always set both, even if nil, to ensure proper reset
         self.eventService = eventService
         self.customPaywallTraits = customPaywallTraits ?? [:]
-        self.skipIfAlreadyEntitled = skipIfAlreadyEntitled
+        self.dontShowIfAlreadyEntitled = dontShowIfAlreadyEntitled
     }
     
     /// Clear both event service and custom traits after paywall closes
     private func clearPresentationContext() {
         self.eventService = nil
         self.customPaywallTraits = [:]
-        self.skipIfAlreadyEntitled = false
+        self.dontShowIfAlreadyEntitled = false
     }
     
     func setAnalytics(_ analytics: Analytics, writeKey: String? = nil) {
@@ -164,8 +164,8 @@ public class HeliumPaywallDelegateWrapper: ObservableObject {
                 transactionIds = await TransactionTools.shared.retrieveTransactionIDs(productId: productKey)
             }
             
-            if let transaction = transactionIds?.transaction {
-                await HeliumEntitlementsManager.shared.ensureSuccessTransactionAdded(transaction: transaction)
+            Task {
+                await HeliumEntitlementsManager.shared.updateAfterPurchase(productID: productKey, transaction: transactionIds?.transaction)
             }
             
             let skPostPurchaseTxnTimeMS = UInt64(Double(DispatchTime.now().uptimeNanoseconds - transactionRetrievalStartTime.uptimeNanoseconds) / 1_000_000.0)

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -163,6 +163,11 @@ public class HeliumPaywallDelegateWrapper: ObservableObject {
             if transactionIds == nil {
                 transactionIds = await TransactionTools.shared.retrieveTransactionIDs(productId: productKey)
             }
+            
+            if let transaction = transactionIds?.transaction {
+                await HeliumEntitlementsManager.shared.ensureSuccessTransactionAdded(transaction: transaction)
+            }
+            
             let skPostPurchaseTxnTimeMS = UInt64(Double(DispatchTime.now().uptimeNanoseconds - transactionRetrievalStartTime.uptimeNanoseconds) / 1_000_000.0)
             self.fireEvent(PurchaseSucceededEvent(productId: productKey, triggerName: triggerName, paywallName: paywallTemplateName, storeKitTransactionId: transactionIds?.transactionId, storeKitOriginalTransactionId: transactionIds?.originalTransactionId, skPostPurchaseTxnTimeMS: skPostPurchaseTxnTimeMS))
         case .pending:

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -85,24 +85,32 @@ public class HeliumPaywallDelegateWrapper: ObservableObject {
     private var analytics: Analytics?
     private var currentWriteKey: String?
     private var isAnalyticsEnabled: Bool = true
+    
     private var eventService: PaywallEventHandlers?
     private var customPaywallTraits: [String: Any] = [:]
+    private(set) var skipIfAlreadyEntitled: Bool = false
     
     public func setDelegate(_ delegate: HeliumPaywallDelegate) {
         self.delegate = delegate
     }
     
     /// Consolidated method to set both event service and custom traits for a paywall presentation
-    public func configurePresentationContext(eventService: PaywallEventHandlers?, customPaywallTraits: [String: Any]?) {
+    public func configurePresentationContext(
+        eventService: PaywallEventHandlers?,
+        customPaywallTraits: [String: Any]?,
+        skipIfAlreadyEntitled: Bool = false,
+    ) {
         // Always set both, even if nil, to ensure proper reset
         self.eventService = eventService
         self.customPaywallTraits = customPaywallTraits ?? [:]
+        self.skipIfAlreadyEntitled = skipIfAlreadyEntitled
     }
     
     /// Clear both event service and custom traits after paywall closes
     private func clearPresentationContext() {
         self.eventService = nil
         self.customPaywallTraits = [:]
+        self.skipIfAlreadyEntitled = false
     }
     
     func setAnalytics(_ analytics: Analytics, writeKey: String? = nil) {

--- a/Sources/Helium/HeliumCore/StoreKitDelegate.swift
+++ b/Sources/Helium/HeliumCore/StoreKitDelegate.swift
@@ -61,12 +61,7 @@ open class StoreKitDelegate: HeliumPaywallDelegate, HeliumDelegateReturnsTransac
     }
     
     open func restorePurchases() async -> Bool {
-        for await result in Transaction.currentEntitlements {
-            if case .verified = result {
-                return true
-            }
-        }
-        return false
+        return await Helium.shared.hasAnyEntitlement()
     }
     
     open func onHeliumPaywallEvent(event: HeliumPaywallEvent) {

--- a/Sources/Helium/HeliumCore/StoreKitTools/TransactionTools.swift
+++ b/Sources/Helium/HeliumCore/StoreKitTools/TransactionTools.swift
@@ -10,15 +10,18 @@ import StoreKit
 struct TransactionIdPair {
     let transactionId: String?
     let originalTransactionId: String?
+    let transaction: Transaction?
     
     init(transaction: Transaction) {
         transactionId = transaction.id.description
         originalTransactionId = transaction.originalID.description
+        self.transaction = transaction
     }
     
     init(storeKit1Purchase: SKPaymentTransaction) {
         transactionId = storeKit1Purchase.transactionIdentifier
         originalTransactionId = storeKit1Purchase.original?.transactionIdentifier
+        transaction = nil
     }
 }
 

--- a/Sources/Helium/HeliumPaywallPresenter.swift
+++ b/Sources/Helium/HeliumPaywallPresenter.swift
@@ -25,7 +25,7 @@ class HeliumPaywallPresenter {
     }
     
     private func paywallEntitlementsCheck(trigger: String) async -> Bool {
-        if HeliumPaywallDelegateWrapper.shared.skipIfAlreadyEntitled {
+        if HeliumPaywallDelegateWrapper.shared.dontShowIfAlreadyEntitled {
             let skipIt = await Helium.shared.hasEntitlementForPaywall(trigger: trigger)
             if skipIt == true {
                 print("[Helium] Did not show paywall, user already has entitlement.")

--- a/Sources/Helium/HeliumPaywallPresenter.swift
+++ b/Sources/Helium/HeliumPaywallPresenter.swift
@@ -24,8 +24,23 @@ class HeliumPaywallPresenter {
         }
     }
     
+    private func paywallEntitlementsCheck(trigger: String) async -> Bool {
+        if HeliumPaywallDelegateWrapper.shared.skipIfAlreadyEntitled {
+            let skipIt = await Helium.shared.hasEntitlementForPaywall(trigger: trigger)
+            if skipIt == true {
+                print("[Helium] Did not show paywall, user already has entitlement.")
+                return true
+            }
+        }
+        return false
+    }
+    
     func presentUpsell(trigger: String, isSecondTry: Bool = false, from viewController: UIViewController? = nil) {
         Task { @MainActor in
+            if await paywallEntitlementsCheck(trigger: trigger) {
+                return
+            }
+            
             let upsellViewResult = Helium.shared.upsellViewResultFor(trigger: trigger)
             guard let contentView = upsellViewResult.view else {
                 HeliumPaywallDelegateWrapper.shared.fireEvent(
@@ -86,11 +101,8 @@ class HeliumPaywallPresenter {
             // Schedule timeout with trigger-specific budget
             Task {
                 try? await Task.sleep(nanoseconds: UInt64(loadingBudget * 1_000_000_000))
-                await MainActor.run {
-                    // Update to real paywall or fallback if still not ready
-                    self.updateLoadingPaywall(trigger: trigger)
-                    NotificationCenter.default.removeObserver(self, name: configDownloadEventName, object: nil)
-                }
+                await updateLoadingPaywall(trigger: trigger)
+                NotificationCenter.default.removeObserver(self, name: configDownloadEventName, object: nil)
             }
             
             // Also listen for download completion
@@ -104,13 +116,17 @@ class HeliumPaywallPresenter {
     }
     
     @MainActor
-    private func updateLoadingPaywall(trigger: String) {
+    private func updateLoadingPaywall(trigger: String) async {
         guard let loadingPaywall = paywallsDisplayed.first(where: { $0.trigger == trigger && $0.isLoading }) else {
             return
         }
         
         if Helium.shared.skipPaywallIfNeeded(trigger: trigger) {
             hideUpsell()
+            return
+        }
+        
+        if await paywallEntitlementsCheck(trigger: trigger) {
             return
         }
         
@@ -136,7 +152,7 @@ class HeliumPaywallPresenter {
         Task { @MainActor in
             // Update any loading paywalls
             for paywall in paywallsDisplayed where paywall.isLoading {
-                updateLoadingPaywall(trigger: paywall.trigger)
+                await updateLoadingPaywall(trigger: paywall.trigger)
             }
         }
         NotificationCenter.default.removeObserver(self, name: configDownloadEventName, object: nil)

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -20,7 +20,8 @@ public class Helium {
         trigger: String,
         from viewController: UIViewController? = nil,
         eventHandlers: PaywallEventHandlers? = nil,
-        customPaywallTraits: [String: Any]? = nil
+        customPaywallTraits: [String: Any]? = nil,
+        skipIfAlreadyEntitled: Bool = false
     ) {
         if skipPaywallIfNeeded(trigger: trigger) {
             return
@@ -29,7 +30,8 @@ public class Helium {
         // Configure presentation context (always set both to ensure proper reset)
         HeliumPaywallDelegateWrapper.shared.configurePresentationContext(
             eventService: eventHandlers,
-            customPaywallTraits: customPaywallTraits
+            customPaywallTraits: customPaywallTraits,
+            skipIfAlreadyEntitled: skipIfAlreadyEntitled
         )
         
         HeliumPaywallPresenter.shared.presentUpsellWithLoadingBudget(trigger: trigger, from: viewController)
@@ -488,6 +490,17 @@ public class Helium {
     }
     
     // MARK: - Entitlements / Subscription Status
+    
+    /// Checks if the user has an active entitlement for any product attached to the paywall that will show for provided trigger.
+    /// - Parameter trigger: Trigger that would be used to show the paywall.
+    /// - Parameter considerAssociatedSubscriptions: If true, look at subscription groups associated with products in the paywall, otherwise just look at exact products in the paywall.
+    /// - Returns: `true` if the user has bought one of the products on the paywall or is actively subscribed to a subscription group that includes one of the products. `false` if not. Returns `nil` if not known (i.e. the paywall is not downloaded yet).
+    func hasEntitlementForPaywall(
+        trigger: String,
+        considerAssociatedSubscriptions: Bool = false
+    ) async -> Bool? {
+        return await HeliumEntitlementsManager.shared.hasEntitlementForPaywall(trigger: trigger, considerAssociatedSubscriptions: considerAssociatedSubscriptions)
+    }
     
     /// Checks if the user has any active subscription (auto-renewable or optionally non-renewing).
     /// - Parameter includeNonRenewing: Whether to include non-renewing subscriptions in the check (default: true)

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -21,7 +21,7 @@ public class Helium {
         from viewController: UIViewController? = nil,
         eventHandlers: PaywallEventHandlers? = nil,
         customPaywallTraits: [String: Any]? = nil,
-        skipIfAlreadyEntitled: Bool = false
+        dontShowIfAlreadyEntitled: Bool = false
     ) {
         if skipPaywallIfNeeded(trigger: trigger) {
             return
@@ -31,7 +31,7 @@ public class Helium {
         HeliumPaywallDelegateWrapper.shared.configurePresentationContext(
             eventService: eventHandlers,
             customPaywallTraits: customPaywallTraits,
-            skipIfAlreadyEntitled: skipIfAlreadyEntitled
+            dontShowIfAlreadyEntitled: dontShowIfAlreadyEntitled
         )
         
         HeliumPaywallPresenter.shared.presentUpsellWithLoadingBudget(trigger: trigger, from: viewController)

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -538,11 +538,10 @@ public class Helium {
         return await HeliumEntitlementsManager.shared.hasActiveSubscriptionFor(subscriptionGroupID: subscriptionGroupID)
     }
     
-    /// Returns a dictionary of all active subscriptions with their current status.
-    /// - Parameter includeNonRenewing: Whether to include non-renewing subscriptions (default: true)
-    /// - Returns: Dictionary mapping product IDs to their subscription status
-    public func activeSubscriptions(includeNonRenewing: Bool = true) async -> [String: Product.SubscriptionInfo.Status] {
-        return await HeliumEntitlementsManager.shared.activeSubscriptions(includeNonRenewing: includeNonRenewing)
+    /// Returns a dictionary of all active auto-renewable subscriptions with their current subscription info.
+    /// - Returns: Dictionary mapping product IDs to their subscription info
+    public func activeSubscriptions() async -> [String: Product.SubscriptionInfo] {
+        return await HeliumEntitlementsManager.shared.activeSubscriptions()
     }
     
     /// Returns an array of all purchased product IDs that the user currently has access to.

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -401,6 +401,8 @@ public class Helium {
         
         Task {
             await WebViewManager.shared.preCreateFirstWebView()
+            
+            await HeliumEntitlementsManager.shared.configure()
         }
     }
     
@@ -483,6 +485,72 @@ public class Helium {
         
         presentUpsell(trigger: trigger)
         return true
+    }
+    
+    // MARK: - Entitlements / Subscription Status
+    
+    /// Checks if the user has any active subscription (auto-renewable or optionally non-renewing).
+    /// - Parameter includeNonRenewing: Whether to include non-renewing subscriptions in the check (default: true)
+    /// - Returns: `true` if the user has at least one active subscription, `false` otherwise
+    public func hasAnyActiveSubscription(includeNonRenewing: Bool = true) async -> Bool {
+        return await HeliumEntitlementsManager.shared.hasAnyActiveSubscription(includeNonRenewing: includeNonRenewing)
+    }
+    
+    /// Checks if the user has any entitlement (any non-consumable purchase or subscription).
+    /// - Returns: `true` if the user has at least one entitlement, `false` otherwise
+    /// - Note: This method does not include consumable purchases
+    public func hasAnyEntitlement() async -> Bool {
+        return await HeliumEntitlementsManager.shared.hasAnyEntitlement()
+    }
+    
+    /// Checks if the user has entitlement for this product (any non-consumable purchase or subscription).
+    /// - Parameter productId: The product ID to check
+    /// - Returns: `true` if the user has an active entitlement for the product, `false` otherwise
+    /// - Note: This method does not work for consumable purchases
+    public func hasActiveEntitlementFor(productId: String) async -> Bool {
+        return await HeliumEntitlementsManager.shared.hasActiveEntitlementFor(productId: productId)
+    }
+    
+    /// Checks if the user has an active subscription for a specific product.
+    /// - Parameter productId: The product ID to check
+    /// - Returns: `true` if the user has an active subscription for the product, `false` otherwise
+    public func hasActiveSubscriptionFor(productId: String) async -> Bool {
+        return await HeliumEntitlementsManager.shared.hasActiveSubscriptionFor(productId: productId)
+    }
+    
+    /// Checks if the user has an active entitlement for a specific subscription group.
+    /// - Parameter subscriptionGroupID: The subscription group ID to check
+    /// - Returns: `true` if the user has an active subscription in the specified group, `false` otherwise
+    public func hasActiveSubscriptionFor(subscriptionGroupID: String) async -> Bool {
+        return await HeliumEntitlementsManager.shared.hasActiveSubscriptionFor(subscriptionGroupID: subscriptionGroupID)
+    }
+    
+    /// Returns a dictionary of all active subscriptions with their current status.
+    /// - Parameter includeNonRenewing: Whether to include non-renewing subscriptions (default: true)
+    /// - Returns: Dictionary mapping product IDs to their subscription status
+    public func activeSubscriptions(includeNonRenewing: Bool = true) async -> [String: Product.SubscriptionInfo.Status] {
+        return await HeliumEntitlementsManager.shared.activeSubscriptions(includeNonRenewing: includeNonRenewing)
+    }
+    
+    /// Returns an array of all purchased product IDs that the user currently has access to.
+    /// - Returns: Array of product ID strings for all current entitlements
+    /// - Note: This method does not include consumable purchases
+    public func purchasedProductIds() async -> [String] {
+        return await HeliumEntitlementsManager.shared.purchasedProductIds()
+    }
+    
+    /// Gets the subscription status for a specific subscription group.
+    /// - Parameter subscriptionGroupID: The subscription group ID to check
+    /// - Returns: The subscription status if found, `nil` otherwise
+    public func subscriptionStatusFor(subscriptionGroupID: String) async -> Product.SubscriptionInfo.Status? {
+        return await HeliumEntitlementsManager.shared.subscriptionStatusFor(subscriptionGroupID: subscriptionGroupID)
+    }
+    
+    /// Gets the subscription status for a specific product.
+    /// - Parameter productId: The product ID to check
+    /// - Returns: The subscription status if found, `nil` otherwise
+    public func subscriptionStatusFor(productId: String) async -> Product.SubscriptionInfo.Status? {
+        return await HeliumEntitlementsManager.shared.subscriptionStatusFor(productId: productId)
     }
     
 }


### PR DESCRIPTION
This PR does 2 things:
- exposes several entitlement/subscription methods to sdk-user
- adds an option to avoid showing paywall if a product in the paywall has already been purchased

May have gone a bit overboard with the utility methods. The main ones I see being used are:
- `hasAnyEntitlement()`
- `hasAnyActiveSubscription()`
- `hasEntitlementForPaywall(trigger:)`

Right now hasEntitlementForPaywall will return nil if paywalls not downloaded. So you might see a loading paywall, then paywall gets downloaded, and then it hides.

For next iteration, I think we might do something like:
- after a purchase, store (as a file?) trigger and associated purchased productID, subscriptionGroupID, and expirationDate if it has one. Update expirationDate whenever a transaction with same productID has newer expiration. I think storing per trigger makes sense, even if products change on the paywall?