### PR TITLE
Loading update fix

### DIFF
--- a/Sources/Helium/HeliumCore/BuildConstants.swift
+++ b/Sources/Helium/HeliumCore/BuildConstants.swift
@@ -8,5 +8,5 @@
  */
 public struct BuildConstants {
     /// Current SDK version
-    public static let version = "3.0.4"
+    public static let version = "3.0.5"
 }

--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -211,15 +211,17 @@ public struct DynamicWebView: View {
         if fallbackPaywall != nil {
             shouldShowFallback = true
         } else {
-            HeliumPaywallDelegateWrapper.shared.fireEvent(
-                PaywallOpenFailedEvent(
-                    triggerName: triggerName ?? "",
-                    paywallName: HeliumFetchedConfigManager.shared.getPaywallInfoForTrigger(triggerName ?? "")?.paywallTemplateName ?? "unknown",
-                    error: "WebView failed to load - \(reason)"
-                )
+            let openFailEvent = PaywallOpenFailedEvent(
+                triggerName: triggerName ?? "",
+                paywallName: HeliumFetchedConfigManager.shared.getPaywallInfoForTrigger(triggerName ?? "")?.paywallTemplateName ?? "unknown",
+                error: "WebView failed to load - \(reason)"
             )
             if presentationState.viewType == .presented {
-                Helium.shared.hideUpsell()
+                HeliumPaywallPresenter.shared.hideUpsell {
+                    HeliumPaywallDelegateWrapper.shared.fireEvent(openFailEvent)
+                }
+            } else {
+                HeliumPaywallDelegateWrapper.shared.fireEvent(openFailEvent)
             }
         }
     }

--- a/Sources/Helium/HeliumCore/HeliumController.swift
+++ b/Sources/Helium/HeliumCore/HeliumController.swift
@@ -108,7 +108,11 @@ public class HeliumController {
                         numAttempts: numFetchRequests
                     )
                 )
-                // Use the config as needed
+                
+                NotificationCenter.default.post(
+                    name: NSNotification.Name("HeliumConfigDownloadComplete"),
+                    object: nil
+                )
             case .failure(let error):
             
                 let configuration = SegmentConfiguration(writeKey: self.FAILURE_MONITOR_BROWSER_WRITE_KEY)

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -276,14 +276,6 @@ public class HeliumFetchedConfigManager: ObservableObject {
     
     @MainActor private func updateDownloadState(_ status: HeliumFetchedConfigStatus) {
         self.downloadStatus = status
-        
-        // Post notification when download completes successfully
-        if case .downloadSuccess = status {
-            NotificationCenter.default.post(
-                name: NSNotification.Name("HeliumConfigDownloadComplete"),
-                object: nil
-            )
-        }
     }
     
     public func getConfig() -> HeliumFetchedConfig? {


### PR DESCRIPTION
Discovered this while testing Flutter
- We should fire the download complete event (which tells loading paywall to swap content) AFTER analytics set from download and paywall download success fires. In Flutter this situation crashes if fallback bundle set. In iOS it seems to be ok but analytics might use fallback / sometimes iOS seems to show fallback when it shouldn't.
- Also flutter-related, paywall open failed event should not fire until presented paywall is completely dismissed, otherwise flutter fallback view won't display