### PR TITLE
[3.0.6] Explicit event for experiment allocation event

### DIFF
--- a/Sources/Helium/HeliumCore/BuildConstants.swift
+++ b/Sources/Helium/HeliumCore/BuildConstants.swift
@@ -8,5 +8,5 @@
  */
 public struct BuildConstants {
     /// Current SDK version
-    public static let version = "3.0.5"
+    public static let version = "3.0.6"
 }

--- a/Sources/Helium/HeliumCore/ExperimentAllocationTracker.swift
+++ b/Sources/Helium/HeliumCore/ExperimentAllocationTracker.swift
@@ -1,0 +1,61 @@
+//
+//  ExperimentAllocationTracker.swift
+//  Helium
+//
+//  Centralized tracking for experiment allocation events
+//
+
+import Foundation
+
+/// Manages experiment allocation event tracking across all presentation types
+/// - Note: Ensures UserAllocatedEvent fires exactly once per trigger per session,
+///   regardless of whether paywall is presented modally, embedded, or via view modifier
+class ExperimentAllocationTracker {
+    static let shared = ExperimentAllocationTracker()
+    
+    private init() {}
+    
+    /// Set of triggers for which allocation events have been fired
+    private var allocatedTriggers: Set<String> = []
+    
+    /// Tracks allocation and fires UserAllocatedEvent if this is the first time
+    /// showing a non-fallback paywall for this trigger
+    ///
+    /// - Parameters:
+    ///   - trigger: The trigger name being displayed
+    ///   - isFallback: Whether this is a fallback paywall
+    ///
+    /// - Note: This method is idempotent - calling it multiple times for the same
+    ///   trigger will only fire the allocation event once
+    func trackAllocationIfNeeded(trigger: String, isFallback: Bool) {
+        // Don't fire for fallbacks or if already fired for this trigger
+        guard !isFallback && !allocatedTriggers.contains(trigger) else {
+            return
+        }
+        
+        // Mark as allocated
+        allocatedTriggers.insert(trigger)
+        
+        // Extract experiment info and fire event
+        guard let paywallInfo = HeliumFetchedConfigManager.shared.getPaywallInfoForTrigger(trigger),
+              let experimentInfo = paywallInfo.extractExperimentInfo(trigger: trigger) else {
+            return
+        }
+        
+        let allocationEvent = UserAllocatedEvent(experimentInfo: experimentInfo)
+        HeliumPaywallDelegateWrapper.shared.fireEvent(allocationEvent)
+    }
+    
+    /// Resets all allocation tracking
+    /// - Note: Called when SDK cache is cleared via clearAllCachedState()
+    func reset() {
+        allocatedTriggers.removeAll()
+    }
+    
+    /// Check if allocation event has been fired for a trigger
+    /// - Parameter trigger: The trigger name to check
+    /// - Returns: true if allocation event was already fired for this trigger
+    func hasTrackedAllocation(for trigger: String) -> Bool {
+        return allocatedTriggers.contains(trigger)
+    }
+}

--- a/Sources/Helium/HeliumCore/ExperimentInfo.swift
+++ b/Sources/Helium/HeliumCore/ExperimentInfo.swift
@@ -19,7 +19,7 @@ struct ExperimentFieldsResponse: Codable {
     let allocations: [Int]
     let chosenAllocation: Int
     let audienceId: String?
-    let audienceData: JSON?
+    let audienceData: AnyCodable?
 }
 
 // MARK: - Targeting Details
@@ -32,9 +32,9 @@ public struct TargetingDetails: Codable {
     
     /// Raw audience data containing targeting criteria
     /// - Note: JSON mapping with audience configuration details
-    public let audienceData: JSON?
+    public let audienceData: AnyCodable?
     
-    public init(audienceId: String?, audienceData: JSON?) {
+    public init(audienceId: String?, audienceData: AnyCodable?) {
         self.audienceId = audienceId
         self.audienceData = audienceData
     }
@@ -183,7 +183,7 @@ public struct ExperimentInfo: Codable {
                     dict["experiment_info_audience_id"] = audienceId
                 }
                 if let audienceData = targeting.audienceData {
-                    dict["experiment_info_audience_data"] = audienceData.dictionaryValue ?? [:]
+                    dict["experiment_info_audience_data"] = audienceData.value
                 }
             }
         }

--- a/Sources/Helium/HeliumCore/ExperimentInfo.swift
+++ b/Sources/Helium/HeliumCore/ExperimentInfo.swift
@@ -1,0 +1,220 @@
+//
+//  ExperimentInfo.swift
+//  Helium
+//
+//  Experiment Allocation Information Models
+//
+
+import Foundation
+
+// MARK: - Server Response Structure
+
+/// Structured experiment fields from server response
+/// - Note: Matches experimentFields structure from bandit server
+struct ExperimentFieldsResponse: Codable {
+    let experimentId: String?
+    let experimentName: String?
+    let experimentType: String?
+    let userPercentage: Int
+    let allocations: [Int]
+    let chosenAllocation: Int
+    let audienceId: String?
+    let audienceData: JSON?
+}
+
+// MARK: - Targeting Details
+
+/// Details about audience targeting for an experiment
+public struct TargetingDetails: Codable {
+    /// Unique identifier for the audience being targeted
+    /// - Note: Used for lookup in Helium dashboard
+    public let audienceId: String?
+    
+    /// Raw audience data containing targeting criteria
+    /// - Note: JSON mapping with audience configuration details
+    public let audienceData: JSON?
+    
+    public init(audienceId: String?, audienceData: JSON?) {
+        self.audienceId = audienceId
+        self.audienceData = audienceData
+    }
+}
+
+// MARK: - Experiment Details
+
+/// Details about the experiment configuration
+public struct ExperimentDetails: Codable {
+    /// Name of the experiment
+    public let name: String?
+    
+    /// Unique identifier for the experiment
+    public let id: String?
+    
+    /// Start date of the experiment
+    // public let startDate: Date?
+    
+    /// End date of the experiment
+    // public let endDate: Date?
+    
+    /// Targeting details for this experiment
+    public let targetingDetails: TargetingDetails?
+    
+    /// Type of experiment (e.g., "AB_TEST", "MAB", "CMAB")
+    public let type: String?
+    
+    // Additional experiment configuration
+    // public let rolloutPercentage: Double?
+    
+    public init(
+        name: String?,
+        id: String?,
+        targetingDetails: TargetingDetails?,
+        type: String?
+    ) {
+        self.name = name
+        self.id = id
+        self.targetingDetails = targetingDetails
+        self.type = type
+    }
+}
+
+// MARK: - User Hash Details
+
+/// Details about user hash bucketing for allocation
+public struct UserHashDetails: Codable {
+    /// User hash bucket (1-100) - used for consistent allocation
+    public let hashedUserIdBucket1To100: Int?
+    
+    /// User ID that was hashed for allocation
+    public let hashedUserId: String?
+    
+    /// Type of hash used (e.g., "HASH_USER_ID", "HASH_HELIUM_PERSISTENT_ID")
+    public let hashType: String?
+    
+    public init(
+        hashedUserIdBucket1To100: Int?,
+        hashedUserId: String?,
+        hashType: String?
+    ) {
+        self.hashedUserIdBucket1To100 = hashedUserIdBucket1To100
+        self.hashedUserId = hashedUserId
+        self.hashType = hashType
+    }
+}
+
+// MARK: - Variant Details
+
+/// Details about the chosen variant in an experiment
+public struct VariantDetails: Codable {
+    /// Name or identifier of the allocation/variant (e.g., paywall template name)
+    public let allocationName: String?
+    
+    /// Unique identifier for this allocation (paywall UUID)
+    public let allocationId: String?
+    
+    /// Index of chosen variant (1 to len(variants))
+    public let allocationIndex: Int?
+    
+    /// Timestamp when allocation occurred
+    public let allocationTime: Date
+    
+    public init(
+        allocationName: String?,
+        allocationId: String?,
+        allocationIndex: Int?,
+        allocationTime: Date = Date()
+    ) {
+        self.allocationName = allocationName
+        self.allocationId = allocationId
+        self.allocationIndex = allocationIndex
+        self.allocationTime = allocationTime
+    }
+}
+
+// MARK: - Experiment Info
+
+/// Complete experiment allocation information for a user
+public struct ExperimentInfo: Codable {
+    /// Trigger name at which user was enrolled
+    public let trigger: String
+    
+    /// Details about the experiment configuration
+    public let experimentDetails: ExperimentDetails?
+    
+    /// Details about the chosen variant
+    public let chosenVariantDetails: VariantDetails?
+    
+    /// User hash bucketing details
+    public let userHashDetails: UserHashDetails?
+    
+    public init(
+        trigger: String,
+        experimentDetails: ExperimentDetails?,
+        chosenVariantDetails: VariantDetails?,
+        userHashDetails: UserHashDetails?
+    ) {
+        self.trigger = trigger
+        self.experimentDetails = experimentDetails
+        self.chosenVariantDetails = chosenVariantDetails
+        self.userHashDetails = userHashDetails
+    }
+    
+    /// Convert to dictionary with experiment_info_* prefixed keys for consistent logging
+    func toDictionaryWithPrefix() -> [String: Any] {
+        var dict: [String: Any] = [
+            "experiment_info_trigger": trigger
+        ]
+        
+        // Experiment details
+        if let experimentDetails = experimentDetails {
+            if let name = experimentDetails.name {
+                dict["experiment_info_experiment_name"] = name
+            }
+            if let id = experimentDetails.id {
+                dict["experiment_info_experiment_id"] = id
+            }
+            if let type = experimentDetails.type {
+                dict["experiment_info_experiment_type"] = type
+            }
+            
+            // Targeting details
+            if let targeting = experimentDetails.targetingDetails {
+                if let audienceId = targeting.audienceId {
+                    dict["experiment_info_audience_id"] = audienceId
+                }
+                if let audienceData = targeting.audienceData {
+                    dict["experiment_info_audience_data"] = audienceData.dictionaryValue ?? [:]
+                }
+            }
+        }
+        
+        // Variant details
+        if let variantDetails = chosenVariantDetails {
+            if let allocationName = variantDetails.allocationName {
+                dict["experiment_info_allocation_name"] = allocationName
+            }
+            if let allocationId = variantDetails.allocationId {
+                dict["experiment_info_allocation_id"] = allocationId
+            }
+            if let allocationIndex = variantDetails.allocationIndex {
+                dict["experiment_info_allocation_index"] = allocationIndex
+            }
+            dict["experiment_info_allocation_time"] = variantDetails.allocationTime.timeIntervalSince1970
+        }
+        
+        // User hash details
+        if let hashDetails = userHashDetails {
+            if let hashedUserIdBucket = hashDetails.hashedUserIdBucket1To100 {
+                dict["experiment_info_hashed_user_id_bucket"] = hashedUserIdBucket
+            }
+            if let hashedUserId = hashDetails.hashedUserId {
+                dict["experiment_info_hashed_user_id"] = hashedUserId
+            }
+            if let hashType = hashDetails.hashType {
+                dict["experiment_info_hash_type"] = hashType
+            }
+        }
+        
+        return dict
+    }
+}

--- a/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
@@ -232,6 +232,15 @@ public class HeliumActionsDelegate: BaseActionsDelegate, ObservableObject {
             viewType: viewType
         )
         HeliumPaywallDelegateWrapper.shared.fireEvent(event)
+        
+        // Track experiment allocation for embedded/triggered views
+        // Determine if this is a fallback by checking if it's in the fetched config
+        let isFallback = HeliumFetchedConfigManager.shared.getPaywallInfoForTrigger(trigger) == nil
+        
+        ExperimentAllocationTracker.shared.trackAllocationIfNeeded(
+            trigger: trigger,
+            isFallback: isFallback
+        )
     }
     
     public func logClosure() {

--- a/Sources/Helium/HeliumCore/PaywallEvents.swift
+++ b/Sources/Helium/HeliumCore/PaywallEvents.swift
@@ -880,3 +880,45 @@ public struct PaywallWebViewRenderedEvent: PaywallContextEvent {
         )
     }
 }
+
+// MARK: - Experiment Events
+
+/// Event fired when a user is allocated to an experiment variant
+/// - Note: Fired once per trigger when a user is first assigned to an experiment variant. Contains complete experiment allocation details including variant information, targeting criteria, and hash bucketing.
+public struct UserAllocatedEvent: HeliumEvent {
+    /// Complete experiment allocation information
+    /// - Note: Includes experiment details, variant selection, targeting, and allocation metadata
+    public let experimentInfo: ExperimentInfo
+    
+    /// When this event occurred
+    /// - Note: Captured using Date() at event creation time
+    public let timestamp: Date
+    
+    public init(experimentInfo: ExperimentInfo, timestamp: Date = Date()) {
+        self.experimentInfo = experimentInfo
+        self.timestamp = timestamp
+    }
+    
+    public var eventName: String { "userAllocated" }
+    
+    public func toDictionary() -> [String: Any] {
+        var dict: [String: Any] = [
+            "type": eventName,
+            "timestamp": timestamp.timeIntervalSince1970
+        ]
+        
+        // Merge in all experiment info fields with prefixed keys
+        let experimentDict = experimentInfo.toDictionaryWithPrefix()
+        for (key, value) in experimentDict {
+            dict[key] = value
+        }
+        
+        return dict
+    }
+    
+    public func toLegacyEvent() -> HeliumPaywallEvent {
+        // No legacy event equivalent - this is a new event type
+        // Return a generic event that won't cause issues
+        return .initializeStart
+    }
+}

--- a/Sources/Helium/HeliumPaywallPresenter.swift
+++ b/Sources/Helium/HeliumPaywallPresenter.swift
@@ -319,6 +319,12 @@ class HeliumPaywallPresenter {
     
     private func dispatchOpenEvent(paywallVC: HeliumViewController) {
         dispatchOpenOrCloseEvent(openEvent: true, paywallVC: paywallVC)
+        
+        // Fire user allocation event if this is the first time showing this trigger
+        ExperimentAllocationTracker.shared.trackAllocationIfNeeded(
+            trigger: paywallVC.trigger,
+            isFallback: paywallVC.isFallback
+        )
     }
     
     private func dispatchCloseEvent(paywallVC: HeliumViewController) {


### PR DESCRIPTION
This pull request introduces a comprehensive experiment allocation tracking system to the Helium SDK. The changes add new models for experiment allocation information, a centralized tracker to ensure allocation events are fired only once per trigger per session, and new analytics events to capture experiment assignments. Public APIs are also extended to allow retrieval of experiment allocation details for analytics and debugging. 

**Experiment Allocation Tracking and Event Firing**
- Added `ExperimentAllocationTracker` singleton to centrally track experiment allocation events, ensuring that the `UserAllocatedEvent` is fired exactly once per trigger per session, regardless of paywall presentation type (modal, embedded, view modifier, or skipped).
- Integrated allocation tracking into paywall presentation and skip logic (`HeliumActionsDelegate`, `HeliumPaywallPresenter`, and `Helium`), so allocation events are triggered for both shown and skipped paywalls. [[1]](diffhunk://#diff-eadbbe64a67a116f20150c1446d8ce25d13faed714588fedc11933638323bde7R235-R243) [[2]](diffhunk://#diff-3798b7a32755fb4e4601ba6273dd24ea0549332b30413bc215a2d5f716d1627aR322-R327) [[3]](diffhunk://#diff-ad48673353aee0bf95f0b6a18f7c6796fcf168832c39347ada73226dbdbc844bR41-R46)

**Experiment Info Models and Extraction**
- Introduced new models (`ExperimentFieldsResponse`, `ExperimentInfo`, `ExperimentDetails`, `VariantDetails`, `UserHashDetails`, `TargetingDetails`) to structure experiment allocation information.
- Added an `extractExperimentInfo(trigger:)` method to `HeliumPaywallInfo` for extracting experiment details from paywall configuration, supporting both new structured and legacy formats.

**Analytics Event Enhancements**
- Added a new analytics event type, `UserAllocatedEvent`, which captures complete experiment allocation details when a user is assigned to a variant. This event is fired once per trigger.

**Public API Extensions**
- Added new public API methods to `Helium` for retrieving experiment allocation information: `getExperimentInfo(for:)` (per trigger) and `getHeliumExperimentInfo()` (global). These methods provide access to detailed experiment assignment data for use in analytics, debugging, and conditional logic. [[1]](diffhunk://#diff-ad48673353aee0bf95f0b6a18f7c6796fcf168832c39347ada73226dbdbc844bR71-R74) [[2]](diffhunk://#diff-ad48673353aee0bf95f0b6a18f7c6796fcf168832c39347ada73226dbdbc844bR228-R270)

**SDK Versioning and State Reset**
- Bumped the SDK version to `3.0.6` and ensured that experiment allocation tracking is reset when all cached state is cleared, supporting safe re-initialization and testing. [[1]](diffhunk://#diff-435146615af5e31fe38de195d75eefb5035e6f66efe7f3d427fc203e99524d67L11-R11) [[2]](diffhunk://#diff-ad48673353aee0bf95f0b6a18f7c6796fcf168832c39347ada73226dbdbc844bR121-R123)