### PR TITLE
Misc fixes for web checkout flow

### DIFF
--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -68,10 +68,11 @@ class HeliumPaywallDelegateWrapper {
         
         let transactionStatus: HeliumPaywallTransactionStatus
         
-        var isStripePurchaseFlow: Bool = false
+        var isStripeCheckoutFlow: Bool = false
         let allStripeProductIds = Array((HeliumFetchedConfigManager.shared.getServerProductsPriceMap() ?? [:]).keys)
-        if allStripeProductIds.contains(productKey) {
-            isStripePurchaseFlow = true
+        let stripeApplePayFlow = ApplePayHelper.shared.getStripeApplePayAvailable()
+        if !stripeApplePayFlow && allStripeProductIds.contains(productKey) {
+            isStripeCheckoutFlow = true
             do {
                 try await StripeCheckoutManager.shared.startCheckoutFlow(
                     for: productKey,
@@ -124,7 +125,7 @@ class HeliumPaywallDelegateWrapper {
             }
         case .pending:
             self.fireEvent(PurchasePendingEvent(productId: productKey, triggerName: triggerName, paywallName: paywallTemplateName), paywallSession: paywallSession)
-            if !isStripePurchaseFlow {
+            if !isStripeCheckoutFlow {
                 let detachedSession = paywallSession.withPresentationContext(.empty)
                 observePendingPurchase(productId: productKey, triggerName: triggerName, paywallTemplateName: paywallTemplateName, paywallSession: detachedSession)
             }
@@ -133,7 +134,12 @@ class HeliumPaywallDelegateWrapper {
     }
     
     func restorePurchases(triggerName: String, paywallTemplateName: String, paywallSession: PaywallSession) async -> Bool {
-        let result = await delegate.restorePurchases()
+        var result = await delegate.restorePurchases()
+        
+        if !result && Helium.config.stripeCheckoutEnabled {
+            await HeliumEntitlementsManager.shared.stripeEntitlementsSource.refreshEntitlements()
+            result = await !HeliumEntitlementsManager.shared.stripeEntitlementsSource.purchasedHeliumProductIds().isEmpty
+        }
         if result {
             self.fireEvent(PurchaseRestoredEvent(productId: "HELIUM_GENERIC_PRODUCT", triggerName: triggerName, paywallName: paywallTemplateName), paywallSession: paywallSession)
         } else {
@@ -290,7 +296,7 @@ class HeliumPaywallDelegateWrapper {
             notShownAddendum = "Your paywall does not include any iOS products. Ensure you have synced your iOS products and selected products for your paywall \(paywallLink)"
         case .stripeNoCustomUserId:
             notShownAddendum = "Stripe purchase flows require a custom user ID to be set"
-        case .stripeCheckoutMissingUrls:
+        case .stripeCheckoutNotEnabled:
             notShownAddendum = "Stripe Checkout Flow requires success/cancel URLs to be set. See Helium.config.enableStripeCheckout"
         default:
             notShownAddendum = paywallUnavailableReason?.rawValue ?? ""

--- a/Sources/Helium/HeliumCore/Models.swift
+++ b/Sources/Helium/HeliumCore/Models.swift
@@ -783,7 +783,7 @@ public enum PaywallUnavailableReason: String, Codable {
     case bundleFetchCannotDecodeContent
     case noProductsIOS
     case stripeNoCustomUserId
-    case stripeCheckoutMissingUrls
+    case stripeCheckoutNotEnabled
 }
 
 /// Reason a paywall was not shown.

--- a/Sources/Helium/HeliumCore/StripeCheckout/HeliumStripeAPIClient.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/HeliumStripeAPIClient.swift
@@ -34,9 +34,9 @@ public class HeliumStripeAPIClient {
 
     // MARK: - Request Body Builder
 
-    public func baseRequestBody(productId: String? = nil) -> [String: Any] {
+    public func baseRequestBody(productId: String? = nil) throws -> [String: Any] {
         guard let apiKey = Helium.lastApiKeyUsed else {
-            return [:]
+            throw HeliumStripeAPIError.notInitialized
         }
         var body: [String: Any] = [
             "apiKey": apiKey,

--- a/Sources/Helium/HeliumCore/StripeCheckout/StripeCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/StripeCheckoutManager.swift
@@ -84,14 +84,15 @@ public class StripeCheckoutManager: NSObject {
         var ctx: [String: Any] = [:]
 
         let analyticsData = try JSONEncoder().encode(analyticsEvent)
-        ctx["analytics"] = analyticsData.base64EncodedString()
+        let analyticsJSON = try JSONSerialization.jsonObject(with: analyticsData)
+        ctx["analytics"] = analyticsJSON
 
         ctx["initialStripeSelection"] = productKey
         ctx["trigger"] = triggerName
         ctx["successUrl"] = successURL
         ctx["cancelUrl"] = cancelURL
 
-        let baseBody = HeliumStripeAPIClient.shared.baseRequestBody()
+        let baseBody = try HeliumStripeAPIClient.shared.baseRequestBody()
         for (key, value) in baseBody where key != "apiKey" {
             if let stringValue = value as? String {
                 ctx[key] = stringValue
@@ -99,7 +100,7 @@ public class StripeCheckoutManager: NSObject {
         }
 
         let ctxData = try JSONSerialization.data(withJSONObject: ctx)
-        let ctxBase64 = ctxData.base64EncodedString()
+        let ctxBase64 = ctxData.base64URLEncodedString()
 
         var queryItems = components.queryItems ?? []
         queryItems.append(URLQueryItem(name: "ctx", value: ctxBase64))
@@ -169,13 +170,14 @@ public class StripeCheckoutManager: NSObject {
         Task { @MainActor [weak self] in
             guard let self else { return }
 
-            // Stripe entitlements may not be available immediately after an external purchase.
-            // Wait 2s before the first check, then retry up to 2 more times with 3s delays
-            // (8s total delay, not counting request time).
-            let delays: [UInt64] = [2_000_000_000, 3_000_000_000, 3_000_000_000]
+            // Stripe entitlements may not be immediately available after an external purchase.
+            // Retry a few times (if needed) with increasing delays.
+            let delays: [UInt64] = [0, 2_000_000_000, 3_000_000_000, 5_000_000_000]
 
             for delay in delays {
-                try? await Task.sleep(nanoseconds: delay)
+                if delay > 0 {
+                    try? await Task.sleep(nanoseconds: delay)
+                }
                 guard !activeCheckoutObservations.isEmpty else { return }
 
                 await HeliumEntitlementsManager.shared.stripeEntitlementsSource.refreshEntitlements()
@@ -227,18 +229,23 @@ public class StripeCheckoutManager: NSObject {
             }
         }
     }
+    
+    // Used by Stripe one-tap Apple Pay flow
+    public func handleNewPurchase(productId: String, priceId: String?, subscriptionExpiresAt: Date?) {
+        HeliumEntitlementsManager.shared.stripeEntitlementsSource.didCompletePurchase(productId: productId, priceId: priceId, subscriptionExpiresAt: subscriptionExpiresAt)
+    }
 
     // MARK: - API Calls
 
     /// Syncs Stripe customer metadata with the current user identity.
     @discardableResult
-    public func updateCustomerMetadata(
+    func updateCustomerMetadata(
         name: String? = nil,
         email: String? = nil,
         phone: String? = nil,
         description: String? = nil
     ) async throws -> Bool {
-        var body = HeliumStripeAPIClient.shared.baseRequestBody()
+        var body = try HeliumStripeAPIClient.shared.baseRequestBody()
         body["metadata"] = [
             "userId": body["userId"] as? String ?? "",
             "rcUserId": body["rcUserId"] as? String ?? "",
@@ -259,8 +266,8 @@ public class StripeCheckoutManager: NSObject {
     }
 
     /// Creates a Stripe Customer Portal session and returns the portal URL.
-    public func createPortalSession(returnUrl: String) async throws -> URL {
-        var body = HeliumStripeAPIClient.shared.baseRequestBody()
+    func createPortalSession(returnUrl: String) async throws -> URL {
+        var body = try HeliumStripeAPIClient.shared.baseRequestBody()
         body["returnUrl"] = returnUrl
 
         let response: PortalSessionResponse = try await HeliumStripeAPIClient.shared.post("stripe/create-portal-session", body: body)
@@ -293,5 +300,16 @@ enum StripeCheckoutError: LocalizedError {
         case .webPaywallBundleUrlMissing:
             return "No web paywall bundle URL available for this paywall."
         }
+    }
+}
+
+// MARK: - Base64URL
+
+extension Data {
+    func base64URLEncodedString() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "="))
     }
 }

--- a/Sources/Helium/HeliumCore/StripeCheckout/StripeCheckoutModels.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/StripeCheckoutModels.swift
@@ -83,7 +83,7 @@ public struct PaymentSuccessResponse: Sendable {
 
 // MARK: - API Response Types
 
-struct ExecutePurchaseResponse: Decodable {
+public struct ExecutePurchaseResponse: Decodable {
     let subscriptionId: String?
     let subscriptionItemId: String?
     let productId: String?
@@ -126,6 +126,7 @@ public enum HeliumStripeAPIError: LocalizedError {
     case serverError(statusCode: Int, message: String)
     case invalidEndpoint(path: String)
     case checkoutSessionNotCompleted
+    case notInitialized
 
     public var errorDescription: String? {
         switch self {
@@ -135,6 +136,8 @@ public enum HeliumStripeAPIError: LocalizedError {
             return "Invalid endpoint \(path)"
         case .checkoutSessionNotCompleted:
             return "Checkout session has not been completed"
+        case .notInitialized:
+            return "Helium has not been initialized. Call Helium.initialize() before making Stripe API calls."
         }
     }
 }

--- a/Sources/Helium/HeliumCore/StripeCheckout/StripeEntitlementsSource.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/StripeEntitlementsSource.swift
@@ -198,10 +198,8 @@ open class StripeEntitlementsSource: ThirdPartyEntitlementsSource, @unchecked Se
     }
 
     private func performFetch() async {
-        let body = HeliumStripeAPIClient.shared.baseRequestBody()
-        guard !body.isEmpty else { return }
-
         do {
+            let body = try HeliumStripeAPIClient.shared.baseRequestBody()
             let response: StripeEntitlementResponse = try await HeliumStripeAPIClient.shared.post("stripe/check-entitlement", body: body)
 
             // If superseded by a newer fetch, discard this result

--- a/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
+++ b/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
@@ -555,7 +555,7 @@ extension HeliumPaywallPresenter {
                 return fallbackViewFor(trigger: trigger, paywallInfo: templatePaywallInfo, fallbackReason: .stripeNoCustomUserId, presentationContext: presentationContext)
             }
             if hasStripeProducts && !Helium.config.stripeCheckoutEnabled {
-                return fallbackViewFor(trigger: trigger, paywallInfo: templatePaywallInfo, fallbackReason: .stripeCheckoutMissingUrls, presentationContext: presentationContext)
+                return fallbackViewFor(trigger: trigger, paywallInfo: templatePaywallInfo, fallbackReason: .stripeCheckoutNotEnabled, presentationContext: presentationContext)
             }
             
             do {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches purchase/restore logic and Stripe checkout URL construction; mistakes could break checkout attribution or entitlement syncing, but changes are localized and mostly defensive.
> 
> **Overview**
> Improves the Stripe web checkout flow by building the `ctx` query parameter as *JSON* (not base64-encoded JSON string) and encoding it with **base64url** so the resulting checkout URLs are more robust.
> 
> Makes Stripe API requests fail fast when Helium isn’t initialized (`baseRequestBody` now throws `notInitialized`), and updates entitlement refresh code paths accordingly.
> 
> Tightens paywall purchase/restore behavior: Stripe Checkout is skipped when Stripe Apple Pay one-tap is available, restores fall back to checking Stripe entitlements when StoreKit restore fails, and the “Stripe checkout unavailable” fallback reason is renamed to `stripeCheckoutNotEnabled` for clearer messaging. Also adds a `handleNewPurchase` hook to immediately update Stripe entitlements for the one-tap Apple Pay flow and tweaks foreground retry timing for post-checkout entitlement detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e709541130d5b46a014b7ee3d29e29240030641c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new public API for purchase notifications.

* **Bug Fixes**
  * Improved purchase recovery when restore fails.
  * Enhanced error handling for Stripe initialization.
  * Refined Apple Pay detection in Stripe payment flows.
  * Updated error messaging for unavailable Stripe checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->