### PR TITLE
HEL-5060 new targeting variable for stripe checkout flow

### DIFF
--- a/Sources/Helium/HeliumCore/HeliumIdentityManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumIdentityManager.swift
@@ -325,14 +325,20 @@ public class ApplePayHelper {
     public static let shared = ApplePayHelper()
 
     @HeliumAtomic private var cachedCanMakePayments: Bool?
+    @HeliumAtomic private var cachedCanMakePaymentsWithCards: Bool?
+
+    private static let defaultPaymentNetworks: [PKPaymentNetwork] = [
+        .amex, .masterCard, .visa, .discover
+    ]
 
     private init() {
-        cachedCanMakePayments = PKPaymentAuthorizationController.canMakePayments(usingNetworks: Self.defaultPaymentNetworks)
+        cachedCanMakePayments = PKPaymentAuthorizationController.canMakePayments()
+        cachedCanMakePaymentsWithCards = PKPaymentAuthorizationController.canMakePayments(usingNetworks: Self.defaultPaymentNetworks)
     }
 
     /// Checks if the device supports Apple Pay (cached)
     func canMakePayments() -> Bool {
-        return cachedCanMakePayments ?? PKPaymentAuthorizationController.canMakePayments(usingNetworks: Self.defaultPaymentNetworks)
+        return cachedCanMakePayments ?? PKPaymentAuthorizationController.canMakePayments()
     }
     
     @HeliumAtomic private var isStripeApplePayAvailable: Bool = false
@@ -343,12 +349,9 @@ public class ApplePayHelper {
         return isStripeApplePayAvailable && canMakePayments()
     }
 
-    private static let defaultPaymentNetworks: [PKPaymentNetwork] = [
-        .amex, .masterCard, .visa, .discover
-    ]
-
     func isStripeCheckoutEligible() -> Bool {
-        guard Helium.config.stripeCheckoutEnabled, canMakePayments() else { return false }
+        let hasCards = cachedCanMakePaymentsWithCards ?? PKPaymentAuthorizationController.canMakePayments(usingNetworks: Self.defaultPaymentNetworks)
+        guard Helium.config.stripeCheckoutEnabled, hasCards else { return false }
         if #available(iOS 16.4, *) { return true } else { return false }
     }
 }

--- a/Sources/Helium/HeliumCore/HeliumIdentityManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumIdentityManager.swift
@@ -350,9 +350,19 @@ public class ApplePayHelper {
     }
 
     func isStripeCheckoutEligible() -> Bool {
+        if !Helium.config.stripeCheckoutEnabled {
+            return false
+        }
         let hasCards = cachedCanMakePaymentsWithCards ?? PKPaymentAuthorizationController.canMakePayments(usingNetworks: Self.defaultPaymentNetworks)
-        guard Helium.config.stripeCheckoutEnabled, hasCards else { return false }
-        if #available(iOS 16.4, *) { return true } else { return false }
+        if !hasCards {
+            return false
+        }
+        // Our Stripe Apple pay flow on web requires 16.4+ 
+        if #available(iOS 16.4, *) {
+            return true
+        } else {
+            return false
+        }
     }
 }
 

--- a/Sources/Helium/HeliumCore/HeliumIdentityManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumIdentityManager.swift
@@ -327,12 +327,12 @@ public class ApplePayHelper {
     @HeliumAtomic private var cachedCanMakePayments: Bool?
 
     private init() {
-        cachedCanMakePayments = PKPaymentAuthorizationController.canMakePayments()
+        cachedCanMakePayments = PKPaymentAuthorizationController.canMakePayments(usingNetworks: Self.defaultPaymentNetworks)
     }
 
     /// Checks if the device supports Apple Pay (cached)
     func canMakePayments() -> Bool {
-        return cachedCanMakePayments ?? PKPaymentAuthorizationController.canMakePayments()
+        return cachedCanMakePayments ?? PKPaymentAuthorizationController.canMakePayments(usingNetworks: Self.defaultPaymentNetworks)
     }
     
     @HeliumAtomic private var isStripeApplePayAvailable: Bool = false
@@ -341,6 +341,15 @@ public class ApplePayHelper {
     }
     public func getStripeApplePayAvailable() -> Bool {
         return isStripeApplePayAvailable && canMakePayments()
+    }
+
+    private static let defaultPaymentNetworks: [PKPaymentNetwork] = [
+        .amex, .masterCard, .visa, .discover
+    ]
+
+    func isStripeCheckoutEligible() -> Bool {
+        guard Helium.config.stripeCheckoutEnabled, canMakePayments() else { return false }
+        if #available(iOS 16.4, *) { return true } else { return false }
     }
 }
 

--- a/Sources/Helium/HeliumCore/StripeCheckout/StripeCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/StripeCheckoutManager.swift
@@ -166,6 +166,8 @@ public class StripeCheckoutManager: NSObject {
         guard !activeCheckoutObservations.isEmpty else { return }
         guard foregroundObserver != nil else { return }
         stopForegroundObserver()
+        
+        HeliumLogger.log(.debug, category: .entitlements, "Checking for new Stripe entitlements...")
 
         Task { @MainActor [weak self] in
             guard let self else { return }
@@ -174,7 +176,7 @@ public class StripeCheckoutManager: NSObject {
             // Retry a few times (if needed) with increasing delays.
             let delays: [UInt64] = [0, 2_000_000_000, 3_000_000_000, 5_000_000_000]
 
-            for delay in delays {
+            for (i, delay) in delays.enumerated() {
                 if delay > 0 {
                     try? await Task.sleep(nanoseconds: delay)
                 }
@@ -214,6 +216,8 @@ public class StripeCheckoutManager: NSObject {
                         break
                     }
                 }
+                
+                HeliumLogger.log(.debug, category: .entitlements, "Detected new Stripe purchase? \(purchaseDetected) (attempt #\(i + 1))")
 
                 if purchaseDetected {
                     activeCheckoutObservations.removeAll()

--- a/Sources/Helium/HeliumCore/StripeCheckout/StripeCheckoutModels.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/StripeCheckoutModels.swift
@@ -98,7 +98,7 @@ public struct ExecutePurchaseResponse: Decodable {
         subscriptionItemId ?? subscriptionId ?? paymentIntentId
     }
 
-    func toPaymentSuccessResponse(backupProductId: String = "") -> PaymentSuccessResponse {
+    public func toPaymentSuccessResponse(backupProductId: String = "") -> PaymentSuccessResponse {
         PaymentSuccessResponse(
             productId: productId ?? backupProductId,
             priceId: priceId,

--- a/Sources/Helium/HeliumCore/UserContext.swift
+++ b/Sources/Helium/HeliumCore/UserContext.swift
@@ -203,7 +203,8 @@ public struct CodableUserContext: Codable {
             "heliumFirstSeenDate": heliumFirstSeenDate,
             "isFirstHeliumSession": HeliumIdentityManager.shared.isFirstHeliumSession,
             "userSeed": userSeed,
-            "additionalParams": self.additionalParams.dictionaryRepresentation
+            "additionalParams": self.additionalParams.dictionaryRepresentation,
+            "stripeCheckoutEligible": ApplePayHelper.shared.isStripeCheckoutEligible()
         ]
     }
 


### PR DESCRIPTION
And other minor improvements 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes payment-flow gating/targeting by adding a new eligibility check (Apple Pay card/network + iOS version + config flag) and sends that new signal in request payloads, which could affect checkout availability decisions.
> 
> **Overview**
> Adds a new `stripeCheckoutEligible` targeting variable by introducing `ApplePayHelper.isStripeCheckoutEligible()` (requires Stripe Checkout enabled, Apple Pay set up with major card networks, and iOS 16.4+), and includes this flag in `CodableUserContext.buildRequestPayload()`.
> 
> Improves Stripe Checkout observation diagnostics by adding debug logs around entitlement refresh attempts and whether a new Stripe purchase was detected.
> 
> Makes `ExecutePurchaseResponse.toPaymentSuccessResponse()` public to support external callers, and caches `canMakePayments(usingNetworks:)` for consistent Apple Pay/network capability checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4583eaa0182d0865809f9b1c337f95f62c50fefd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Stripe Checkout eligibility detection on supported devices and include this eligibility flag in outgoing requests.
  * Exposed payment-success response conversion to enable external integrations.

* **Improvements**
  * Improved Apple Pay validation for major payment networks (American Express, Mastercard, Visa, Discover).

* **Chores**
  * Enhanced debug logging for Stripe Checkout refresh operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->