### PR TITLE
SDK-15 third party anonymous id on identify events

### DIFF
--- a/HeliumExample/HeliumExample/ContentView.swift
+++ b/HeliumExample/HeliumExample/ContentView.swift
@@ -73,6 +73,10 @@ struct ContentView: View {
             }
             .accessibilityIdentifier("presentFallbackInvalidTrigger")
             
+            Button("set random user id") {
+                Helium.identify.userId = UUID().uuidString
+            }
+
             Button("check entitlement") {
                 Task {
                     let hasAny = await Helium.entitlements.hasAny()

--- a/Sources/Helium/HeliumCore/HeliumAnalyticsManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumAnalyticsManager.swift
@@ -122,7 +122,9 @@ class HeliumAnalyticsManager {
     
     private func performIdentify(on analytics: Analytics) {
         let resolvedUserId = HeliumIdentityManager.shared.getResolvedUserId()
-        let userContext = HeliumIdentityManager.shared.getUserContext()
+        var userContext = HeliumIdentityManager.shared.getUserContext()
+        userContext.hasCustomUserId = HeliumIdentityManager.shared.hasCustomUserId()
+        userContext.thirdPartyAnalyticsAnonymousId = HeliumIdentityManager.shared.getThirdPartyAnalyticsAnonymousId()
         analytics.identify(userId: resolvedUserId, traits: userContext)
     }
     

--- a/Sources/Helium/HeliumCore/UserContext.swift
+++ b/Sources/Helium/HeliumCore/UserContext.swift
@@ -109,7 +109,8 @@ public struct CodableUserContext: Codable {
     var applicationInfo: CodableApplicationInfo
     var isLowPowerMode: Bool
     var isApplePayAvailable: Bool
-    var hasCustomUserId: Bool
+    var hasCustomUserId: Bool? = nil
+    var thirdPartyAnalyticsAnonymousId: String? = nil
     var heliumFirstSeenDate: String
     var userSeed: Int
     var additionalParams: HeliumUserTraits
@@ -187,7 +188,8 @@ public struct CodableUserContext: Codable {
             "heliumInitializeId": HeliumIdentityManager.shared.heliumInitializeId,
             "heliumPersistentId": HeliumIdentityManager.shared.getHeliumPersistentId(),
             "userId": HeliumIdentityManager.shared.getResolvedUserId(),
-            "hasCustomUserId": hasCustomUserId,
+            "hasCustomUserId": HeliumIdentityManager.shared.hasCustomUserId(),
+            "thirdPartyAnalyticsAnonymousId": HeliumIdentityManager.shared.getThirdPartyAnalyticsAnonymousId() ?? "",
             "rcUserId": HeliumIdentityManager.shared.revenueCatAppUserId ?? "",
             "stripeCustomerId": HeliumIdentityManager.shared.getStripeCustomerId() ?? "",
             "organizationId": HeliumFetchedConfigManager.shared.getOrganizationID() ?? "unknown",
@@ -260,7 +262,6 @@ public struct CodableUserContext: Codable {
             applicationInfo: applicationInfo,
             isLowPowerMode: LowPowerModeHelper.shared.isLowPowerModeEnabled(),
             isApplePayAvailable: ApplePayHelper.shared.canMakePayments(),
-            hasCustomUserId: HeliumIdentityManager.shared.hasCustomUserId(),
             heliumFirstSeenDate: HeliumIdentityManager.shared.getHeliumFirstSeenDate(),
             userSeed: HeliumIdentityManager.shared.getUserSeed(),
             additionalParams: userTraits ?? HeliumUserTraits([:])

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -460,6 +460,7 @@ public class HeliumIdentify {
     /// - Amplitude: pass device ID
     /// - Mixpanel: pass anonymous ID
     /// - PostHog: pass anonymous ID
+    /// - Statsig: pass stable ID
     ///
     /// Set this before calling `Helium.shared.initialize()` for best results. Can also be updated after initialization.
     public var thirdPartyAnalyticsAnonymousId: String? {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the analytics identify payload/schema by adding `thirdPartyAnalyticsAnonymousId` (and dynamically populating `hasCustomUserId`), which could impact downstream event parsing or dashboards if consumers assume prior trait shapes.
> 
> **Overview**
> **Identify calls now include richer identity traits.** `HeliumAnalyticsManager.performIdentify` augments the identify `traits` with `hasCustomUserId` and the `thirdPartyAnalyticsAnonymousId` so these fields are present on `identify` events (not just track events).
> 
> **User context payload construction was adjusted** to compute `hasCustomUserId`/`thirdPartyAnalyticsAnonymousId` at request-build time and to make `CodableUserContext.hasCustomUserId` optional, avoiding stale values.
> 
> **Example app tweak:** adds a "set random user id" button for quickly exercising identify behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57fc967166fc4ace5feba4d3446d474029fe5414. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a button to manually set a random user ID.
  * Enhanced user context tracking to include custom user ID identification and third-party analytics anonymous identifier support.

* **Documentation**
  * Updated documentation for third-party analytics identifier support, including Statsig specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->