### PR TITLE
SDK-17 pull in new enableProductionPaywallPreviews flag!

### DIFF
--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelService.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelService.swift
@@ -5,6 +5,9 @@ class HeliumControlPanelService {
     private init() {}
 
     var allowPaywallControlPanel: Bool {
+        if HeliumFetchedConfigManager.shared.fetchedConfig?.enableProductionPaywallPreviews == true {
+            return true
+        }
         let env = AppReceiptsHelper.shared.getEnvironment()
         return env == AppReceiptsHelper.Environment.debug.rawValue
             || env == AppReceiptsHelper.Environment.sandbox.rawValue

--- a/Sources/Helium/HeliumCore/Models.swift
+++ b/Sources/Helium/HeliumCore/Models.swift
@@ -118,6 +118,7 @@ public struct HeliumFetchedConfig: Codable {
     var generatedAt: String?
     var stripeProducts: [String: ServerProductPrice]?
     var stripeCustomerId: String?
+    var enableProductionPaywallPreviews: Bool?
     
     /// Extract experiment info for a specific trigger
     /// - Parameter trigger: The trigger name to extract experiment info for


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes gating logic for the paywall control panel so it can be enabled in production based on remote config, which could expose preview tooling if misconfigured. Impact is limited to control-panel availability and depends on server-provided config.
> 
> **Overview**
> **Production paywall previews can now be enabled via remote config.**
> 
> `HeliumFetchedConfig` adds an optional `enableProductionPaywallPreviews` flag, and `HeliumControlPanelService.allowPaywallControlPanel` now returns true when this flag is set, bypassing the previous debug/sandbox-only receipt-environment check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60d5d82064dd19d8d2f65a10dd69e5568ca1dc7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to enable production paywall previews.
  * Control panel now respects production paywall preview settings from configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->