### PR TITLE
Hel 5134 paddle entitlements source

### DIFF
--- a/HeliumExample/HeliumExample/HeliumExampleApp.swift
+++ b/HeliumExample/HeliumExample/HeliumExampleApp.swift
@@ -33,7 +33,7 @@ struct HeliumExampleApp: App {
             AppConfig.apiKey
         }
         
-        Helium.config.enableStripeCheckout(successURL: "heliumexamplestripe://openapp", cancelURL: "heliumexamplestripe://openapp")
+        Helium.config.enableExternalWebCheckout(successURL: "heliumexamplestripe://openapp", cancelURL: "heliumexamplestripe://openapp")
         
         Helium.shared.initialize(
             apiKey: apiKey

--- a/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
@@ -18,7 +18,7 @@ actor HeliumEntitlementsManager {
         if let thirdParty = Helium.config.thirdPartyEntitlementsSource {
             sources.append(thirdParty)
         }
-        if Helium.config.stripeCheckoutEnabled {
+        if Helium.config.webCheckoutEnabled {
             sources.append(stripeEntitlementsSource)
         }
         return sources
@@ -172,7 +172,7 @@ actor HeliumEntitlementsManager {
         startTransactionListener()
         await loadEntitlementsIfNeeded()
 
-        if Helium.config.stripeCheckoutEnabled {
+        if Helium.config.webCheckoutEnabled {
             stripeEntitlementsSource.configure()
         }
 

--- a/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
@@ -11,6 +11,7 @@ actor HeliumEntitlementsManager {
     
     static let shared = HeliumEntitlementsManager()
     
+    nonisolated let paddleEntitlementsSource = PaddleEntitlementsSource()
     nonisolated let stripeEntitlementsSource = StripeEntitlementsSource()
 
     private var allThirdPartySources: [ThirdPartyEntitlementsSource] {
@@ -19,6 +20,7 @@ actor HeliumEntitlementsManager {
             sources.append(thirdParty)
         }
         if Helium.config.webCheckoutEnabled {
+            sources.append(paddleEntitlementsSource)
             sources.append(stripeEntitlementsSource)
         }
         return sources
@@ -173,6 +175,7 @@ actor HeliumEntitlementsManager {
         await loadEntitlementsIfNeeded()
 
         if Helium.config.webCheckoutEnabled {
+            paddleEntitlementsSource.configure()
             stripeEntitlementsSource.configure()
         }
 

--- a/Sources/Helium/HeliumCore/HeliumIdentityManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumIdentityManager.swift
@@ -350,7 +350,7 @@ public class ApplePayHelper {
     }
 
     func isStripeCheckoutEligible() -> Bool {
-        if !Helium.config.stripeCheckoutEnabled {
+        if !Helium.config.webCheckoutEnabled {
             return false
         }
         let hasCards = cachedCanMakePaymentsWithCards ?? PKPaymentAuthorizationController.canMakePayments(usingNetworks: Self.defaultPaymentNetworks)

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -136,7 +136,7 @@ class HeliumPaywallDelegateWrapper {
     func restorePurchases(triggerName: String, paywallTemplateName: String, paywallSession: PaywallSession) async -> Bool {
         var result = await delegate.restorePurchases()
         
-        if !result && Helium.config.stripeCheckoutEnabled {
+        if !result && Helium.config.webCheckoutEnabled {
             await HeliumEntitlementsManager.shared.stripeEntitlementsSource.refreshEntitlements()
             result = await !HeliumEntitlementsManager.shared.stripeEntitlementsSource.purchasedHeliumProductIds().isEmpty
         }

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -137,8 +137,12 @@ class HeliumPaywallDelegateWrapper {
         var result = await delegate.restorePurchases()
         
         if !result && Helium.config.webCheckoutEnabled {
-            await HeliumEntitlementsManager.shared.stripeEntitlementsSource.refreshEntitlements()
-            result = await !HeliumEntitlementsManager.shared.stripeEntitlementsSource.purchasedHeliumProductIds().isEmpty
+            await HeliumEntitlementsManager.shared.paddleEntitlementsSource.refreshEntitlements()
+            result = await !HeliumEntitlementsManager.shared.paddleEntitlementsSource.purchasedHeliumProductIds().isEmpty
+            if !result {
+                await HeliumEntitlementsManager.shared.stripeEntitlementsSource.refreshEntitlements()
+                result = await !HeliumEntitlementsManager.shared.stripeEntitlementsSource.purchasedHeliumProductIds().isEmpty
+            }
         }
         if result {
             self.fireEvent(PurchaseRestoredEvent(productId: "HELIUM_GENERIC_PRODUCT", triggerName: triggerName, paywallName: paywallTemplateName), paywallSession: paywallSession)

--- a/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
@@ -210,10 +210,16 @@ open class HeliumPaymentEntitlementsSource: ThirdPartyEntitlementsSource, @unche
     }
 }
 
-// MARK: - StripeEntitlementsSource
+// MARK: - Provider-specific implementations
 
 public class StripeEntitlementsSource: HeliumPaymentEntitlementsSource {
     public init() {
         super.init(provider: .stripe)
+    }
+}
+
+public class PaddleEntitlementsSource: HeliumPaymentEntitlementsSource {
+    public init() {
+        super.init(provider: .paddle)
     }
 }

--- a/Sources/Helium/HeliumCore/StripeCheckout/PaymentProviderConfig.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/PaymentProviderConfig.swift
@@ -24,8 +24,21 @@ struct PaymentProviderConfig {
         getCustomerId: { HeliumIdentityManager.shared.getStripeCustomerId() },
         setCustomerId: { HeliumIdentityManager.shared.setStripeCustomerId($0) },
         entitlementsPersistenceFileName: "helium_stripe_entitlements.json",
-        getCheckoutSuccessURL: { Helium.config.stripeCheckoutSuccessURL },
-        getCheckoutCancelURL: { Helium.config.stripeCheckoutCancelURL },
+        getCheckoutSuccessURL: { Helium.config.checkoutSuccessURL },
+        getCheckoutCancelURL: { Helium.config.checkoutCancelURL },
         getOfferedProducts: { $0.productsOfferedStripe }
+    )
+    
+    static let paddle = PaymentProviderConfig(
+        displayName: "Paddle",
+        providerSlug: "paddle",
+        customerIdBodyKey: "paddleCustomerId",
+        // todo
+        getCustomerId: { nil },
+        setCustomerId: { _ in /* TODO */ },
+        entitlementsPersistenceFileName: "helium_paddle_entitlements.json",
+        getCheckoutSuccessURL: { Helium.config.checkoutSuccessURL },
+        getCheckoutCancelURL: { Helium.config.checkoutCancelURL },
+        getOfferedProducts: { _ in return [] /* TODO */ }
     )
 }

--- a/Sources/Helium/HeliumCore/StripeCheckout/WebCheckoutModels.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/WebCheckoutModels.swift
@@ -158,7 +158,7 @@ enum WebCheckoutError: LocalizedError {
         case .cannotPresentCheckout:
             return "Could not present the checkout view"
         case .checkoutURLsNotConfigured:
-            return "Checkout URLs not configured. Call Helium.config.enableCheckout() before presenting a paywall."
+            return "Checkout URLs not configured. Call Helium.config.enableExternalWebCheckout() before presenting a paywall."
         case .failedToBuildEnrichedURL:
             return "Failed to build enriched checkout URL."
         case .failedToOpenEnrichedURL:

--- a/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
+++ b/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
@@ -554,7 +554,7 @@ extension HeliumPaywallPresenter {
             if hasStripeProducts && !HeliumIdentityManager.shared.hasCustomUserId() {
                 return fallbackViewFor(trigger: trigger, paywallInfo: templatePaywallInfo, fallbackReason: .stripeNoCustomUserId, presentationContext: presentationContext)
             }
-            if hasStripeProducts && !Helium.config.stripeCheckoutEnabled {
+            if hasStripeProducts && !Helium.config.webCheckoutEnabled {
                 return fallbackViewFor(trigger: trigger, paywallInfo: templatePaywallInfo, fallbackReason: .stripeCheckoutNotEnabled, presentationContext: presentationContext)
             }
             

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -618,7 +618,7 @@ public class HeliumConfig {
     /// Disables External Web Checkout Flow. Paywalls with Paddle or Stripe products
     /// will not show. Your fallback paywall/s, if provided, will show instead.
     /// NOTE - if you have existing Paddle/Stripe customers, Helium will stop respecting their entitlements.
-    public func disableStripeCheckout() {
+    public func disableExternalWebCheckout() {
         checkoutSuccessURL = nil
         checkoutCancelURL = nil
         webCheckoutEnabled = false

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -615,9 +615,9 @@ public class HeliumConfig {
         webCheckoutEnabled = true
     }
 
-    /// Disables Stripe checkout flow. Paywalls with Stripe products
+    /// Disables External Web Checkout Flow. Paywalls with Paddle or Stripe products
     /// will not show. Your fallback paywall/s, if provided, will show instead.
-    /// NOTE - if you have existing Stripe customers, Helium will stop respecting their entitlements.
+    /// NOTE - if you have existing Paddle/Stripe customers, Helium will stop respecting their entitlements.
     public func disableStripeCheckout() {
         checkoutSuccessURL = nil
         checkoutCancelURL = nil

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -414,7 +414,7 @@ public class HeliumIdentify {
                 HeliumAnalyticsManager.shared.identify()
                 
                 // Sync Stripe customer metadata if Stripe is configured
-                if Helium.config.stripeCheckoutEnabled,
+                if Helium.config.webCheckoutEnabled,
                    Helium.shared.isInitialized() {
                     Task {
                         if HeliumIdentityManager.shared.getStripeCustomerId() == nil {
@@ -572,15 +572,15 @@ public class HeliumConfig {
     /// Set this to `false` to disable the diagnostic view for all users in DEBUG builds.
     public var paywallNotShownDiagnosticDisplayEnabled: Bool = true
 
-    // MARK: - Stripe Checkout Configuration
+    // MARK: - External Web Checkout Configuration
     
-    private(set) var stripeCheckoutEnabled: Bool = false
+    private(set) var webCheckoutEnabled: Bool = false
     
-    /// Custom success redirect URL for Stripe Checkout Flow.
-    private(set) var stripeCheckoutSuccessURL: String? = nil
+    /// Custom success redirect URL for External Checkout Flow.
+    private(set) var checkoutSuccessURL: String? = nil
 
-    /// Custom cancel redirect URL for Stripe Checkout Flow.
-    private(set) var stripeCheckoutCancelURL: String? = nil
+    /// Custom cancel redirect URL for External Checkout Flow.
+    private(set) var checkoutCancelURL: String? = nil
 
     /// Enables Stripe Checkout Flow for any Stripe products in your paywalls. If not enabled, paywalls with Stripe products
     /// will not show. Your fallback paywall/s, if provided, will show instead.
@@ -591,24 +591,24 @@ public class HeliumConfig {
     ///   - successURL: The URL Stripe redirects to after a successful payment.
     ///     Include `{CHECKOUT_SESSION_ID}` in the URL to receive the session ID.
     ///   - cancelURL: The URL Stripe redirects to when the user cancels checkout.
-    public func enableStripeCheckout(successURL: String, cancelURL: String) {
+    public func enableExternalWebCheckout(successURL: String, cancelURL: String) {
         guard let successParsed = URL(string: successURL), successParsed.scheme != nil,
               let cancelParsed = URL(string: cancelURL), cancelParsed.scheme != nil else {
             HeliumLogger.log(.error, category: .core, "enableStripeCheckout: invalid URLs provided. Both successURL and cancelURL must be valid URLs with a scheme (e.g. https://example.com or myapp://path).")
             return
         }
-        stripeCheckoutSuccessURL = successURL
-        stripeCheckoutCancelURL = cancelURL
-        stripeCheckoutEnabled = true
+        checkoutSuccessURL = successURL
+        checkoutCancelURL = cancelURL
+        webCheckoutEnabled = true
     }
 
     /// Disables Stripe checkout flow. Paywalls with Stripe products
     /// will not show. Your fallback paywall/s, if provided, will show instead.
     /// NOTE - if you have existing Stripe customers, Helium will stop respecting their entitlements.
     public func disableStripeCheckout() {
-        stripeCheckoutSuccessURL = nil
-        stripeCheckoutCancelURL = nil
-        stripeCheckoutEnabled = false
+        checkoutSuccessURL = nil
+        checkoutCancelURL = nil
+        webCheckoutEnabled = false
     }
 
 }

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -356,6 +356,19 @@ public class Helium {
         HeliumIdentityManager.shared.setStripeCustomerId(nil)
     }
     
+    // MARK: - Paddle Checkout
+    
+    /// Resets Paddle entitlements and optionally clears the user ID.
+    /// If your app can support multiple Paddle users on the same device, you'll want to call this to effectively "log out" a Paddle user.
+    public func resetPaddleEntitlements(clearUserId: Bool) {
+        if clearUserId {
+            Helium.identify.userId = nil
+        }
+        HeliumEntitlementsManager.shared.paddleEntitlementsSource.clearEntitlements()
+        // todo clear paddle customer id
+//        HeliumIdentityManager.shared.setStripeCustomerId(nil)
+    }
+    
 }
 
 /// Configuration options for presenting a paywall.
@@ -582,19 +595,19 @@ public class HeliumConfig {
     /// Custom cancel redirect URL for External Checkout Flow.
     private(set) var checkoutCancelURL: String? = nil
 
-    /// Enables Stripe Checkout Flow for any Stripe products in your paywalls. If not enabled, paywalls with Stripe products
+    /// Enables External Web Checkout Flow for any Paddle or Stripe products in your paywalls. If not enabled, paywalls with Paddle/Stripe products
     /// will not show. Your fallback paywall/s, if provided, will show instead.
     ///
-    /// You must provide redirect URLs so Stripe knows where to send the user after checkout completes or is cancelled.
+    /// You must provide redirect URLs so Helium knows where to send the user after checkout completes or is cancelled.
     ///
     /// - Parameters:
-    ///   - successURL: The URL Stripe redirects to after a successful payment.
+    ///   - successURL: The URL to redirect to after a successful payment.
     ///     Include `{CHECKOUT_SESSION_ID}` in the URL to receive the session ID.
     ///   - cancelURL: The URL Stripe redirects to when the user cancels checkout.
     public func enableExternalWebCheckout(successURL: String, cancelURL: String) {
         guard let successParsed = URL(string: successURL), successParsed.scheme != nil,
               let cancelParsed = URL(string: cancelURL), cancelParsed.scheme != nil else {
-            HeliumLogger.log(.error, category: .core, "enableStripeCheckout: invalid URLs provided. Both successURL and cancelURL must be valid URLs with a scheme (e.g. https://example.com or myapp://path).")
+            HeliumLogger.log(.error, category: .core, "enableExternalWebCheckout: invalid URLs provided. Both successURL and cancelURL must be valid URLs with a scheme (e.g. https://example.com or myapp://path).")
             return
         }
         checkoutSuccessURL = successURL


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a public API rename and changes entitlement/restore behavior behind a new `webCheckoutEnabled` flag, which may break existing integrations and alter purchase restoration outcomes. Paddle support is partially stubbed (customer ID/products TODO), so edge cases may surface until fully implemented.
> 
> **Overview**
> Adds a new `PaddleEntitlementsSource` alongside Stripe and wires it into entitlement loading and restore flows when external web checkout is enabled.
> 
> Renames/generalizes the public configuration API from Stripe-specific checkout (`enableStripeCheckout`/`disableStripeCheckout`, `stripeCheckout*` fields) to provider-agnostic external web checkout (`enableExternalWebCheckout`/`disableExternalWebCheckout`, shared success/cancel URLs), updating eligibility and paywall gating checks to use `webCheckoutEnabled`. Also exposes `resetPaddleEntitlements` and updates the example app to use the new config API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20c31cba3c212ed82bc866a902e8cff6f18147ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->