### PR TITLE
Hel 5131 paddle products offered

### DIFF
--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
@@ -21,6 +21,7 @@ struct HeliumPaywallPreviewVersion: Codable, Identifiable {
     let previewUrl: String?
     let productIds: [String]?
     let stripeProductIds: [String]?
+    let paddleProductIds: [String]?
     let lastSavedAt: String?
     var id: String { versionId }
 

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
@@ -232,7 +232,9 @@ struct HeliumControlPanelView: View {
                     bundleId: bundleId,
                     bundleUrl: bundleUrl,
                     bundleHtml: html,
-                    productIds: version.productIds ?? []
+                    productIds: version.productIds ?? [],
+                    productIdsStripe: version.stripeProductIds ?? [],
+                    productIdsPaddle: version.paddleProductIds ?? []
                 )
 
                 await MainActor.run { loadingVersionId = nil }

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -1033,6 +1033,7 @@ public class HeliumFetchedConfigManager {
         // Clear fields inherited from source trigger that would interfere with preview
         previewPaywallInfo.forceShowFallback = nil
         previewPaywallInfo.productsOfferedStripe = nil
+        previewPaywallInfo.productsOfferedPaddle = nil
 
         // Store the preview trigger config
         config.triggerToPaywalls[Self.HELIUM_PREVIEW_TRIGGER] = previewPaywallInfo

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -997,7 +997,9 @@ public class HeliumFetchedConfigManager {
         bundleId: String,
         bundleUrl: String,
         bundleHtml: String,
-        productIds: [String]
+        productIds: [String],
+        productIdsStripe: [String],
+        productIdsPaddle: [String]
     ) throws {
         guard var config = fetchedConfig else {
             throw HeliumControlPanelError.noConfigAvailable
@@ -1029,11 +1031,11 @@ public class HeliumFetchedConfigManager {
 
         // Update product IDs
         previewPaywallInfo.productsOfferedIOS = productIds
+        previewPaywallInfo.productsOfferedStripe = productIdsStripe
+        previewPaywallInfo.productsOfferedPaddle = productIdsPaddle
 
         // Clear fields inherited from source trigger that would interfere with preview
         previewPaywallInfo.forceShowFallback = nil
-        previewPaywallInfo.productsOfferedStripe = nil
-        previewPaywallInfo.productsOfferedPaddle = nil
 
         // Store the preview trigger config
         config.triggerToPaywalls[Self.HELIUM_PREVIEW_TRIGGER] = previewPaywallInfo

--- a/Sources/Helium/HeliumCore/Models.swift
+++ b/Sources/Helium/HeliumCore/Models.swift
@@ -37,6 +37,7 @@ public struct HeliumPaywallInfo: Codable {
     var productsOffered: [String]?
     var productsOfferedIOS: [String]?
     var productsOfferedStripe: [String]?
+    var productsOfferedPaddle: [String]?
     var resolvedConfig: AnyCodable
     var shouldShow: Bool?
     var fallbackPaywallName: String?
@@ -55,7 +56,7 @@ public struct HeliumPaywallInfo: Codable {
     }
     
     var productIds: [String] {
-        productIdsIOS + (productsOfferedStripe ?? [])
+        productIdsIOS + (productsOfferedStripe ?? []) + (productsOfferedPaddle ?? [])
     }
     
     var hasProducts: Bool {

--- a/Sources/Helium/HeliumCore/StripeCheckout/PaymentProviderConfig.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/PaymentProviderConfig.swift
@@ -39,6 +39,6 @@ struct PaymentProviderConfig {
         entitlementsPersistenceFileName: "helium_paddle_entitlements.json",
         getCheckoutSuccessURL: { Helium.config.checkoutSuccessURL },
         getCheckoutCancelURL: { Helium.config.checkoutCancelURL },
-        getOfferedProducts: { _ in return [] /* TODO */ }
+        getOfferedProducts: { $0.productsOfferedPaddle }
     )
 }

--- a/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
+++ b/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
@@ -550,11 +550,13 @@ extension HeliumPaywallPresenter {
                 return fallbackViewFor(trigger: trigger, paywallInfo: templatePaywallInfo, fallbackReason: .noProductsIOS, presentationContext: presentationContext)
             }
             
+            let hasPaddleProducts = !(templatePaywallInfo.productsOfferedPaddle ?? []).isEmpty
             let hasStripeProducts = !(templatePaywallInfo.productsOfferedStripe ?? []).isEmpty
-            if hasStripeProducts && !HeliumIdentityManager.shared.hasCustomUserId() {
+            let hasAppToWebProducts = hasPaddleProducts || hasStripeProducts
+            if hasAppToWebProducts && !HeliumIdentityManager.shared.hasCustomUserId() {
                 return fallbackViewFor(trigger: trigger, paywallInfo: templatePaywallInfo, fallbackReason: .stripeNoCustomUserId, presentationContext: presentationContext)
             }
-            if hasStripeProducts && !Helium.config.webCheckoutEnabled {
+            if hasAppToWebProducts && !Helium.config.webCheckoutEnabled {
                 return fallbackViewFor(trigger: trigger, paywallInfo: templatePaywallInfo, fallbackReason: .stripeCheckoutNotEnabled, presentationContext: presentationContext)
             }
             


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes paywall product selection and presentation gating logic; misconfiguration could cause paywalls to fall back or block showing when Paddle/Stripe products are present.
> 
> **Overview**
> Adds first-class support for **Paddle product IDs** alongside iOS and Stripe in paywall preview and runtime paywall models.
> 
> The control-panel preview flow now fetches/threads `paddleProductIds` through `setPreviewTriggerConfig`, stores them on `HeliumPaywallInfo`, and includes them in the unified `productIds` list used for product presence checks. Paddle’s provider config now returns offered products from the paywall, and paywall presentation gating (custom user id + `webCheckoutEnabled`) now triggers for *any* app-to-web products (Stripe or Paddle), not just Stripe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95d0ce69d6784c9b9fa13f4c442f34c9b53f6b2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Paddle as a payment provider option alongside iOS and Stripe.
  * Paywall configuration and preview system now supports managing Paddle product identifiers.
  * Improved fallback behavior for web-based checkout when using Paddle products.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->