### PR TITLE
HEL-5130 pull in paddle products from on-launch and link up paddle checkout flow

### DIFF
--- a/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
@@ -19,8 +19,10 @@ actor HeliumEntitlementsManager {
         if let thirdParty = Helium.config.thirdPartyEntitlementsSource {
             sources.append(thirdParty)
         }
-        if Helium.config.webCheckoutEnabled {
+        if paddleEntitlementsSource.isConfigured {
             sources.append(paddleEntitlementsSource)
+        }
+        if stripeEntitlementsSource.isConfigured {
             sources.append(stripeEntitlementsSource)
         }
         return sources
@@ -174,8 +176,10 @@ actor HeliumEntitlementsManager {
         startTransactionListener()
         await loadEntitlementsIfNeeded()
 
-        if Helium.config.webCheckoutEnabled {
+        if Helium.config.webCheckoutEnabled || HeliumIdentityManager.shared.getPaddleCustomerId() != nil {
             paddleEntitlementsSource.configure()
+        }
+        if Helium.config.webCheckoutEnabled || HeliumIdentityManager.shared.getStripeCustomerId() != nil {
             stripeEntitlementsSource.configure()
         }
 

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -864,6 +864,12 @@ public class HeliumFetchedConfigManager {
                 map.merge(converted) { storeKitValue, _ in storeKitValue }
             }
         }
+        if let serverPrices = config?.paddleProducts {
+            let converted = serverPrices.mapValues { $0.toLocalizedPrice() }
+            _localizedPriceMap.withValue { map in
+                map.merge(converted) { storeKitValue, _ in storeKitValue }
+            }
+        }
 
         var allFound = false
         _localizedPriceMap.withValue { map in
@@ -896,8 +902,11 @@ public class HeliumFetchedConfigManager {
 
     // NOTE - be careful about removing the public declaration here because this is in use
     // by some sdk integrations.
-    public func getServerProductsPriceMap() -> [String: ServerProductPrice]? {
+    public func getStripeProductsPriceMap() -> [String: ServerProductPrice]? {
         return fetchedConfig?.stripeProducts
+    }
+    public func getPaddleProductsPriceMap() -> [String: ServerProductPrice]? {
+        return fetchedConfig?.paddleProducts
     }
     
     /// Get localized prices filtered by a specific trigger's product IDs

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -347,6 +347,10 @@ public class HeliumFetchedConfigManager {
             if let stripeCustomerId = fetchedConfig?.stripeCustomerId {
                 HeliumIdentityManager.shared.setStripeCustomerId(stripeCustomerId)
             }
+
+            if let paddleCustomerId = fetchedConfig?.paddleCustomerId {
+                HeliumIdentityManager.shared.setPaddleCustomerId(paddleCustomerId)
+            }
             
             // Download assets
             

--- a/Sources/Helium/HeliumCore/HeliumIdentityManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumIdentityManager.swift
@@ -67,6 +67,7 @@ public class HeliumIdentityManager {
     private let heliumUserSeedKey = "heliumUserSeed"
     private let heliumHasCustomUserIdKey = "heliumHasCustomUserId"
     private let heliumStripeCustomerIdKey = "heliumStripeCustomerId"
+    private let heliumPaddleCustomerIdKey = "heliumPaddleCustomerId"
     private let heliumAppTransactionIDKey = "heliumAppTransactionID"
     private let heliumThirdPartyAnalyticsAnonymousIdKey = "heliumThirdPartyAnalyticsAnonymousId"
     private let heliumUserTraitsKey = "heliumUserTraits"
@@ -152,7 +153,19 @@ public class HeliumIdentityManager {
     public func getStripeCustomerId() -> String? {
         return UserDefaults.standard.string(forKey: heliumStripeCustomerIdKey)
     }
-    
+
+    public func setPaddleCustomerId(_ customerId: String?) {
+        guard let customerId, !customerId.isEmpty else {
+            UserDefaults.standard.removeObject(forKey: heliumPaddleCustomerIdKey)
+            return
+        }
+        UserDefaults.standard.setValue(customerId, forKey: heliumPaddleCustomerIdKey)
+    }
+
+    public func getPaddleCustomerId() -> String? {
+        return UserDefaults.standard.string(forKey: heliumPaddleCustomerIdKey)
+    }
+
     public func getAppTransactionID() -> String? {
         return appTransactionID
     }

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -68,13 +68,28 @@ class HeliumPaywallDelegateWrapper {
         
         let transactionStatus: HeliumPaywallTransactionStatus
         
-        var isStripeCheckoutFlow: Bool = false
-        let allStripeProductIds = Array((HeliumFetchedConfigManager.shared.getServerProductsPriceMap() ?? [:]).keys)
+        var isExternalCheckoutFlow: Bool = false
+        let allStripeProductIds = Array((HeliumFetchedConfigManager.shared.getStripeProductsPriceMap() ?? [:]).keys)
         let stripeApplePayFlow = ApplePayHelper.shared.getStripeApplePayAvailable()
+        
+        let allPaddleProductIds = Array((HeliumFetchedConfigManager.shared.getPaddleProductsPriceMap() ?? [:]).keys)
+        
         if !stripeApplePayFlow && allStripeProductIds.contains(productKey) {
-            isStripeCheckoutFlow = true
+            isExternalCheckoutFlow = true
             do {
                 try await StripeCheckoutManager.shared.startCheckoutFlow(
+                    for: productKey,
+                    triggerName: triggerName,
+                    paywallSession: paywallSession
+                )
+                transactionStatus = .pending
+            } catch {
+                transactionStatus = .failed(error)
+            }
+        } else if allPaddleProductIds.contains(productKey) {
+            isExternalCheckoutFlow = true
+            do {
+                try await PaddleCheckoutManager.shared.startCheckoutFlow(
                     for: productKey,
                     triggerName: triggerName,
                     paywallSession: paywallSession
@@ -125,7 +140,7 @@ class HeliumPaywallDelegateWrapper {
             }
         case .pending:
             self.fireEvent(PurchasePendingEvent(productId: productKey, triggerName: triggerName, paywallName: paywallTemplateName), paywallSession: paywallSession)
-            if !isStripeCheckoutFlow {
+            if !isExternalCheckoutFlow {
                 let detachedSession = paywallSession.withPresentationContext(.empty)
                 observePendingPurchase(productId: productKey, triggerName: triggerName, paywallTemplateName: paywallTemplateName, paywallSession: detachedSession)
             }

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -282,6 +282,7 @@ class HeliumPaywallDelegateWrapper {
 
         if event is PaywallCloseEvent, let paywallSession {
             Task { @MainActor in
+                PaddleCheckoutManager.shared.stopObserving(paywallSession: paywallSession)
                 StripeCheckoutManager.shared.stopObserving(paywallSession: paywallSession)
             }
         }

--- a/Sources/Helium/HeliumCore/Models.swift
+++ b/Sources/Helium/HeliumCore/Models.swift
@@ -117,8 +117,12 @@ public struct HeliumFetchedConfig: Codable {
     var additionalFields: JSON?
     var bundles: [String: String]?
     var generatedAt: String?
+    
     var stripeProducts: [String: ServerProductPrice]?
     var stripeCustomerId: String?
+    
+    var paddleProducts: [String: ServerProductPrice]?
+//    var paddleCustomerId: String? // todo figure out how we handle paddle customer ids
     
     /// Extract experiment info for a specific trigger
     /// - Parameter trigger: The trigger name to extract experiment info for

--- a/Sources/Helium/HeliumCore/Models.swift
+++ b/Sources/Helium/HeliumCore/Models.swift
@@ -122,7 +122,7 @@ public struct HeliumFetchedConfig: Codable {
     var stripeCustomerId: String?
     
     var paddleProducts: [String: ServerProductPrice]?
-//    var paddleCustomerId: String? // todo figure out how we handle paddle customer ids
+    var paddleCustomerId: String?
     
     /// Extract experiment info for a specific trigger
     /// - Parameter trigger: The trigger name to extract experiment info for

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -1,15 +1,21 @@
 import UIKit
 import SafariServices
 
-public typealias StripeCheckoutManager = ExternalWebCheckoutManager
-
-/// Orchestrates the external web checkout flow (browser-based) for payment providers.
-public class ExternalWebCheckoutManager: NSObject {
-
+public class StripeCheckoutManager {
     public static let shared = ExternalWebCheckoutManager(
         provider: .stripe,
         entitlementsSource: HeliumEntitlementsManager.shared.stripeEntitlementsSource
     )
+}
+public class PaddleCheckoutManager {
+    public static let shared = ExternalWebCheckoutManager(
+        provider: .paddle,
+        entitlementsSource: HeliumEntitlementsManager.shared.paddleEntitlementsSource
+    )
+}
+
+/// Orchestrates the external web checkout flow (browser-based) for payment providers.
+public class ExternalWebCheckoutManager: NSObject {
 
     private let provider: PaymentProviderConfig
     private let entitlementsSource: HeliumPaymentEntitlementsSource

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -103,7 +103,7 @@ public class ExternalWebCheckoutManager: NSObject {
         let analyticsJSON = try JSONSerialization.jsonObject(with: analyticsData)
         ctx["analytics"] = analyticsJSON
 
-        ctx["initialStripeSelection"] = productKey
+        ctx[provider.initialProductKey] = productKey
         ctx["trigger"] = triggerName
         ctx["successUrl"] = successURL
         ctx["cancelUrl"] = cancelURL

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -198,49 +198,9 @@ public class ExternalWebCheckoutManager: NSObject {
                 }
                 guard !activeCheckoutObservations.isEmpty else { return }
 
-                await entitlementsSource.refreshEntitlements()
-                let currentEntitledIds = await entitlementsSource.purchasedHeliumProductIds()
-
-                var purchaseDetected = false
-                let observationsSnapshot = activeCheckoutObservations
-                    .sorted { $0.value.addedAt > $1.value.addedAt }
-                for (sessionId, observation) in observationsSnapshot {
-                    guard let offeredProducts = observation.paywallSession.paywallInfoWithBackups.flatMap({ provider.getOfferedProducts($0) }) else {
-                        activeCheckoutObservations.removeValue(forKey: sessionId)
-                        continue
-                    }
-
-                    let newlyEntitledIds = currentEntitledIds
-                        .subtracting(observation.entitledProductIdsBeforeCheckout)
-
-                    // If multiple sessions offer the same product, we attribute to the most
-                    // recently added session (likely the one the user just interacted with).
-                    // In practice, second-try paywalls offer different products.
-                    if let purchasedProductId = newlyEntitledIds.first(where: { offeredProducts.contains($0) }) {
-                        purchaseDetected = true
-                        HeliumPaywallDelegateWrapper.shared.fireEvent(
-                            PurchaseSucceededEvent(
-                                productId: purchasedProductId,
-                                triggerName: observation.paywallSession.trigger,
-                                paywallName: observation.paywallSession.paywallInfoWithBackups?.paywallTemplateName ?? "",
-                                storeKitTransactionId: nil,
-                                storeKitOriginalTransactionId: nil
-                            ),
-                            paywallSession: observation.paywallSession,
-                            sendToAnalytics: false
-                        )
-                        break
-                    }
-                }
-
+                let purchaseDetected = await checkForNewPurchase()
                 HeliumLogger.log(.debug, category: .entitlements, "Detected new \(provider.displayName) purchase? \(purchaseDetected) (attempt #\(i + 1))")
-
-                if purchaseDetected {
-                    activeCheckoutObservations.removeAll()
-                    // TODO: Ideally call HeliumActionsDelegate.dismissAll to handle dismissAction for DynamicPaywallModifier case...
-                    Helium.shared.hideAllPaywalls()
-                    return
-                }
+                if purchaseDetected { return }
             }
 
             // All retries exhausted — resume observing for next foreground return
@@ -248,6 +208,49 @@ public class ExternalWebCheckoutManager: NSObject {
                 startForegroundObserver()
             }
         }
+    }
+
+    /// Refreshes entitlements once, looks for a newly-entitled offered product
+    /// across active observations (newest-first), and if found fires
+    /// PurchaseSucceededEvent, clears all observations, and hides paywalls.
+    @MainActor
+    private func checkForNewPurchase() async -> Bool {
+        await entitlementsSource.refreshEntitlements()
+        let currentEntitledIds = await entitlementsSource.purchasedHeliumProductIds()
+
+        let observationsSnapshot = activeCheckoutObservations
+            .sorted { $0.value.addedAt > $1.value.addedAt }
+        for (sessionId, observation) in observationsSnapshot {
+            guard let offeredProducts = observation.paywallSession.paywallInfoWithBackups.flatMap({ provider.getOfferedProducts($0) }) else {
+                activeCheckoutObservations.removeValue(forKey: sessionId)
+                continue
+            }
+
+            let newlyEntitledIds = currentEntitledIds
+                .subtracting(observation.entitledProductIdsBeforeCheckout)
+
+            // If multiple sessions offer the same product, we attribute to the most
+            // recently added session (likely the one the user just interacted with).
+            // In practice, second-try paywalls offer different products.
+            if let purchasedProductId = newlyEntitledIds.first(where: { offeredProducts.contains($0) }) {
+                HeliumPaywallDelegateWrapper.shared.fireEvent(
+                    PurchaseSucceededEvent(
+                        productId: purchasedProductId,
+                        triggerName: observation.paywallSession.trigger,
+                        paywallName: observation.paywallSession.paywallInfoWithBackups?.paywallTemplateName ?? "",
+                        storeKitTransactionId: nil,
+                        storeKitOriginalTransactionId: nil
+                    ),
+                    paywallSession: observation.paywallSession,
+                    sendToAnalytics: false
+                )
+                activeCheckoutObservations.removeAll()
+                // TODO: Ideally call HeliumActionsDelegate.dismissAll to handle dismissAction for DynamicPaywallModifier case.....
+                Helium.shared.hideAllPaywalls()
+                return true
+            }
+        }
+        return false
     }
 
     // Used by Stripe one-tap Apple Pay flow (so must be public)

--- a/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
@@ -35,7 +35,9 @@ open class HeliumPaymentEntitlementsSource: ThirdPartyEntitlementsSource, @unche
         self.provider = provider
     }
 
+    private(set) var isConfigured = false
     func configure() {
+        guard !isConfigured else { return }
         loadPersistedData()
         Task { await fetchFromServer() }
     }

--- a/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
@@ -126,6 +126,13 @@ open class HeliumPaymentEntitlementsSource: ThirdPartyEntitlementsSource, @unche
     }
 
     private func fetchFromServer(forceNew: Bool = false) async {
+        guard Helium.identify.userId != nil
+                || Helium.identify.revenueCatAppUserId != nil
+                || provider.getCustomerId() != nil else {
+            // We can safely assume entitlements result will be empty if no stripe/paddle customer id and no id
+            // set by host app that may persist across app installs / device change.
+            return
+        }
         let (task, myId): (Task<Void, Never>, UInt) = lock.withLock {
             if !forceNew, let existing = currentFetchTask {
                 return (existing, fetchId)
@@ -146,13 +153,6 @@ open class HeliumPaymentEntitlementsSource: ThirdPartyEntitlementsSource, @unche
     }
 
     private func performFetch() async {
-        guard Helium.identify.userId != nil
-                || Helium.identify.revenueCatAppUserId != nil
-                || provider.getCustomerId() != nil else {
-            // We can safely assume entitlements result will be empty if no stripe/paddle customer id and no id
-            // set by host app that may persist across app installs / device change.
-            return
-        }
         do {
             let body = try HeliumPaymentAPIClient.shared.baseRequestBody(provider: provider)
             let response: PaymentEntitlementResponse = try await HeliumPaymentAPIClient.shared.post(provider.checkEntitlementPath, body: body)

--- a/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
@@ -159,7 +159,7 @@ open class HeliumPaymentEntitlementsSource: ThirdPartyEntitlementsSource, @unche
             let activeSubscriptions = response.subscriptions.filter { $0.isActive }
 
             let productEntitlements: [ProductEntitlement] = activeSubscriptions.map { sub in
-                let dateString = sub.currentPeriodEnd ?? sub.trialEnd
+                let dateString = sub.currentPeriodEnd ?? sub.trialEnd ?? sub.trialEndsAt
                 let expiresAt = parseISODate(dateString)
                 return ProductEntitlement(productId: sub.productId, priceId: sub.priceId, subscriptionExpiresAt: expiresAt)
             }

--- a/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
@@ -143,6 +143,13 @@ open class HeliumPaymentEntitlementsSource: ThirdPartyEntitlementsSource, @unche
     }
 
     private func performFetch() async {
+        guard Helium.identify.userId != nil
+                || Helium.identify.revenueCatAppUserId != nil
+                || provider.getCustomerId() != nil else {
+            // We can safely assume entitlements result will be empty if no stripe/paddle customer id and no id
+            // set by host app that may persist across app installs / device change.
+            return
+        }
         do {
             let body = try HeliumPaymentAPIClient.shared.baseRequestBody(provider: provider)
             let response: PaymentEntitlementResponse = try await HeliumPaymentAPIClient.shared.post(provider.checkEntitlementPath, body: body)

--- a/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
@@ -38,6 +38,7 @@ open class HeliumPaymentEntitlementsSource: ThirdPartyEntitlementsSource, @unche
     private(set) var isConfigured = false
     func configure() {
         guard !isConfigured else { return }
+        isConfigured = true
         loadPersistedData()
         Task { await fetchFromServer() }
     }

--- a/Sources/Helium/HeliumCore/StripeCheckout/PaymentProviderConfig.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/PaymentProviderConfig.swift
@@ -35,9 +35,8 @@ struct PaymentProviderConfig {
         displayName: "Paddle",
         providerSlug: "paddle",
         customerIdBodyKey: "paddleCustomerId",
-        // todo
-        getCustomerId: { nil },
-        setCustomerId: { _ in /* TODO */ },
+        getCustomerId: { HeliumIdentityManager.shared.getPaddleCustomerId() },
+        setCustomerId: { HeliumIdentityManager.shared.setPaddleCustomerId($0) },
         initialProductKey: "initialPaddleSelection",
         entitlementsPersistenceFileName: "helium_paddle_entitlements.json",
         getCheckoutSuccessURL: { Helium.config.checkoutSuccessURL },

--- a/Sources/Helium/HeliumCore/StripeCheckout/PaymentProviderConfig.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/PaymentProviderConfig.swift
@@ -8,6 +8,7 @@ struct PaymentProviderConfig {
     let customerIdBodyKey: String
     let getCustomerId: () -> String?
     let setCustomerId: (String) -> Void
+    let initialProductKey: String
     let entitlementsPersistenceFileName: String
     let getCheckoutSuccessURL: () -> String?
     let getCheckoutCancelURL: () -> String?
@@ -23,6 +24,7 @@ struct PaymentProviderConfig {
         customerIdBodyKey: "stripeCustomerId",
         getCustomerId: { HeliumIdentityManager.shared.getStripeCustomerId() },
         setCustomerId: { HeliumIdentityManager.shared.setStripeCustomerId($0) },
+        initialProductKey: "initialStripeSelection",
         entitlementsPersistenceFileName: "helium_stripe_entitlements.json",
         getCheckoutSuccessURL: { Helium.config.checkoutSuccessURL },
         getCheckoutCancelURL: { Helium.config.checkoutCancelURL },
@@ -36,6 +38,7 @@ struct PaymentProviderConfig {
         // todo
         getCustomerId: { nil },
         setCustomerId: { _ in /* TODO */ },
+        initialProductKey: "initialPaddleSelection",
         entitlementsPersistenceFileName: "helium_paddle_entitlements.json",
         getCheckoutSuccessURL: { Helium.config.checkoutSuccessURL },
         getCheckoutCancelURL: { Helium.config.checkoutCancelURL },

--- a/Sources/Helium/HeliumCore/StripeCheckout/WebCheckoutModels.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/WebCheckoutModels.swift
@@ -83,6 +83,11 @@ struct PaymentEntitlementResponse: Codable, Sendable {
     let customerId: String?
 }
 
+// Stripe and Paddle don't return identical shapes. Stripe emits `trialEnd`;
+// Paddle emits `trialStartsAt`/`trialEndsAt` and additional fields
+// (`startedAt`, `nextBilledAt`, `currentPeriodStart`, `canceledAt`,
+// `scheduledChange`) that we don't currently consume. Add them here if a
+// consumer ever needs them.
 struct PaymentSubscriptionInfo: Codable, Sendable {
     let subscriptionId: String
     let productId: String
@@ -93,6 +98,7 @@ struct PaymentSubscriptionInfo: Codable, Sendable {
     let currentPeriodEnd: String?
     let cancelAtPeriodEnd: Bool?
     let trialEnd: String?
+    let trialEndsAt: String?
 
     var isActive: Bool {
         ["active", "trialing"].contains(status)

--- a/Sources/Helium/HeliumCore/UserContext.swift
+++ b/Sources/Helium/HeliumCore/UserContext.swift
@@ -192,6 +192,7 @@ public struct CodableUserContext: Codable {
             "thirdPartyAnalyticsAnonymousId": HeliumIdentityManager.shared.getThirdPartyAnalyticsAnonymousId() ?? "",
             "rcUserId": HeliumIdentityManager.shared.revenueCatAppUserId ?? "",
             "stripeCustomerId": HeliumIdentityManager.shared.getStripeCustomerId() ?? "",
+            "paddleCustomerId": HeliumIdentityManager.shared.getPaddleCustomerId() ?? "",
             "organizationId": HeliumFetchedConfigManager.shared.getOrganizationID() ?? "unknown",
             "appTransactionId": HeliumIdentityManager.shared.appTransactionID ?? "",
             "locale": localeDict,

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -365,8 +365,7 @@ public class Helium {
             Helium.identify.userId = nil
         }
         HeliumEntitlementsManager.shared.paddleEntitlementsSource.clearEntitlements()
-        // todo clear paddle customer id
-//        HeliumIdentityManager.shared.setStripeCustomerId(nil)
+        HeliumIdentityManager.shared.setPaddleCustomerId(nil)
     }
     
 }
@@ -426,7 +425,7 @@ public class HeliumIdentify {
             if newValue != nil && userIdChanged {
                 HeliumAnalyticsManager.shared.identify()
                 
-                // Sync Stripe customer metadata if Stripe is configured
+                // Sync Stripe/Paddle customer metadata if web checkout is configured
                 if Helium.config.webCheckoutEnabled,
                    Helium.shared.isInitialized() {
                     Task {
@@ -434,6 +433,11 @@ public class HeliumIdentify {
                             await HeliumEntitlementsManager.shared.stripeEntitlementsSource.refreshEntitlements()
                         } else {
                             try? await StripeCheckoutManager.shared.updateCustomerMetadata()
+                        }
+                        if HeliumIdentityManager.shared.getPaddleCustomerId() == nil {
+                            await HeliumEntitlementsManager.shared.paddleEntitlementsSource.refreshEntitlements()
+                        } else {
+                            try? await PaddleCheckoutManager.shared.updateCustomerMetadata()
                         }
                     }
                 }

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -821,6 +821,12 @@ public class HeliumEntitlements {
         return !productIds.isEmpty
     }
     
+    /// Returns `true` if the user has any active Paddle entitlement.
+    public func hasActivePaddleEntitlement() async -> Bool {
+        let productIds = await HeliumEntitlementsManager.shared.paddleEntitlementsSource.purchasedHeliumProductIds()
+        return !productIds.isEmpty
+    }
+    
 }
 
 @available(iOS 15.0, *)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Expands external payment/entitlements logic to include Paddle and changes how external checkout is selected and observed, which can affect purchase completion and entitlement detection. Risk is moderate because it touches payment flows, identity persistence, and server price merging but is largely additive and provider-scoped.
> 
> **Overview**
> Adds **Paddle** as a first-class external web-checkout provider alongside Stripe, including server-provided `paddleProducts`/`paddleCustomerId` in fetched config and merging Paddle prices into the localized price map.
> 
> Updates purchase handling to route eligible products into either `StripeCheckoutManager` or the new `PaddleCheckoutManager`, unifies external-checkout observation/cleanup, and refactors `ExternalWebCheckoutManager` to be provider-driven (e.g., provider-specific initial product key and shared “detect new purchase” logic).
> 
> Persists and propagates Paddle customer IDs (`HeliumIdentityManager`, `UserContext`, config fetch), makes third-party entitlements sources configure based on provider configuration/known customer IDs, and adds a public `hasActivePaddleEntitlement()` plus `resetPaddleEntitlements` clearing the Paddle customer ID.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5dc2833126c5a2f57f09bbac980016b227bad2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Paddle as a second external payment provider with full web-checkout support.
  * Exposed separate provider-specific server price maps and a public way to query Paddle server prices.
  * Added a public check for active Paddle entitlements.

* **Refactor**
  * Unified external checkout flow to support multiple providers and merge server prices while preserving local StoreKit values.
  * Persist and propagate Paddle customer IDs for entitlements/sync.

* **Bug Fixes**
  * Skip entitlement fetch when no user/customer identity exists; adjust pending-purchase observation and cleanup for external flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->