### PR TITLE
SDK-22 fix for paywall traits not changing if values change (and user context...)

### DIFF
--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -236,6 +236,7 @@ struct DynamicWebView: View {
                 }
                 
                 _ = Date()
+                preparedWebView.configuration.userContentController.removeAllUserScripts()
                 preparedWebView.configuration.userContentController.addUserScript(combinedScript)
                 
                 // File loading timing


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Clearing all `WKUserScript`s on a reused `WKWebView` could unintentionally remove other injected scripts, potentially affecting paywall behavior if anything else relied on persistent scripts.
> 
> **Overview**
> Ensures pooled/reused paywall `WKWebView`s don’t accumulate or retain stale injected context by calling `removeAllUserScripts()` before adding the latest `combinedScript` in `DynamicWebView.loadWebView()`.
> 
> This fixes cases where updated runtime values (e.g., paywall traits/user context) wouldn’t take effect because an older script injection persisted across presentations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6353d85b0e459a92510395d5ea5277a94c1c3ac9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where web views could retain outdated scripts when reused, potentially causing conflicts with newly loaded content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->