### PR TITLE
HEL-5189 Improved paywall-not-shown feedback especially if no workflows yet

### DIFF
--- a/Sources/Helium/HeliumCore/HeliumFallbackViewManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumFallbackViewManager.swift
@@ -22,8 +22,7 @@ public class HeliumFallbackViewManager {
     private var loadedConfig: HeliumFetchedConfig?
     private var loadedConfigJSON: JSON?
     
-    // **MARK: - Public Methods**
-    public func setUpFallbackBundle() {
+    func setUpFallbackBundle() {
         var fallbackBundleURL: URL? = Bundle.main.url(forResource: defaultFallbacksName, withExtension: "json")
         if let customURL = Helium.config.customFallbacksURL {
             // This is synchronous but very fast (typically < 1 ms).

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -934,10 +934,6 @@ public class HeliumFetchedConfigManager {
         return fetchedConfig
     }
     
-    func hasBundles() -> Bool {
-        return fetchedConfig?.bundles?.count ?? 0 > 0
-    }
-    
     public func getConfigId() -> UUID? {
         return fetchedConfig?.fetchedConfigID
     }

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -322,6 +322,8 @@ class HeliumPaywallDelegateWrapper {
             notShownAddendum = "Paywall html could not be read. Ensure the paywall is not corrupted and contact Helium if this continues to be an issue."
         case .bundleFetchInvalidUrl, .bundleFetchInvalidUrlDetected, .bundleFetch403, .bundleFetch404, .bundleFetch410:
             notShownAddendum = "Could not retrieve paywall. Contact Helium if this continues to be an issue."
+        case .couldNotFindBundleUrl:
+            notShownAddendum = "Could not extract paywall url. Contact Helium if this continues to be an issue."
         default:
             notShownAddendum = paywallUnavailableReason?.rawValue ?? ""
         }

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -300,7 +300,7 @@ class HeliumPaywallDelegateWrapper {
         case .notInitialized:
             notShownAddendum = "Helium is not initialized"
         case .triggerHasNoPaywall:
-            notShownAddendum = "Could not find paywall for trigger \"\(trigger)\". Verify your trigger is in a workflow https://app.tryhelium.com/workflows"
+            notShownAddendum = "Could not find paywall for trigger \"\(trigger)\". Verify your trigger is in a workflow. Note that changes to a workflow may take a few minutes to be reflected here. https://app.tryhelium.com/workflows"
         case .paywallsNotDownloaded, .configFetchInProgress, .bundlesFetchInProgress, .productsFetchInProgress:
             notShownAddendum = "Paywalls have not completed downloading. Check your connection and consider adjusting loading budget or initializing Helium sooner before presenting paywall"
         case .paywallsDownloadFail:
@@ -314,10 +314,14 @@ class HeliumPaywallDelegateWrapper {
                 paywallLink += "/\(paywallId)"
             }
             notShownAddendum = "Your paywall does not include any iOS products. Ensure you have synced your iOS products and selected products for your paywall \(paywallLink)"
-        case .stripeNoCustomUserId:
-            notShownAddendum = "Stripe purchase flows require a custom user ID to be set"
-        case .stripeCheckoutNotEnabled:
-            notShownAddendum = "Stripe Checkout Flow requires success/cancel URLs to be set. See Helium.config.enableStripeCheckout"
+        case .webCheckoutNoCustomUserId:
+            notShownAddendum = "External Web Checkout requires a custom user ID to be set"
+        case .webCheckoutNotEnabled:
+            notShownAddendum = "External Web Checkout requires success/cancel URLs to be set. See Helium.config.enableStripeCheckout"
+        case .bundleFetchCannotDecodeContent:
+            notShownAddendum = "Paywall html could not be read. Ensure the paywall is not corrupted and contact Helium if this continues to be an issue."
+        case .bundleFetchInvalidUrl, .bundleFetchInvalidUrlDetected, .bundleFetch403, .bundleFetch404, .bundleFetch410:
+            notShownAddendum = "Could not retrieve paywall. Contact Helium if this continues to be an issue."
         default:
             notShownAddendum = paywallUnavailableReason?.rawValue ?? ""
         }

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -317,7 +317,7 @@ class HeliumPaywallDelegateWrapper {
         case .webCheckoutNoCustomUserId:
             notShownAddendum = "External Web Checkout requires a custom user ID to be set"
         case .webCheckoutNotEnabled:
-            notShownAddendum = "External Web Checkout requires success/cancel URLs to be set. See Helium.config.enableStripeCheckout"
+            notShownAddendum = "External Web Checkout requires success/cancel URLs to be set. See Helium.config.enableExternalWebCheckout"
         case .bundleFetchCannotDecodeContent:
             notShownAddendum = "Paywall html could not be read. Ensure the paywall is not corrupted and contact Helium if this continues to be an issue."
         case .bundleFetchInvalidUrl, .bundleFetchInvalidUrlDetected, .bundleFetch403, .bundleFetch404, .bundleFetch410:

--- a/Sources/Helium/HeliumCore/Models.swift
+++ b/Sources/Helium/HeliumCore/Models.swift
@@ -772,7 +772,6 @@ public enum PaywallUnavailableReason: String, Codable {
     case configFetchInProgress
     case bundlesFetchInProgress
     case productsFetchInProgress
-    case paywallBundlesMissing
     case paywallsDownloadFail
     case secondTryNoMatch
     case alreadyPresented
@@ -787,8 +786,8 @@ public enum PaywallUnavailableReason: String, Codable {
     case bundleFetch410
     case bundleFetchCannotDecodeContent
     case noProductsIOS
-    case stripeNoCustomUserId
-    case stripeCheckoutNotEnabled
+    case webCheckoutNoCustomUserId
+    case webCheckoutNotEnabled
 }
 
 /// Reason a paywall was not shown.

--- a/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
+++ b/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
@@ -598,6 +598,7 @@ extension HeliumPaywallPresenter {
                     fallbackReason = .productsFetchInProgress
                 }
             case .downloadSuccess:
+                // Not reachable with current code paths, but include so all switch cases are accounted for.
                 fallbackReason = .triggerHasNoPaywall
             case .downloadFailure:
                 fallbackReason = .paywallsDownloadFail

--- a/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
+++ b/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
@@ -529,12 +529,13 @@ extension HeliumPaywallPresenter {
     func upsellViewResultFor(trigger: String, presentationContext: PaywallPresentationContext) -> PaywallViewResult {
         HeliumLogger.log(.debug, category: .ui, "upsellViewResultFor called", metadata: ["trigger": trigger])
         if !Helium.shared.isInitialized() {
+            // Note - no fallback paywall here since fallbacks not initialized yet either
             HeliumLogger.log(.warn, category: .core, "Helium not initialized when presenting paywall")
             return PaywallViewResult(viewAndSession: nil, fallbackReason: .notInitialized)
         }
         
         let paywallInfo = HeliumFetchedConfigManager.shared.getPaywallInfoForTrigger(trigger)
-        if Helium.shared.paywallsLoaded() && HeliumFetchedConfigManager.shared.hasBundles() {
+        if Helium.shared.paywallsLoaded() {
             guard let templatePaywallInfo = paywallInfo else {
                 return fallbackViewFor(trigger: trigger, paywallInfo: nil, fallbackReason: .triggerHasNoPaywall, presentationContext: presentationContext)
             }
@@ -554,10 +555,10 @@ extension HeliumPaywallPresenter {
             let hasStripeProducts = !(templatePaywallInfo.productsOfferedStripe ?? []).isEmpty
             let hasAppToWebProducts = hasPaddleProducts || hasStripeProducts
             if hasAppToWebProducts && !HeliumIdentityManager.shared.hasCustomUserId() {
-                return fallbackViewFor(trigger: trigger, paywallInfo: templatePaywallInfo, fallbackReason: .stripeNoCustomUserId, presentationContext: presentationContext)
+                return fallbackViewFor(trigger: trigger, paywallInfo: templatePaywallInfo, fallbackReason: .webCheckoutNoCustomUserId, presentationContext: presentationContext)
             }
             if hasAppToWebProducts && !Helium.config.webCheckoutEnabled {
-                return fallbackViewFor(trigger: trigger, paywallInfo: templatePaywallInfo, fallbackReason: .stripeCheckoutNotEnabled, presentationContext: presentationContext)
+                return fallbackViewFor(trigger: trigger, paywallInfo: templatePaywallInfo, fallbackReason: .webCheckoutNotEnabled, presentationContext: presentationContext)
             }
             
             do {
@@ -597,7 +598,7 @@ extension HeliumPaywallPresenter {
                     fallbackReason = .productsFetchInProgress
                 }
             case .downloadSuccess:
-                fallbackReason = .paywallBundlesMissing
+                fallbackReason = .triggerHasNoPaywall
             case .downloadFailure:
                 fallbackReason = .paywallsDownloadFail
             }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Behavior changes are limited to paywall gating and logging/fallback reasons; low risk but could affect when fallback paywalls are shown and the diagnostics users see.
> 
> **Overview**
> Improves *paywall-not-shown* diagnostics by expanding `PaywallUnavailableReason` handling and making error messages more actionable (e.g., clarifying workflow propagation delays and differentiating bundle fetch failures).
> 
> Renames Stripe-specific unavailability reasons to external web checkout (`webCheckoutNoCustomUserId`, `webCheckoutNotEnabled`) and updates `HeliumPaywallPresenter` gating to rely on `paywallsLoaded()` without additionally requiring bundles, removing the unused `hasBundles()`/`paywallBundlesMissing` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3a721ba9f67028a6f0b1daf91323d79c4154714. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for paywall unavailability with clearer guidance that workflow changes may take a few minutes to reflect.
  * Updated checkout terminology and error handling for more accurate paywall retrieval failure messages.
  * Refined paywall presentation logic to better handle missing or misconfigured paywalls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->