### PR TITLE
Hel 5191 paddle customer portal

### DIFF
--- a/HeliumExample/HeliumExample/ContentView.swift
+++ b/HeliumExample/HeliumExample/ContentView.swift
@@ -16,6 +16,7 @@ struct ContentView: View {
     @State private var showEntitlementAlert: Bool = false
     @State private var entitlementInfo: String = ""
     @State private var trigger: String = AppConfig.triggerKey
+    @State private var userId: String = Helium.identify.userId ?? "nil"
 
     var body: some View {
         VStack(spacing: 20) {

--- a/HeliumExample/HeliumExample/ContentView.swift
+++ b/HeliumExample/HeliumExample/ContentView.swift
@@ -18,7 +18,7 @@ struct ContentView: View {
     @State private var trigger: String = AppConfig.triggerKey
 
     var body: some View {
-        VStack(spacing: 28) {
+        VStack(spacing: 20) {
             VStack(alignment: .leading, spacing: 4) {
                 Text("Trigger").font(.caption).foregroundStyle(.secondary)
                 TextField("Trigger key", text: $trigger)
@@ -27,6 +27,15 @@ struct ContentView: View {
                 Spacer().frame(height: 10)
                 
                 Toggle("dontShowIfAlreadyEntitled", isOn: $dontShowIfAlreadyEntitled)
+
+                Spacer().frame(height: 10)
+
+                Text("User ID").font(.caption).foregroundStyle(.secondary)
+                Text(userId)
+                    .font(.footnote)
+                    .textSelection(.enabled)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 30)
@@ -73,8 +82,12 @@ struct ContentView: View {
             }
             .accessibilityIdentifier("presentFallbackInvalidTrigger")
             
+            Spacer().frame(height: 20)
+            
             Button("set random user id") {
-                Helium.identify.userId = UUID().uuidString
+                let newId = UUID().uuidString
+                Helium.identify.userId = newId
+                userId = newId
             }
 
             Button("check entitlement") {

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -289,9 +289,11 @@ public class ExternalWebCheckoutManager: NSObject {
     }
 
     /// Creates a Customer Portal session and returns the portal URL.
-    func createPortalSession(returnUrl: String) async throws -> URL {
+    func createPortalSession(returnUrl: String? = nil) async throws -> URL {
         var body = try HeliumPaymentAPIClient.shared.baseRequestBody(provider: provider)
-        body["returnUrl"] = returnUrl
+        if let returnUrl {
+            body["returnUrl"] = returnUrl
+        }
 
         let response: PortalSessionResponse = try await HeliumPaymentAPIClient.shared.post(provider.createPortalSessionPath, body: body)
         guard let portalUrl = response.portalUrl, let url = URL(string: portalUrl) else {

--- a/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentAPIClient.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentAPIClient.swift
@@ -39,12 +39,20 @@ public class HeliumPaymentAPIClient {
         }
         var body: [String: Any] = [
             "apiKey": apiKey,
-            "userId": Helium.identify.userId ?? HeliumIdentityManager.shared.getHeliumPersistentId(),
-            "rcUserId": Helium.identify.revenueCatAppUserId ?? "",
-            provider.customerIdBodyKey: provider.getCustomerId() ?? "",
-            "heliumPersistentId": HeliumIdentityManager.shared.getHeliumPersistentId(),
-            "appTransactionId": HeliumIdentityManager.shared.getAppTransactionID() ?? ""
+            "heliumPersistentId": HeliumIdentityManager.shared.getHeliumPersistentId()
         ]
+        if let userId = Helium.identify.userId {
+            body["userId"] = userId
+        }
+        if let rcUserId = Helium.identify.revenueCatAppUserId {
+            body["rcUserId"] = rcUserId
+        }
+        if let appTransactionId = HeliumIdentityManager.shared.getAppTransactionID() {
+            body["appTransactionId"] = appTransactionId
+        }
+        if let customerId = provider.getCustomerId(), !customerId.isEmpty {
+            body[provider.customerIdBodyKey] = customerId
+        }
         if let productId {
             body["productPriceId"] = productId
         }

--- a/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
@@ -126,13 +126,6 @@ open class HeliumPaymentEntitlementsSource: ThirdPartyEntitlementsSource, @unche
     }
 
     private func fetchFromServer(forceNew: Bool = false) async {
-        guard Helium.identify.userId != nil
-                || Helium.identify.revenueCatAppUserId != nil
-                || provider.getCustomerId() != nil else {
-            // We can safely assume entitlements result will be empty if no stripe/paddle customer id and no id
-            // set by host app that may persist across app installs / device change.
-            return
-        }
         let (task, myId): (Task<Void, Never>, UInt) = lock.withLock {
             if !forceNew, let existing = currentFetchTask {
                 return (existing, fetchId)

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -346,12 +346,10 @@ public class Helium {
         return try await StripeCheckoutManager.shared.createPortalSession(returnUrl: returnUrl)
     }
     
-    /// Resets Stripe entitlements and optionally clears the user ID.
+    /// Resets Stripe entitlements and clears the user ID.
     /// If your app can support multiple Stripe users on the same device, you'll want to call this to effectively "log out" a Stripe user.
-    public func resetStripeEntitlements(clearUserId: Bool) {
-        if clearUserId {
-            Helium.identify.userId = nil
-        }
+    public func resetStripeEntitlements() {
+        Helium.identify.userId = nil
         HeliumEntitlementsManager.shared.stripeEntitlementsSource.clearEntitlements()
         HeliumIdentityManager.shared.setStripeCustomerId(nil)
     }
@@ -367,12 +365,10 @@ public class Helium {
         return try await PaddleCheckoutManager.shared.createPortalSession()
     }
     
-    /// Resets Paddle entitlements and optionally clears the user ID.
+    /// Resets Paddle entitlements and clears the user ID.
     /// If your app can support multiple Paddle users on the same device, you'll want to call this to effectively "log out" a Paddle user.
-    public func resetPaddleEntitlements(clearUserId: Bool) {
-        if clearUserId {
-            Helium.identify.userId = nil
-        }
+    public func resetPaddleEntitlements() {
+        Helium.identify.userId = nil
         HeliumEntitlementsManager.shared.paddleEntitlementsSource.clearEntitlements()
         HeliumIdentityManager.shared.setPaddleCustomerId(nil)
     }

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -357,6 +357,15 @@ public class Helium {
     }
     
     // MARK: - Paddle Checkout
+
+    /// Creates a Paddle Customer Portal session for the current user and returns the portal URL.
+    /// The host app can open this URL in a browser or in-app webview to let
+    /// the user manage their subscriptions.
+    ///
+    /// - Returns: The portal session URL.
+    public func createPaddlePortalSession() async throws -> URL {
+        return try await PaddleCheckoutManager.shared.createPortalSession()
+    }
     
     /// Resets Paddle entitlements and optionally clears the user ID.
     /// If your app can support multiple Paddle users on the same device, you'll want to call this to effectively "log out" a Paddle user.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches payment/entitlements request construction and portal-session creation for Stripe/Paddle, which can affect backend compatibility and subscription management flows. Changes are localized but involve user identity propagation and logout/reset behavior.
> 
> **Overview**
> Adds a public `createPaddlePortalSession()` API and aligns portal-session creation so `returnUrl` is optional at the checkout-manager level.
> 
> Tightens payment API request bodies to only include identity/customer fields when present (no more empty-string defaults), and removes the early-return guard that skipped server entitlement refreshes when no IDs were set.
> 
> Simplifies `resetStripeEntitlements`/`resetPaddleEntitlements` to always clear `Helium.identify.userId`, and updates the example app UI to display the current user ID and keep it in sync when randomized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0c5f2bc39de2f828054a05158b70dbdf9dac659. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Paddle portal session creation functionality for managing subscriptions.
  * Introduced User ID display section in the app interface with improved layout spacing.

* **Improvements**
  * Made return URL parameter optional for checkout session configuration.
  * Simplified entitlements reset methods by removing the clearUserId parameter; user IDs are now unconditionally cleared on reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->