### PR TITLE
Hel 5135 rc paddle entitlements

### DIFF
--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -74,11 +74,17 @@ class HeliumPaywallDelegateWrapper {
 
         let allPaddleProductIds = Array((HeliumFetchedConfigManager.shared.getPaddleProductsPriceMap() ?? [:]).keys)
 
-        var paymentProcessor: HeliumPaymentProcessor = .appStore
-
-        if !stripeApplePayFlowEnabled && allStripeProductIds.contains(productKey) {
-            isExternalCheckoutFlow = true
+        let paymentProcessor: HeliumPaymentProcessor
+        if allStripeProductIds.contains(productKey) {
             paymentProcessor = .stripe
+        } else if allPaddleProductIds.contains(productKey) {
+            paymentProcessor = .paddle
+        } else {
+            paymentProcessor = .appStore
+        }
+        
+        if paymentProcessor == .stripe && !stripeApplePayFlowEnabled {
+            isExternalCheckoutFlow = true
             do {
                 try await StripeCheckoutManager.shared.startCheckoutFlow(
                     for: productKey,
@@ -89,9 +95,8 @@ class HeliumPaywallDelegateWrapper {
             } catch {
                 transactionStatus = .failed(error)
             }
-        } else if allPaddleProductIds.contains(productKey) {
+        } else if paymentProcessor == .paddle {
             isExternalCheckoutFlow = true
-            paymentProcessor = .paddle
             do {
                 try await PaddleCheckoutManager.shared.startCheckoutFlow(
                     for: productKey,
@@ -103,9 +108,6 @@ class HeliumPaywallDelegateWrapper {
                 transactionStatus = .failed(error)
             }
         } else {
-            if stripeApplePayFlowEnabled && allStripeProductIds.contains(productKey) {
-                paymentProcessor = .stripe
-            }
             transactionStatus = await delegate.makePurchase(productId: productKey)
         }
         

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -67,8 +67,7 @@ class HeliumPaywallDelegateWrapper {
         StoreKit1Listener.ensureListening()
         
         let transactionStatus: HeliumPaywallTransactionStatus
-        
-        var isExternalCheckoutFlow: Bool = false
+
         let allStripeProductIds = Array((HeliumFetchedConfigManager.shared.getStripeProductsPriceMap() ?? [:]).keys)
         let stripeApplePayFlowEnabled = ApplePayHelper.shared.getStripeApplePayAvailable()
 
@@ -82,9 +81,8 @@ class HeliumPaywallDelegateWrapper {
         } else {
             paymentProcessor = .appStore
         }
-        
+
         if paymentProcessor == .stripe && !stripeApplePayFlowEnabled {
-            isExternalCheckoutFlow = true
             do {
                 try await StripeCheckoutManager.shared.startCheckoutFlow(
                     for: productKey,
@@ -96,7 +94,6 @@ class HeliumPaywallDelegateWrapper {
                 transactionStatus = .failed(error)
             }
         } else if paymentProcessor == .paddle {
-            isExternalCheckoutFlow = true
             do {
                 try await PaddleCheckoutManager.shared.startCheckoutFlow(
                     for: productKey,
@@ -158,7 +155,9 @@ class HeliumPaywallDelegateWrapper {
             }
         case .pending:
             self.fireEvent(PurchasePendingEvent(productId: productKey, triggerName: triggerName, paywallName: paywallTemplateName), paywallSession: paywallSession)
-            if !isExternalCheckoutFlow {
+            // Add a listener for pending appStore purchases.
+            // Other processors have their own mechanisms for handling pending purchases.
+            if paymentProcessor == .appStore {
                 let detachedSession = paywallSession.withPresentationContext(.empty)
                 observePendingPurchase(productId: productKey, triggerName: triggerName, paywallTemplateName: paywallTemplateName, paywallSession: detachedSession)
             }

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -70,12 +70,15 @@ class HeliumPaywallDelegateWrapper {
         
         var isExternalCheckoutFlow: Bool = false
         let allStripeProductIds = Array((HeliumFetchedConfigManager.shared.getStripeProductsPriceMap() ?? [:]).keys)
-        let stripeApplePayFlow = ApplePayHelper.shared.getStripeApplePayAvailable()
-        
+        let stripeApplePayFlowEnabled = ApplePayHelper.shared.getStripeApplePayAvailable()
+
         let allPaddleProductIds = Array((HeliumFetchedConfigManager.shared.getPaddleProductsPriceMap() ?? [:]).keys)
-        
-        if !stripeApplePayFlow && allStripeProductIds.contains(productKey) {
+
+        var paymentProcessor: HeliumPaymentProcessor = .appStore
+
+        if !stripeApplePayFlowEnabled && allStripeProductIds.contains(productKey) {
             isExternalCheckoutFlow = true
+            paymentProcessor = .stripe
             do {
                 try await StripeCheckoutManager.shared.startCheckoutFlow(
                     for: productKey,
@@ -88,6 +91,7 @@ class HeliumPaywallDelegateWrapper {
             }
         } else if allPaddleProductIds.contains(productKey) {
             isExternalCheckoutFlow = true
+            paymentProcessor = .paddle
             do {
                 try await PaddleCheckoutManager.shared.startCheckoutFlow(
                     for: productKey,
@@ -99,6 +103,9 @@ class HeliumPaywallDelegateWrapper {
                 transactionStatus = .failed(error)
             }
         } else {
+            if stripeApplePayFlowEnabled && allStripeProductIds.contains(productKey) {
+                paymentProcessor = .stripe
+            }
             transactionStatus = await delegate.makePurchase(productId: productKey)
         }
         
@@ -136,7 +143,16 @@ class HeliumPaywallDelegateWrapper {
                 #endif
                 
                 let skPostPurchaseTxnTimeMS = dispatchTimeDifferenceInMS(from: transactionRetrievalStartTime)
-                fireEvent(PurchaseSucceededEvent(productId: productKey, triggerName: triggerName, paywallName: paywallTemplateName, storeKitTransactionId: transactionIds?.transactionId, storeKitOriginalTransactionId: transactionIds?.originalTransactionId, skPostPurchaseTxnTimeMS: skPostPurchaseTxnTimeMS), paywallSession: paywallSession)
+                let purchaseSucceededEvent = PurchaseSucceededEvent(
+                    productId: productKey,
+                    triggerName: triggerName,
+                    paywallName: paywallTemplateName,
+                    storeKitTransactionId: transactionIds?.transactionId,
+                    storeKitOriginalTransactionId: transactionIds?.originalTransactionId,
+                    skPostPurchaseTxnTimeMS: skPostPurchaseTxnTimeMS,
+                    paymentProcessor: paymentProcessor
+                )
+                fireEvent(purchaseSucceededEvent, paywallSession: paywallSession)
             }
         case .pending:
             self.fireEvent(PurchasePendingEvent(productId: productKey, triggerName: triggerName, paywallName: paywallTemplateName), paywallSession: paywallSession)

--- a/Sources/Helium/HeliumCore/PaywallEvents.swift
+++ b/Sources/Helium/HeliumCore/PaywallEvents.swift
@@ -533,6 +533,13 @@ public struct PurchasePressedEvent: ProductEvent {
     }
 }
 
+/// Identifies which payment processor completed a purchase.
+public enum HeliumPaymentProcessor: String, Codable, Sendable {
+    case appStore
+    case stripe
+    case paddle
+}
+
 /// Event fired when a purchase completes successfully
 /// - Note: Event fired when StoreKit returns .purchased status from makePurchase() delegate method. Transaction has been verified and finished by StoreKit.
 public struct PurchaseSucceededEvent: ProductEvent {
@@ -556,23 +563,27 @@ public struct PurchaseSucceededEvent: ProductEvent {
     
     /// Time taken to retrieve StoreKit transaction IDs after purchase successs in milliseconds
     public let skPostPurchaseTxnTimeMS: UInt64?
-    
+
+    /// Which payment processor completed this purchase.
+    public let paymentProcessor: HeliumPaymentProcessor
+
     /// When this event occurred
     /// - Note: Captured using Date() at event creation time
     public let timestamp: Date
-    
-    public init(productId: String, triggerName: String, paywallName: String, storeKitTransactionId: String?, storeKitOriginalTransactionId: String?, skPostPurchaseTxnTimeMS: UInt64? = nil, timestamp: Date = Date()) {
+
+    public init(productId: String, triggerName: String, paywallName: String, storeKitTransactionId: String?, storeKitOriginalTransactionId: String?, skPostPurchaseTxnTimeMS: UInt64? = nil, paymentProcessor: HeliumPaymentProcessor = .appStore, timestamp: Date = Date()) {
         self.productId = productId
         self.triggerName = triggerName
         self.paywallName = paywallName
         self.storeKitTransactionId = storeKitTransactionId
         self.storeKitOriginalTransactionId = storeKitOriginalTransactionId
         self.skPostPurchaseTxnTimeMS = skPostPurchaseTxnTimeMS
+        self.paymentProcessor = paymentProcessor
         self.timestamp = timestamp
     }
-    
+
     public var eventName: String { "purchaseSucceeded" }
-    
+
     public func toDictionary() -> [String: Any] {
         var dict: [String: Any] = [
             "type": eventName,
@@ -580,6 +591,7 @@ public struct PurchaseSucceededEvent: ProductEvent {
             "triggerName": triggerName,
             "paywallName": paywallName,
             "isSecondTry": isSecondTry,
+            "paymentProvider": paymentProcessor.rawValue,
             "timestamp": timestamp.timeIntervalSince1970
         ]
         if let storeKitTransactionId {

--- a/Sources/Helium/HeliumCore/PaywallEvents.swift
+++ b/Sources/Helium/HeliumCore/PaywallEvents.swift
@@ -540,8 +540,8 @@ public enum HeliumPaymentProcessor: String, Codable, Sendable {
     case paddle
 }
 
-/// Event fired when a purchase completes successfully
-/// - Note: Event fired when StoreKit returns .purchased status from makePurchase() delegate method. Transaction has been verified and finished by StoreKit.
+/// Event fired when a purchase completes successfully.
+/// See `paymentProcessor` to identify which payment processor completed the purchase.
 public struct PurchaseSucceededEvent: ProductEvent {
     /// The product identifier that was successfully purchased
     /// - Note: StoreKit product ID from App Store Connect
@@ -591,7 +591,7 @@ public struct PurchaseSucceededEvent: ProductEvent {
             "triggerName": triggerName,
             "paywallName": paywallName,
             "isSecondTry": isSecondTry,
-            "paymentProvider": paymentProcessor.rawValue,
+            "paymentProcessor": paymentProcessor.rawValue,
             "timestamp": timestamp.timeIntervalSince1970
         ]
         if let storeKitTransactionId {

--- a/Sources/Helium/HeliumCore/PaywallEvents.swift
+++ b/Sources/Helium/HeliumCore/PaywallEvents.swift
@@ -449,7 +449,7 @@ public struct CustomPaywallActionEvent: PaywallContextEvent {
 /// - Note: Event fired when selectProduct() is called from JavaScript 'select-product' message. Occurs when user taps on a product option in the paywall UI to select it.
 public struct ProductSelectedEvent: ProductEvent {
     /// The product identifier that was selected
-    /// - Note: StoreKit product ID from App Store Connect (e.g., "com.app.premium.monthly")
+    /// - Note: StoreKit product ID from App Store Connect, pro\_id:pri\_id from Paddle, prod\_id:price\_id from Stripe
     public let productId: String
     
     /// The trigger identifier for the paywall where selection occurred
@@ -493,7 +493,7 @@ public struct ProductSelectedEvent: ProductEvent {
 /// - Note: Event fired immediately when makePurchase() is called, before StoreKit transaction begins. Always followed by exactly one of: PurchaseSucceeded, PurchaseFailed, PurchaseCancelled, or PurchasePending.
 public struct PurchasePressedEvent: ProductEvent {
     /// The product identifier being purchased
-    /// - Note: StoreKit product ID from App Store Connect
+    /// - Note: StoreKit product ID from App Store Connect, pro\_id:pri\_id from Paddle, prod\_id:price\_id from Stripe
     public let productId: String
     
     /// The trigger identifier for the paywall where purchase was initiated
@@ -543,8 +543,8 @@ public enum HeliumPaymentProcessor: String, Codable, Sendable {
 /// Event fired when a purchase completes successfully.
 /// See `paymentProcessor` to identify which payment processor completed the purchase.
 public struct PurchaseSucceededEvent: ProductEvent {
-    /// The product identifier that was successfully purchased
-    /// - Note: StoreKit product ID from App Store Connect
+    /// The Helium product identifier that was successfully purchased
+    /// - Note: StoreKit product ID from App Store Connect, pro\_id:pri\_id from Paddle, prod\_id:price\_id from Stripe
     public let productId: String
     
     /// The trigger identifier for the paywall where purchase succeeded
@@ -616,7 +616,7 @@ public struct PurchaseSucceededEvent: ProductEvent {
 /// - Note: User explicitly cancelled in StoreKit payment sheet
 public struct PurchaseCancelledEvent: ProductEvent {
     /// The product identifier that user was attempting to purchase
-    /// - Note: StoreKit product ID from App Store Connect
+    /// - Note: StoreKit product ID from App Store Connect, pro\_id:pri\_id from Paddle, prod\_id:price\_id from Stripe
     public let productId: String
     
     /// The trigger identifier for the paywall where purchase was cancelled
@@ -660,7 +660,7 @@ public struct PurchaseCancelledEvent: ProductEvent {
 /// - Note: Event fired when StoreKit returns .failed status from makePurchase() delegate method. Contains the actual Error object from StoreKit for debugging.
 public struct PurchaseFailedEvent: ProductEvent {
     /// The product identifier that failed to purchase
-    /// - Note: StoreKit product ID from App Store Connect
+    /// - Note: StoreKit product ID from App Store Connect, pro\_id:pri\_id from Paddle, prod\_id:price\_id from Stripe
     public let productId: String
     
     /// The trigger identifier for the paywall where purchase failed

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -64,7 +64,8 @@ public class ExternalWebCheckoutManager: NSObject {
             triggerName: triggerName,
             paywallName: paywallSession.paywallInfoWithBackups?.paywallTemplateName ?? "",
             storeKitTransactionId: nil,
-            storeKitOriginalTransactionId: nil
+            storeKitOriginalTransactionId: nil,
+            paymentProcessor: provider.purchaseEventPaymentProcessor
         )
         let loggedEvent = HeliumAnalyticsManager.shared.buildLoggedEvent(
             for: templateEvent,
@@ -242,7 +243,8 @@ public class ExternalWebCheckoutManager: NSObject {
                         triggerName: observation.paywallSession.trigger,
                         paywallName: observation.paywallSession.paywallInfoWithBackups?.paywallTemplateName ?? "",
                         storeKitTransactionId: nil,
-                        storeKitOriginalTransactionId: nil
+                        storeKitOriginalTransactionId: nil,
+                        paymentProcessor: provider.purchaseEventPaymentProcessor
                     ),
                     paywallSession: observation.paywallSession,
                     sendToAnalytics: false

--- a/Sources/Helium/HeliumCore/StripeCheckout/PaymentProviderConfig.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/PaymentProviderConfig.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Captures the provider-specific values that differ between Stripe, Paddle, etc.
 struct PaymentProviderConfig {
     let displayName: String
-    
+
     let providerSlug: String
     let customerIdBodyKey: String
     let getCustomerId: () -> String?
@@ -14,6 +14,7 @@ struct PaymentProviderConfig {
     let getCheckoutSuccessURL: () -> String?
     let getCheckoutCancelURL: () -> String?
     let getOfferedProducts: (HeliumPaywallInfo) -> [String]?
+    let purchaseEventPaymentProcessor: HeliumPaymentProcessor
 
     var checkEntitlementPath: String { "\(providerSlug)/check-entitlement" }
     var updateCustomerMetadataPath: String { "\(providerSlug)/update-customer-metadata" }
@@ -30,9 +31,10 @@ struct PaymentProviderConfig {
         entitlementsPersistenceFileName: "helium_stripe_entitlements.json",
         getCheckoutSuccessURL: { Helium.config.checkoutSuccessURL },
         getCheckoutCancelURL: { Helium.config.checkoutCancelURL },
-        getOfferedProducts: { $0.productsOfferedStripe }
+        getOfferedProducts: { $0.productsOfferedStripe },
+        purchaseEventPaymentProcessor: .stripe
     )
-    
+
     static let paddle = PaymentProviderConfig(
         displayName: "Paddle",
         providerSlug: "paddle",
@@ -44,6 +46,7 @@ struct PaymentProviderConfig {
         entitlementsPersistenceFileName: "helium_paddle_entitlements.json",
         getCheckoutSuccessURL: { Helium.config.checkoutSuccessURL },
         getCheckoutCancelURL: { Helium.config.checkoutCancelURL },
-        getOfferedProducts: { $0.productsOfferedPaddle }
+        getOfferedProducts: { $0.productsOfferedPaddle },
+        purchaseEventPaymentProcessor: .paddle
     )
 }

--- a/Sources/HeliumRevenueCat/HeliumRevenueCat.swift
+++ b/Sources/HeliumRevenueCat/HeliumRevenueCat.swift
@@ -24,14 +24,19 @@ open class RevenueCatDelegate: HeliumPaywallDelegate, HeliumDelegateReturnsTrans
     private var latestSuccessfulPurchaseOffering: Offering? = nil
     
     private let allowHeliumUserAttribute: Bool
-    
+
     private let stripePurchaseSyncDisabled: Bool
-    private let _stripeSyncLock = NSLock()
-    private var _isSyncingStripePurchase = false
-    private var _stripeSyncCompleted = false
+    private let paddlePurchaseSyncDisabled: Bool
+    private let _thirdPartyPaymentSyncLock = NSLock()
+    private var _isSyncingThirdPartyPayment = false
+    private var _thirdPartyPaymentSyncCompleted = false
     private var _hasInvalidatedCache = false
     
     private func configureRevenueCat(revenueCatApiKey: String) {
+        if Purchases.isConfigured {
+            print("[Helium] RevenueCat has already been configured. Skipping configuration.")
+            return
+        }
         Purchases.configure(withAPIKey: revenueCatApiKey, appUserID: HeliumIdentityManager.shared.getHeliumPersistentId())
     }
     
@@ -42,16 +47,19 @@ open class RevenueCatDelegate: HeliumPaywallDelegate, HeliumDelegateReturnsTrans
     /// - Parameter revenueCatApiKey: (Optional). Only set if you want Helium to handle RevenueCat initialization for you. Otherwise make sure to [initialize RevenueCat](https://www.revenuecat.com/docs/getting-started/quickstart#initialize-and-configure-the-sdk) before initializing Helium.
     /// - Parameter allowHeliumUserAttribute: (Optional) Allow Helium to set [customer attributes](https://www.revenuecat.com/docs/customers/customer-attributes)
     /// - Parameter stripePurchaseSyncDisabled: (Optional) Set to `true` to disable automatic RevenueCat customer info refresh after a Stripe purchase. Defaults to `false`.
+    /// - Parameter paddlePurchaseSyncDisabled: (Optional) Set to `true` to disable automatic RevenueCat customer info refresh after a Paddle purchase. Defaults to `false`.
     public init(
         entitlementId: String? = nil,
         productIds: [String]? = nil,
         revenueCatApiKey: String? = nil,
         allowHeliumUserAttribute: Bool = true,
-        stripePurchaseSyncDisabled: Bool = false
+        stripePurchaseSyncDisabled: Bool = false,
+        paddlePurchaseSyncDisabled: Bool = false
     ) {
         self.entitlementId = entitlementId
         self.allowHeliumUserAttribute = allowHeliumUserAttribute
         self.stripePurchaseSyncDisabled = stripePurchaseSyncDisabled
+        self.paddlePurchaseSyncDisabled = paddlePurchaseSyncDisabled
         
         if let revenueCatApiKey {
             configureRevenueCat(revenueCatApiKey: revenueCatApiKey)
@@ -180,44 +188,44 @@ open class RevenueCatDelegate: HeliumPaywallDelegate, HeliumDelegateReturnsTrans
     /// Subclasses that override this method should call `super.onPaywallEvent(event)`
     /// to preserve built-in post-purchase sync behavior.
     open func onPaywallEvent(_ event: HeliumEvent) {
-        if !stripePurchaseSyncDisabled,
-           let purchaseEvent = event as? PurchaseSucceededEvent,
-           isStripePurchase(event: purchaseEvent) {
-            Task { await syncRevenueCatAfterStripePurchase() }
+        if let purchaseEvent = event as? PurchaseSucceededEvent,
+           shouldSyncAfterThirdPartyPayment(event: purchaseEvent) {
+            Task { await syncRevenueCatAfterThirdPartyPayment() }
         }
     }
-    
-    // MARK: - Stripe Purchase Sync
-    
-    private func isStripePurchase(event: PurchaseSucceededEvent) -> Bool {
-        if let txnId = event.storeKitTransactionId, txnId.hasPrefix("si_") {
-            return true
+
+    // MARK: - Third-Party Payment Sync
+
+    private func shouldSyncAfterThirdPartyPayment(event: PurchaseSucceededEvent) -> Bool {
+        switch event.paymentProcessor {
+        case .stripe:
+            return !stripePurchaseSyncDisabled
+        case .paddle:
+            return !paddlePurchaseSyncDisabled
+        case .appStore:
+            return false
         }
-        let stripeProductPattern = #"^prod_\w+:price_\w+$"#
-        if event.productId.range(of: stripeProductPattern, options: .regularExpression) != nil {
-            return true
-        }
-        return false
     }
-    
-    /// After a Stripe purchase completes, the RevenueCat SDK on-device has no way to
-    /// know that a new entitlement exists until its backend processes the Stripe webhook.
-    /// This method polls RevenueCat with progressive backoff to force a customer info
-    /// refresh, stopping early if the update listener fires (~50s max).
-    private func syncRevenueCatAfterStripePurchase() async {
+
+    /// After a third-party payment (Stripe or Paddle) completes, the RevenueCat SDK
+    /// on-device has no way to know that a new entitlement exists until its backend
+    /// processes the provider webhook. This method polls RevenueCat with progressive
+    /// backoff to force a customer info refresh, stopping early if the update listener
+    /// fires (~50s max).
+    private func syncRevenueCatAfterThirdPartyPayment() async {
         // Atomic check-and-set to prevent concurrent syncs
-        let alreadySyncing: Bool = _stripeSyncLock.withLock {
-            if _isSyncingStripePurchase { return true }
-            _isSyncingStripePurchase = true
+        let alreadySyncing: Bool = _thirdPartyPaymentSyncLock.withLock {
+            if _isSyncingThirdPartyPayment { return true }
+            _isSyncingThirdPartyPayment = true
             return false
         }
         guard !alreadySyncing else { return }
         defer {
-            _stripeSyncLock.withLock { _isSyncingStripePurchase = false }
+            _thirdPartyPaymentSyncLock.withLock { _isSyncingThirdPartyPayment = false }
         }
 
-        _stripeSyncLock.withLock {
-            _stripeSyncCompleted = false
+        _thirdPartyPaymentSyncLock.withLock {
+            _thirdPartyPaymentSyncCompleted = false
             _hasInvalidatedCache = false
         }
 
@@ -228,9 +236,9 @@ open class RevenueCatDelegate: HeliumPaywallDelegate, HeliumDelegateReturnsTrans
         let listenerTask = Task { [weak self] in
             for await _ in Purchases.shared.customerInfoStream {
                 guard let self else { return }
-                let isRealUpdate = self._stripeSyncLock.withLock { self._hasInvalidatedCache }
+                let isRealUpdate = self._thirdPartyPaymentSyncLock.withLock { self._hasInvalidatedCache }
                 if isRealUpdate {
-                    self._stripeSyncLock.withLock { self._stripeSyncCompleted = true }
+                    self._thirdPartyPaymentSyncLock.withLock { self._thirdPartyPaymentSyncCompleted = true }
                     return
                 }
             }
@@ -243,17 +251,17 @@ open class RevenueCatDelegate: HeliumPaywallDelegate, HeliumDelegateReturnsTrans
         await pollPhase(attempts: 2, intervalMs: 15_000)
     }
 
-    private var stripeSyncCompleted: Bool {
-        _stripeSyncLock.withLock { _stripeSyncCompleted }
+    private var thirdPartyPaymentSyncCompleted: Bool {
+        _thirdPartyPaymentSyncLock.withLock { _thirdPartyPaymentSyncCompleted }
     }
 
     private func pollPhase(attempts: Int, intervalMs: UInt64) async {
         for _ in 0..<attempts {
-            if stripeSyncCompleted { return }
+            if thirdPartyPaymentSyncCompleted { return }
             try? await Task.sleep(nanoseconds: intervalMs * 1_000_000)
-            if stripeSyncCompleted { return }
+            if thirdPartyPaymentSyncCompleted { return }
             do {
-                _stripeSyncLock.withLock { _hasInvalidatedCache = true }
+                _thirdPartyPaymentSyncLock.withLock { _hasInvalidatedCache = true }
                 Purchases.shared.invalidateCustomerInfoCache()
                 _ = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
             } catch {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes purchase-event payloads (adds `paymentProcessor`) and alters post-purchase behavior by triggering RevenueCat refresh polling after third-party purchases, which could affect analytics compatibility and purchase state updates.
> 
> **Overview**
> Adds explicit payment-processor attribution across the SDK by introducing `HeliumPaymentProcessor` and attaching it to `PurchaseSucceededEvent` (also emitted to analytics as `paymentProcessor`).
> 
> Refactors purchase handling to derive the processor (App Store vs Stripe vs Paddle) and uses it to drive checkout routing and pending-purchase observation (only App Store pending purchases register a StoreKit listener). External web checkout events now report the correct processor via provider config.
> 
> Updates the RevenueCat delegate to support optional Paddle post-purchase syncing and unifies the existing Stripe sync into a single third-party refresh flow keyed off `PurchaseSucceededEvent.paymentProcessor`, with guards against duplicate RevenueCat configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 035d4f969d999e3df72ae03c3d37bb1ecf24a08f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Track and emit which payment processor (App Store / Stripe / Paddle) was used for purchases.
  * Optional control to enable/disable Paddle purchase sync to RevenueCat.

* **Refactor**
  * Unified checkout flow to select behavior based on detected payment processor.
  * Consolidated third‑party purchase sync logic for Stripe and Paddle.

* **Bug Fix**
  * Avoid reconfiguring RevenueCat if already configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->