### PR TITLE
add option to specify which payment providers are enabled

### DIFF
--- a/HeliumExample/HeliumExample/HeliumExampleApp.swift
+++ b/HeliumExample/HeliumExample/HeliumExampleApp.swift
@@ -17,6 +17,9 @@ struct HeliumExampleApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .onOpenURL { url in
+                    Helium.shared.handleURL(url)
+                }
         }
     }
     

--- a/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
@@ -176,10 +176,11 @@ actor HeliumEntitlementsManager {
         startTransactionListener()
         await loadEntitlementsIfNeeded()
 
-        if Helium.config.webCheckoutEnabled || HeliumIdentityManager.shared.getPaddleCustomerId() != nil {
+        let processors = Helium.config.webCheckoutProcessors
+        if processors.contains(.paddle) || HeliumIdentityManager.shared.getPaddleCustomerId() != nil {
             paddleEntitlementsSource.configure()
         }
-        if Helium.config.webCheckoutEnabled || HeliumIdentityManager.shared.getStripeCustomerId() != nil {
+        if processors.contains(.stripe) || HeliumIdentityManager.shared.getStripeCustomerId() != nil {
             stripeEntitlementsSource.configure()
         }
 

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -337,7 +337,7 @@ class HeliumPaywallDelegateWrapper {
         case .webCheckoutNoCustomUserId:
             notShownAddendum = "External Web Checkout requires a custom user ID to be set"
         case .webCheckoutNotEnabled:
-            notShownAddendum = "External Web Checkout is not enabled for a payment processor this paywall requires. See Helium.config.enableExternalWebCheckout. Enabled processors: \(Helium.config.webCheckoutProcessors))"
+            notShownAddendum = "External Web Checkout is not enabled for a payment processor this paywall requires. See Helium.config.enableExternalWebCheckout. Enabled processors: \(Helium.config.webCheckoutProcessors)"
         case .bundleFetchCannotDecodeContent:
             notShownAddendum = "Paywall html could not be read. Ensure the paywall is not corrupted and contact Helium if this continues to be an issue."
         case .bundleFetchInvalidUrl, .bundleFetchInvalidUrlDetected, .bundleFetch403, .bundleFetch404, .bundleFetch410:

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -168,16 +168,14 @@ class HeliumPaywallDelegateWrapper {
     func restorePurchases(triggerName: String, paywallTemplateName: String, paywallSession: PaywallSession) async -> Bool {
         var result = await delegate.restorePurchases()
         
-        if !result && Helium.config.webCheckoutEnabled {
-            let processors = Helium.config.webCheckoutProcessors
-            if processors.contains(.paddle) {
-                await HeliumEntitlementsManager.shared.paddleEntitlementsSource.refreshEntitlements()
-                result = await !HeliumEntitlementsManager.shared.paddleEntitlementsSource.purchasedHeliumProductIds().isEmpty
-            }
-            if !result && processors.contains(.stripe) {
-                await HeliumEntitlementsManager.shared.stripeEntitlementsSource.refreshEntitlements()
-                result = await !HeliumEntitlementsManager.shared.stripeEntitlementsSource.purchasedHeliumProductIds().isEmpty
-            }
+        let processors = Helium.config.webCheckoutProcessors
+        if !result && processors.contains(.paddle) {
+            await HeliumEntitlementsManager.shared.paddleEntitlementsSource.refreshEntitlements()
+            result = await !HeliumEntitlementsManager.shared.paddleEntitlementsSource.purchasedHeliumProductIds().isEmpty
+        }
+        if !result && processors.contains(.stripe) {
+            await HeliumEntitlementsManager.shared.stripeEntitlementsSource.refreshEntitlements()
+            result = await !HeliumEntitlementsManager.shared.stripeEntitlementsSource.purchasedHeliumProductIds().isEmpty
         }
         if result {
             self.fireEvent(PurchaseRestoredEvent(productId: "HELIUM_GENERIC_PRODUCT", triggerName: triggerName, paywallName: paywallTemplateName), paywallSession: paywallSession)

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -169,9 +169,12 @@ class HeliumPaywallDelegateWrapper {
         var result = await delegate.restorePurchases()
         
         if !result && Helium.config.webCheckoutEnabled {
-            await HeliumEntitlementsManager.shared.paddleEntitlementsSource.refreshEntitlements()
-            result = await !HeliumEntitlementsManager.shared.paddleEntitlementsSource.purchasedHeliumProductIds().isEmpty
-            if !result {
+            let processors = Helium.config.webCheckoutProcessors
+            if processors.contains(.paddle) {
+                await HeliumEntitlementsManager.shared.paddleEntitlementsSource.refreshEntitlements()
+                result = await !HeliumEntitlementsManager.shared.paddleEntitlementsSource.purchasedHeliumProductIds().isEmpty
+            }
+            if !result && processors.contains(.stripe) {
                 await HeliumEntitlementsManager.shared.stripeEntitlementsSource.refreshEntitlements()
                 result = await !HeliumEntitlementsManager.shared.stripeEntitlementsSource.purchasedHeliumProductIds().isEmpty
             }
@@ -334,7 +337,7 @@ class HeliumPaywallDelegateWrapper {
         case .webCheckoutNoCustomUserId:
             notShownAddendum = "External Web Checkout requires a custom user ID to be set"
         case .webCheckoutNotEnabled:
-            notShownAddendum = "External Web Checkout requires success/cancel URLs to be set. See Helium.config.enableExternalWebCheckout"
+            notShownAddendum = "External Web Checkout is not enabled for a payment processor this paywall requires. See Helium.config.enableExternalWebCheckout. Enabled processors: \(Helium.config.webCheckoutProcessors))"
         case .bundleFetchCannotDecodeContent:
             notShownAddendum = "Paywall html could not be read. Ensure the paywall is not corrupted and contact Helium if this continues to be an issue."
         case .bundleFetchInvalidUrl, .bundleFetchInvalidUrlDetected, .bundleFetch403, .bundleFetch404, .bundleFetch410:

--- a/Sources/Helium/HeliumCore/Models.swift
+++ b/Sources/Helium/HeliumCore/Models.swift
@@ -827,3 +827,22 @@ public enum HeliumLightDarkMode {
     case dark
     case system
 }
+
+/// Selects which External Web Checkout payment processors are enabled.
+/// Use `.all` for both, or `.paddle` / `.stripe` individually.
+public struct WebCheckoutProcessors: OptionSet, Sendable, CustomStringConvertible {
+    public let rawValue: Int
+    public init(rawValue: Int) { self.rawValue = rawValue }
+
+    public static let paddle = WebCheckoutProcessors(rawValue: 1 << 0)
+    public static let stripe = WebCheckoutProcessors(rawValue: 1 << 1)
+    public static let all: WebCheckoutProcessors = [.paddle, .stripe]
+
+    public var description: String {
+        if isEmpty { return "none" }
+        var names: [String] = []
+        if contains(.paddle) { names.append("paddle") }
+        if contains(.stripe) { names.append("stripe") }
+        return names.joined(separator: ", ")
+    }
+}

--- a/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
+++ b/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
@@ -557,7 +557,10 @@ extension HeliumPaywallPresenter {
             if hasAppToWebProducts && !HeliumIdentityManager.shared.hasCustomUserId() {
                 return fallbackViewFor(trigger: trigger, paywallInfo: templatePaywallInfo, fallbackReason: .webCheckoutNoCustomUserId, presentationContext: presentationContext)
             }
-            if hasAppToWebProducts && !Helium.config.webCheckoutEnabled {
+            let processors = Helium.config.webCheckoutProcessors
+            let paddleUsable = hasPaddleProducts && processors.contains(.paddle)
+            let stripeUsable = hasStripeProducts && processors.contains(.stripe)
+            if hasAppToWebProducts && !(paddleUsable || stripeUsable) {
                 return fallbackViewFor(trigger: trigger, paywallInfo: templatePaywallInfo, fallbackReason: .webCheckoutNotEnabled, presentationContext: presentationContext)
             }
             

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -378,6 +378,8 @@ public class Helium {
     /// Forward incoming deep links / universal links to Helium so the SDK can react to
     /// external web checkout success/cancel redirects without waiting for the app to foreground.
     ///
+    /// This is not required, but encouraged for smoother post-purchase experience.
+    ///
     /// Safe to call with unrelated URLs — returns `false` if external web checkout is
     /// disabled or the URL does not match the success/cancel URLs configured via
     /// ``HeliumConfig/enableExternalWebCheckout(successURL:cancelURL:)``.
@@ -480,16 +482,21 @@ public class HeliumIdentify {
                 // Sync Stripe/Paddle customer metadata if web checkout is configured
                 if Helium.config.webCheckoutEnabled,
                    Helium.shared.isInitialized() {
+                    let processors = Helium.config.webCheckoutProcessors
                     Task {
-                        if HeliumIdentityManager.shared.getStripeCustomerId() == nil {
-                            await HeliumEntitlementsManager.shared.stripeEntitlementsSource.refreshEntitlements()
-                        } else {
-                            try? await StripeCheckoutManager.shared.updateCustomerMetadata()
+                        if processors.contains(.paddle) {
+                            if HeliumIdentityManager.shared.getPaddleCustomerId() == nil {
+                                await HeliumEntitlementsManager.shared.paddleEntitlementsSource.refreshEntitlements()
+                            } else {
+                                try? await PaddleCheckoutManager.shared.updateCustomerMetadata()
+                            }
                         }
-                        if HeliumIdentityManager.shared.getPaddleCustomerId() == nil {
-                            await HeliumEntitlementsManager.shared.paddleEntitlementsSource.refreshEntitlements()
-                        } else {
-                            try? await PaddleCheckoutManager.shared.updateCustomerMetadata()
+                        if processors.contains(.stripe) {
+                            if HeliumIdentityManager.shared.getStripeCustomerId() == nil {
+                                await HeliumEntitlementsManager.shared.stripeEntitlementsSource.refreshEntitlements()
+                            } else {
+                                try? await StripeCheckoutManager.shared.updateCustomerMetadata()
+                            }
                         }
                     }
                 }
@@ -584,7 +591,7 @@ public class HeliumIdentify {
 }
 
 public class HeliumConfig {
-    
+
     init() {}
     
     /// Sets the Helium SDK log level.
@@ -642,9 +649,13 @@ public class HeliumConfig {
     public var paywallNotShownDiagnosticDisplayEnabled: Bool = true
 
     // MARK: - External Web Checkout Configuration
-    
-    private(set) var webCheckoutEnabled: Bool = false
-    
+
+    /// Which External Web Checkout payment processors are enabled. Empty means disabled.
+    private(set) var webCheckoutProcessors: WebCheckoutProcessors = []
+
+    /// True if any External Web Checkout payment processor is enabled.
+    var webCheckoutEnabled: Bool { !webCheckoutProcessors.isEmpty }
+
     /// Custom success redirect URL for External Checkout Flow.
     private(set) var checkoutSuccessURL: String? = nil
 
@@ -659,25 +670,37 @@ public class HeliumConfig {
     /// - Parameters:
     ///   - successURL: The URL to redirect to after a successful payment.
     ///     Include `{CHECKOUT_SESSION_ID}` in the URL to receive the session ID.
-    ///   - cancelURL: The URL Stripe redirects to when the user cancels checkout.
-    public func enableExternalWebCheckout(successURL: String, cancelURL: String) {
+    ///   - cancelURL: The URL the provider redirects to when the user cancels checkout.
+    ///   - paymentProcessors: Which payment processors to enable. Defaults to `.all` (both Paddle and Stripe).
+    ///     Pass `.paddle` or `.stripe` if your app only uses one to skip the unused processor's
+    ///     entitlement network calls.
+    public func enableExternalWebCheckout(
+        successURL: String,
+        cancelURL: String,
+        paymentProcessors: WebCheckoutProcessors = .all
+    ) {
         guard let successParsed = URL(string: successURL), successParsed.scheme != nil,
               let cancelParsed = URL(string: cancelURL), cancelParsed.scheme != nil else {
             HeliumLogger.log(.error, category: .core, "enableExternalWebCheckout: invalid URLs provided. Both successURL and cancelURL must be valid URLs with a scheme (e.g. https://example.com or myapp://path).")
             return
         }
+        guard !paymentProcessors.isEmpty else {
+            HeliumLogger.log(.error, category: .core, "enableExternalWebCheckout: paymentProcessors must not be empty. Pass .all, .paddle, or .stripe.")
+            return
+        }
         checkoutSuccessURL = successURL
         checkoutCancelURL = cancelURL
-        webCheckoutEnabled = true
+        webCheckoutProcessors = paymentProcessors
     }
 
     /// Disables External Web Checkout Flow. Paywalls with Paddle or Stripe products
     /// will not show. Your fallback paywall/s, if provided, will show instead.
-    /// NOTE - if you have existing Paddle/Stripe customers, Helium will stop respecting their entitlements.
+    /// NOTE - if you have existing Paddle/Stripe customers, Helium will attempt to continue respecting their entitlements but is
+    /// not guaranteed to do so.
     public func disableExternalWebCheckout() {
         checkoutSuccessURL = nil
         checkoutCancelURL = nil
-        webCheckoutEnabled = false
+        webCheckoutProcessors = []
     }
 
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes web checkout gating and entitlement refresh logic for Paddle/Stripe, which can affect whether paywalls show and whether restores/entitlements sync correctly. API surface changes (new `paymentProcessors` option) could lead to misconfiguration if apps relied on the previous all-or-nothing flag.
> 
> **Overview**
> Adds a new `WebCheckoutProcessors` `OptionSet` and updates `HeliumConfig.enableExternalWebCheckout(...)` to accept a `paymentProcessors` parameter (defaulting to both), replacing the previous single `webCheckoutEnabled` flag with per-provider enablement.
> 
> Updates paywall presentation, restore purchases, entitlement-source configuration, and user-ID metadata sync to only perform Stripe/Paddle web-checkout work when that processor is enabled, and improves the `.webCheckoutNotEnabled` diagnostic message to include the enabled processor set.
> 
> The example app now forwards incoming URLs via `.onOpenURL` to `Helium.shared.handleURL(_:)` for smoother external checkout redirects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42327299a423636aae331bc03346548786579100. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added granular control over payment processors for web checkout, allowing separate configuration of Paddle and Stripe processors.
  * Improved URL handling for web checkout payment flow redirects.

* **API Changes**
  * Updated `enableExternalWebCheckout()` method signature to include optional `paymentProcessors` parameter for specifying which payment processors to enable (defaults to both).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->