### PR TITLE
HEL-4895 add a way to bypass web checkout user id requirement

### DIFF
--- a/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
+++ b/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
@@ -554,7 +554,7 @@ extension HeliumPaywallPresenter {
             let hasPaddleProducts = !(templatePaywallInfo.productsOfferedPaddle ?? []).isEmpty
             let hasStripeProducts = !(templatePaywallInfo.productsOfferedStripe ?? []).isEmpty
             let hasAppToWebProducts = hasPaddleProducts || hasStripeProducts
-            if hasAppToWebProducts && !HeliumIdentityManager.shared.hasCustomUserId() {
+            if hasAppToWebProducts && !HeliumIdentityManager.shared.hasCustomUserId() && !Helium.config.allowWebCheckoutWithoutUserId {
                 return fallbackViewFor(trigger: trigger, paywallInfo: templatePaywallInfo, fallbackReason: .webCheckoutNoCustomUserId, presentationContext: presentationContext)
             }
             let processors = Helium.config.webCheckoutProcessors

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -703,6 +703,22 @@ public class HeliumConfig {
         webCheckoutProcessors = []
     }
 
+    /// Allows Web Checkout paywalls (Paddle/Stripe) to show even when no custom user ID
+    /// has been set via `Helium.identify.userId`.
+    ///
+    /// By default, paywalls with Paddle or Stripe products will not show if user ID is not set.
+    /// Your fallback paywall/s, if provided, will show instead.
+    /// Set this to `true` if your app supports purchase-before-signup flows. Once `Helium.identify.userId`
+    /// is set later, Helium will automatically link the Paddle/Stripe customer to that user ID.
+    ///
+    /// - Warning: Use with caution. If the user purchases via web checkout and your app never sets a
+    ///   `userId` (or uninstalls the app before doing so), the purchase may be unrecoverable for that user.
+    ///   Only enable this if your app has a clear path for the user to set
+    ///   `Helium.identify.userId` post-purchase.
+    ///
+    /// Defaults to `false`.
+    public var allowWebCheckoutWithoutUserId: Bool = false
+
 }
 
 public class HeliumExperiments {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes gating logic for Paddle/Stripe paywalls, potentially allowing purchases before `Helium.identify.userId` is set; misconfiguration could lead to purchases that cannot be linked/recovered.
> 
> **Overview**
> Adds an opt-in config flag, `Helium.config.allowWebCheckoutWithoutUserId`, to allow Paddle/Stripe (web checkout) paywalls to render even when no custom user ID has been set.
> 
> Updates `HeliumPaywallPresenter.upsellViewResultFor` to only fallback with `.webCheckoutNoCustomUserId` when web checkout products exist *and* the new flag is disabled, preserving existing behavior by default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6248df78232ea727d7845026077892ca6a25fc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration setting to allow web checkout to proceed without a user ID being set
  * Provides flexibility for payment flows that don't require user identification upfront

<!-- end of auto-generated comment: release notes by coderabbit.ai -->