### PR TITLE
Make Helium's Segment Migration More Safe

### DIFF
--- a/Sources/Helium/HeliumCore/Segment/SegmentCore/Utilities/Utils.swift
+++ b/Sources/Helium/HeliumCore/Segment/SegmentCore/Utilities/Utils.swift
@@ -68,12 +68,8 @@ internal func eventStorageDirectory(writeKey: String) -> URL {
 private func migrateFromOldLocations(writeKey: String, to newLocation: URL) {
     let fm = FileManager.default
 
-    // Get the parent of where our new segment directory should live
-    let appSupportURL = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-    let newSegmentDir = appSupportURL.appendingPathComponent("segment")
-
-    // If segment dir already exists in app support, we're done
-    guard !fm.fileExists(atPath: newSegmentDir.path) else { return }
+    // If the new location already exists in app support, we're done
+    guard !fm.fileExists(atPath: newLocation.path) else { return }
 
     // Only check the old location that was actually used on this platform
     #if (os(iOS) || os(watchOS)) && !targetEnvironment(macCatalyst)
@@ -83,14 +79,14 @@ private func migrateFromOldLocations(writeKey: String, to newLocation: URL) {
     #endif
 
     guard let oldBaseURL = fm.urls(for: oldSearchPath, in: .userDomainMask).first else { return }
-    let oldSegmentDir = oldBaseURL.appendingPathComponent("segment")
+    let oldLocation = oldBaseURL.appendingPathComponent("segment/\(writeKey)/")
 
-    guard fm.fileExists(atPath: oldSegmentDir.path) else { return }
+    guard fm.fileExists(atPath: oldLocation.path) else { return }
 
     do {
-        try fm.moveItem(at: oldSegmentDir, to: newSegmentDir)
-        Analytics.segmentLog(message: "Migrated analytics data from \(oldSegmentDir.path)", kind: .debug)
+        try fm.moveItem(at: oldLocation, to: newLocation)
+        Analytics.segmentLog(message: "Migrated analytics data from \(oldLocation.path)", kind: .debug)
     } catch {
-        Analytics.segmentLog(message: "Failed to migrate from \(oldSegmentDir.path): \(error)", kind: .error)
+        Analytics.segmentLog(message: "Failed to migrate from \(oldLocation.path): \(error)", kind: .error)
     }
 }


### PR DESCRIPTION
## Summary
Ever since our release that updated Helium to version `4.1.9` we have seen an issue with analytics events not coming through, particularly on the first install. After some significant investigation, I believe the issue to be the `migrateFromOldLocations()` function in Helium v4's bundled Segment SDK. It migrates the **entire** `Documents/segment/` directory rather than just Helium's own writeKey subdirectory, which means for the first app session our own Segment SDK is attempting to write events to a directory that is no longer there.

On first app launch:
1. The app's Segment SDK creates `Documents/segment/{app_writeKey}/`
2. Helium's Segment SDK runs migration, moving **all** of `Documents/segment/` to `ApplicationSupport/segment/`
3. The app's Segment SDK now has dangling references to a directory that no longer exists
4. First-session events are lost

Subsequent sessions work because `ApplicationSupport/segment/` already exists, so migration doesn't run again.

I believe this would effect any app using their own Segment SDK (at least `analytics-swift v1.7.2`, I haven't checked other versions), because they store data at `Documents/segment/{app_writeKey}/`.


## Proposed Fix
Change the migration to only move Helium's specific writeKey subdirectories:
- Still migrates Helium's data from the old location to Application Support (preserving what I believe to be the intended behavior)
- Only migrates the specific writeKey subdirectory, not the entire segment directory
- Does not affect other Segment SDK instances running in the same app

I have validated this fix in our own app and am happy to answer questions about what I have seen if that is helpful.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches on-disk data migration logic and file moves, so path mistakes could strand or lose analytics events. Scope is small and limited to the Segment storage directory calculation/migration.
> 
> **Overview**
> Makes Segment’s one-time storage migration **safer in multi-SDK apps** by migrating only `segment/<writeKey>/` from the old base location (Documents or Caches, platform-dependent) to Application Support, rather than moving the entire `segment/` directory.
> 
> Also simplifies the migration guard to check for the specific new per-writeKey directory and updates logs to reference the per-writeKey source path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ccc52c632521e0814da9baf7b376a3d8a4130da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced data migration logic to correctly organize storage by API key during app updates, ensuring configurations are properly transferred to their designated locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->