### PR TITLE
HEL-5222 paddleCheckoutEligible

### DIFF
--- a/Sources/Helium/HeliumCore/HeliumIdentityManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumIdentityManager.swift
@@ -338,7 +338,7 @@ public class ApplePayHelper {
     public static let shared = ApplePayHelper()
 
     @HeliumAtomic private var cachedCanMakePayments: Bool?
-    @HeliumAtomic private var cachedCanMakePaymentsWithCards: Bool?
+    @HeliumAtomic private var cachedCanMakePaymentsWithCreditCards: Bool?
 
     private static let defaultPaymentNetworks: [PKPaymentNetwork] = [
         .amex, .masterCard, .visa, .discover
@@ -346,7 +346,7 @@ public class ApplePayHelper {
 
     private init() {
         cachedCanMakePayments = PKPaymentAuthorizationController.canMakePayments()
-        cachedCanMakePaymentsWithCards = PKPaymentAuthorizationController.canMakePayments(usingNetworks: Self.defaultPaymentNetworks)
+        cachedCanMakePaymentsWithCreditCards = PKPaymentAuthorizationController.canMakePayments(usingNetworks: Self.defaultPaymentNetworks, capabilities: .credit)
     }
 
     /// Checks if the device supports Apple Pay (cached)
@@ -362,16 +362,18 @@ public class ApplePayHelper {
         return isStripeApplePayAvailable && canMakePayments()
     }
 
-    private func canUseApplePayCards() -> Bool {
-        cachedCanMakePaymentsWithCards ?? PKPaymentAuthorizationController.canMakePayments(usingNetworks: Self.defaultPaymentNetworks)
+    /// Excludes debit and prepaid cards — trial-to-paid conversion is materially
+    /// worse on those, so we gate web-checkout eligibility on having a credit card.
+    private func canUseApplePayCreditCards() -> Bool {
+        cachedCanMakePaymentsWithCreditCards ?? PKPaymentAuthorizationController.canMakePayments(usingNetworks: Self.defaultPaymentNetworks, capabilities: .credit)
     }
 
     func isPaddleCheckoutEligible() -> Bool {
-        return Helium.config.webCheckoutProcessors.contains(.paddle) && canUseApplePayCards()
+        return Helium.config.webCheckoutProcessors.contains(.paddle) && canUseApplePayCreditCards()
     }
 
     func isStripeCheckoutEligible() -> Bool {
-        return Helium.config.webCheckoutProcessors.contains(.stripe) && canUseApplePayCards()
+        return Helium.config.webCheckoutProcessors.contains(.stripe) && canUseApplePayCreditCards()
     }
 }
 

--- a/Sources/Helium/HeliumCore/HeliumIdentityManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumIdentityManager.swift
@@ -362,20 +362,16 @@ public class ApplePayHelper {
         return isStripeApplePayAvailable && canMakePayments()
     }
 
+    private func canUseApplePayCards() -> Bool {
+        cachedCanMakePaymentsWithCards ?? PKPaymentAuthorizationController.canMakePayments(usingNetworks: Self.defaultPaymentNetworks)
+    }
+
+    func isPaddleCheckoutEligible() -> Bool {
+        return Helium.config.webCheckoutProcessors.contains(.paddle) && canUseApplePayCards()
+    }
+
     func isStripeCheckoutEligible() -> Bool {
-        if !Helium.config.webCheckoutEnabled {
-            return false
-        }
-        let hasCards = cachedCanMakePaymentsWithCards ?? PKPaymentAuthorizationController.canMakePayments(usingNetworks: Self.defaultPaymentNetworks)
-        if !hasCards {
-            return false
-        }
-        // Our Stripe Apple pay flow on web requires 16.4+ 
-        if #available(iOS 16.4, *) {
-            return true
-        } else {
-            return false
-        }
+        return Helium.config.webCheckoutProcessors.contains(.stripe) && canUseApplePayCards()
     }
 }
 

--- a/Sources/Helium/HeliumCore/UserContext.swift
+++ b/Sources/Helium/HeliumCore/UserContext.swift
@@ -207,6 +207,7 @@ public struct CodableUserContext: Codable {
             "isFirstHeliumSession": HeliumIdentityManager.shared.isFirstHeliumSession,
             "userSeed": userSeed,
             "additionalParams": self.additionalParams.dictionaryRepresentation,
+            "paddleCheckoutEligible": ApplePayHelper.shared.isPaddleCheckoutEligible(),
             "stripeCheckoutEligible": ApplePayHelper.shared.isStripeCheckoutEligible()
         ]
     }

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -650,10 +650,10 @@ public class HeliumConfig {
     var webCheckoutEnabled: Bool { !webCheckoutProcessors.isEmpty }
 
     /// Custom success redirect URL for External Checkout Flow.
-    private(set) var checkoutSuccessURL: String? = nil
+    @HeliumAtomic private(set) var checkoutSuccessURL: String? = nil
 
     /// Custom cancel redirect URL for External Checkout Flow.
-    private(set) var checkoutCancelURL: String? = nil
+    @HeliumAtomic private(set) var checkoutCancelURL: String? = nil
 
     /// Enables External Web Checkout Flow for any Paddle or Stripe products in your paywalls. If not enabled, paywalls with Paddle/Stripe products
     /// will not show. Your fallback paywall/s, if provided, will show instead.
@@ -691,9 +691,9 @@ public class HeliumConfig {
     /// NOTE - if you have existing Paddle/Stripe customers, Helium will attempt to continue respecting their entitlements but is
     /// not guaranteed to do so.
     public func disableExternalWebCheckout() {
+        webCheckoutProcessors = []
         checkoutSuccessURL = nil
         checkoutCancelURL = nil
-        webCheckoutProcessors = []
     }
 
     /// Allows Web Checkout paywalls (Paddle/Stripe) to show even when no custom user ID


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes web-checkout eligibility decisions for Stripe and adds new Paddle eligibility, which can alter which paywalls/checkout paths users see. Also adjusts Apple Pay capability checks (credit-only) and makes checkout redirect URLs atomic, so regressions would primarily affect purchase flow availability rather than data integrity.
> 
> **Overview**
> Adds **Paddle checkout eligibility** reporting by introducing `ApplePayHelper.isPaddleCheckoutEligible()` and including `paddleCheckoutEligible` in the user context payload.
> 
> Refactors **Stripe checkout eligibility** to rely on `Helium.config.webCheckoutProcessors` plus an Apple Pay **credit-card-only** capability check (replacing the prior generic card check and removing the iOS 16.4 gating). Makes `checkoutSuccessURL`/`checkoutCancelURL` updates atomic and slightly reorders state clearing in `disableExternalWebCheckout()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dec0145ac78a98f315a28fa473a0eaa89037c9d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Paddle checkout eligibility as a supported payment option
  * Checkout requests now include a Paddle-eligibility flag

* **Improvements**
  * Stripe checkout eligibility refined to rely on configured processors and card capability (removed OS gating)
  * Apple Pay availability checks optimized with cached credit-card capability
  * Checkout redirect URL handling made more reliable via atomic updates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->