### PR TITLE
Hel 5234 paddle trials

### DIFF
--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -517,6 +517,12 @@ class WebViewManager {
         )
     }
     
+    /// Returns a `WKWebView` for presentation. WebViews are pooled and reused across presentations,
+    /// so any state installed on the webview, its configuration, userContentController, scrollView,
+    /// or gesture recognizers persists until explicitly reset. When adding new per-presentation state:
+    ///   1. Reset it here (or in `createWebViewHolder` if it's truly one-time setup).
+    ///   2. Verify it doesn't accumulate on the reused instance (see `removeAllUserScripts()` in
+    ///      `DynamicWebView.loadWebView` for the canonical example).
     fileprivate func prepareForShowing(
         filePath: String,
         shouldEnableScroll: Bool,

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
@@ -22,6 +22,7 @@ struct HeliumPaywallPreviewVersion: Codable, Identifiable {
     let productIds: [String]?
     let stripeProductIds: [String]?
     let paddleProductIds: [String]?
+    let webPaddleProductIds: [String]?
     let lastSavedAt: String?
     var id: String { versionId }
 

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
@@ -234,7 +234,8 @@ struct HeliumControlPanelView: View {
                     bundleHtml: html,
                     productIds: version.productIds ?? [],
                     productIdsStripe: version.stripeProductIds ?? [],
-                    productIdsPaddle: version.paddleProductIds ?? []
+                    productIdsPaddle: version.paddleProductIds ?? [],
+                    productIdsPaddleWeb: version.webPaddleProductIds ?? []
                 )
 
                 await MainActor.run { loadingVersionId = nil }

--- a/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
@@ -408,6 +408,8 @@ actor HeliumEntitlementsManager {
 
     /// Checks if user has personally purchased this exact product (excludes family sharing).
     /// Note: This checks the exact productId only, not subscription group membership.
+    /// Note: StoreKit-only — does not consult third-party payment sources (Stripe, Paddle).
+    /// For web-checkout entitlement checks, use the provider's `entitlementsSource` directly.
     func hasPersonallyPurchased(productId: String) async -> Bool {
         // If transactions haven't loaded yet, use persisted data immediately for faster response
         if cache.lastTransactionsLoadedTime == nil {

--- a/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
@@ -261,7 +261,7 @@ actor HeliumEntitlementsManager {
 
         let paywallInfo = HeliumFetchedConfigManager.shared.getPaywallInfoForTrigger(trigger) ?? HeliumFallbackViewManager.shared.getFallbackInfo(trigger: trigger)
 
-        let productIds = paywallInfo?.productIds ?? []
+        let productIds = paywallInfo?.productIdsIncludingWebProductIds ?? []
 
         var result: Bool
 

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -1025,7 +1025,8 @@ public class HeliumFetchedConfigManager {
         bundleHtml: String,
         productIds: [String],
         productIdsStripe: [String],
-        productIdsPaddle: [String]
+        productIdsPaddle: [String],
+        productIdsPaddleWeb: [String],
     ) throws {
         guard var config = fetchedConfig else {
             throw HeliumControlPanelError.noConfigAvailable
@@ -1059,6 +1060,7 @@ public class HeliumFetchedConfigManager {
         previewPaywallInfo.productsOfferedIOS = productIds
         previewPaywallInfo.productsOfferedStripe = productIdsStripe
         previewPaywallInfo.productsOfferedPaddle = productIdsPaddle
+        previewPaywallInfo.webProductsOfferedPaddle = productIdsPaddleWeb
 
         // Clear fields inherited from source trigger that would interfere with preview
         previewPaywallInfo.forceShowFallback = nil

--- a/Sources/Helium/HeliumCore/Models.swift
+++ b/Sources/Helium/HeliumCore/Models.swift
@@ -59,7 +59,11 @@ public struct HeliumPaywallInfo: Codable {
     var productIds: [String] {
         productIdsIOS + (productsOfferedStripe ?? []) + (productsOfferedPaddle ?? [])
     }
-    
+
+    var productIdsIncludingWebProductIds: [String] {
+        productIds + (webProductsOfferedPaddle ?? [])
+    }
+
     var hasProducts: Bool {
         !productIds.isEmpty
     }

--- a/Sources/Helium/HeliumCore/Models.swift
+++ b/Sources/Helium/HeliumCore/Models.swift
@@ -38,6 +38,7 @@ public struct HeliumPaywallInfo: Codable {
     var productsOfferedIOS: [String]?
     var productsOfferedStripe: [String]?
     var productsOfferedPaddle: [String]?
+    var webProductsOfferedPaddle: [String]?
     var resolvedConfig: AnyCodable
     var shouldShow: Bool?
     var fallbackPaywallName: String?

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -98,10 +98,22 @@ public class ExternalWebCheckoutManager: NSObject {
             productKey: productKey,
             triggerName: triggerName,
             successURL: resolvedSuccessURL,
-            cancelURL: resolvedCancelURL
+            cancelURL: resolvedCancelURL,
+            introOfferEligible: isIntroOfferEligibleForWebCheckout(paywallInfo: paywallSession.paywallInfoWithBackups)
         )
 
         return try await openEnrichedCheckoutURL(enrichedURL, productKey: productKey, paywallSession: paywallSession)
+    }
+
+    /// True if every offered product is intro-offer eligible.
+    private func isIntroOfferEligibleForWebCheckout(paywallInfo: HeliumPaywallInfo?) -> Bool {
+        guard let paywallInfo,
+              let products = provider.getOfferedProducts(paywallInfo, false),
+              !products.isEmpty else {
+            return false
+        }
+        let priceMap = HeliumFetchedConfigManager.shared.getLocalizedPriceMap()
+        return products.allSatisfy { priceMap[$0]?.subscriptionInfo?.introOfferEligible == true }
     }
 
     /// Appends analytics, identity, and routing query parameters to a checkout URL
@@ -112,7 +124,8 @@ public class ExternalWebCheckoutManager: NSObject {
         productKey: String,
         triggerName: String,
         successURL: String,
-        cancelURL: String
+        cancelURL: String,
+        introOfferEligible: Bool
     ) throws -> URL {
         guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
             throw WebCheckoutError.failedToBuildEnrichedURL
@@ -132,6 +145,7 @@ public class ExternalWebCheckoutManager: NSObject {
         if let organizationId = HeliumFetchedConfigManager.shared.getOrganizationID() {
             ctx["organizationId"] = organizationId
         }
+        ctx["introOfferEligible"] = introOfferEligible
 
         let baseBody = try HeliumPaymentAPIClient.shared.baseRequestBody(provider: provider)
         for (key, value) in baseBody where key != "apiKey" {

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -334,7 +334,9 @@ public class ExternalWebCheckoutManager: NSObject {
 
         for (sessionId, observation) in observationsSnapshot {
             guard let offeredProducts = observation.paywallSession.paywallInfoWithBackups.flatMap({ provider.getOfferedProducts($0, fromSuccessRedirect) }) else {
-                activeCheckoutObservations.removeValue(forKey: sessionId)
+                // Skip, don't remove. Offered-products is static for the
+                // observation's lifetime, so removing here would also kill the
+                // redirect path where the in-app-set safety net would match.
                 continue
             }
 

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -277,7 +277,7 @@ public class ExternalWebCheckoutManager: NSObject {
     /// immediately available after an external purchase. Returns true if a
     /// purchase was detected.
     @MainActor
-    private func checkForNewPurchaseWithRetry(restoreOnAnyEntitledOffered: Bool = false) async -> Bool {
+    private func checkForNewPurchaseWithRetry(fromSuccessRedirect: Bool = false) async -> Bool {
         let delays: [UInt64] = [0, 2_000_000_000]
 
         for (i, delay) in delays.enumerated() {
@@ -287,7 +287,7 @@ public class ExternalWebCheckoutManager: NSObject {
             if Task.isCancelled { return false }
             guard !activeCheckoutObservations.isEmpty else { return false }
 
-            let purchaseDetected = await checkForNewPurchase(restoreOnAnyEntitledOffered: restoreOnAnyEntitledOffered)
+            let purchaseDetected = await checkForNewPurchase(fromSuccessRedirect: fromSuccessRedirect)
             if Task.isCancelled { return false }
             HeliumLogger.log(.debug, category: .entitlements, "Detected new \(provider.displayName) purchase? \(purchaseDetected) (attempt #\(i + 1))")
             if purchaseDetected { return true }
@@ -298,14 +298,14 @@ public class ExternalWebCheckoutManager: NSObject {
     /// Refreshes entitlements once and scans active observations (newest-first).
     /// A newly-entitled offered product always fires `PurchaseSucceededEvent`.
     /// An already-entitled offered product fires `PurchaseRestoredEvent` only
-    /// when `restoreOnAnyEntitledOffered` is true (success-redirect path —
+    /// when `fromSuccessRedirect` is true (success-redirect path —
     /// positive evidence a checkout completed). On a generic foreground
     /// return, the restored path is suppressed to avoid spurious events when
     /// the user opens checkout for one product while already owning another
     /// offered on the same paywall. In either case, observations are cleared
     /// and paywalls hidden. Succeeded wins over Restored across all sessions.
     @MainActor
-    private func checkForNewPurchase(restoreOnAnyEntitledOffered: Bool = false) async -> Bool {
+    private func checkForNewPurchase(fromSuccessRedirect: Bool = false) async -> Bool {
         await entitlementsSource.refreshEntitlements()
         let currentEntitledIds = await entitlementsSource.purchasedHeliumProductIds()
         HeliumLogger.log(.debug, category: .entitlements, "\(provider.displayName) checkForNewPurchase", metadata: [
@@ -319,7 +319,7 @@ public class ExternalWebCheckoutManager: NSObject {
         var restoredCandidate: (productId: String, observation: CheckoutObservation)?
 
         for (sessionId, observation) in observationsSnapshot {
-            guard let offeredProducts = observation.paywallSession.paywallInfoWithBackups.flatMap({ provider.getOfferedProducts($0) }) else {
+            guard let offeredProducts = observation.paywallSession.paywallInfoWithBackups.flatMap({ provider.getOfferedProducts($0, fromSuccessRedirect) }) else {
                 activeCheckoutObservations.removeValue(forKey: sessionId)
                 continue
             }
@@ -357,7 +357,7 @@ public class ExternalWebCheckoutManager: NSObject {
             // Record newest session with an already-entitled offered product as a
             // restored candidate. Only fires if no session produces a Succeeded match
             // and the caller has positive evidence of checkout completion.
-            if restoreOnAnyEntitledOffered,
+            if fromSuccessRedirect,
                restoredCandidate == nil,
                let entitledProductId = currentEntitledIds.first(where: { offeredProducts.contains($0) })  {
                 restoredCandidate = (entitledProductId, observation)
@@ -402,7 +402,7 @@ public class ExternalWebCheckoutManager: NSObject {
         switch redirectKind {
         case .success:
             HeliumLogger.log(.debug, category: .entitlements, "\(provider.displayName) success redirect handled — checking for new purchase")
-            _ = await checkForNewPurchaseWithRetry(restoreOnAnyEntitledOffered: true)
+            _ = await checkForNewPurchaseWithRetry(fromSuccessRedirect: true)
             if !activeCheckoutObservations.isEmpty {
                 armForegroundObserverAfterBackground()
             }

--- a/Sources/Helium/HeliumCore/StripeCheckout/PaymentProviderConfig.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/PaymentProviderConfig.swift
@@ -13,7 +13,11 @@ struct PaymentProviderConfig {
     let entitlementsPersistenceFileName: String
     let getCheckoutSuccessURL: () -> String?
     let getCheckoutCancelURL: () -> String?
-    let getOfferedProducts: (HeliumPaywallInfo) -> [String]?
+    /// Products this provider considers "offered" for a given paywall.
+    /// `includeInAppSetIfWebEmpty` widens to the in-app Paddle set only when the
+    /// web set is empty — used on the success-redirect path as a safety net
+    /// against server config drift (web bundle URL present, web products missing).
+    let getOfferedProducts: (HeliumPaywallInfo, _ includeInAppSetIfWebEmpty: Bool) -> [String]?
     let purchaseEventPaymentProcessor: HeliumPaymentProcessor
 
     var checkEntitlementPath: String { "\(providerSlug)/check-entitlement" }
@@ -31,7 +35,7 @@ struct PaymentProviderConfig {
         entitlementsPersistenceFileName: "helium_stripe_entitlements.json",
         getCheckoutSuccessURL: { Helium.config.checkoutSuccessURL },
         getCheckoutCancelURL: { Helium.config.checkoutCancelURL },
-        getOfferedProducts: { $0.productsOfferedStripe },
+        getOfferedProducts: { paywallInfo, _ in paywallInfo.productsOfferedStripe },
         purchaseEventPaymentProcessor: .stripe
     )
 
@@ -46,7 +50,12 @@ struct PaymentProviderConfig {
         entitlementsPersistenceFileName: "helium_paddle_entitlements.json",
         getCheckoutSuccessURL: { Helium.config.checkoutSuccessURL },
         getCheckoutCancelURL: { Helium.config.checkoutCancelURL },
-        getOfferedProducts: { $0.productsOfferedPaddle },
+        getOfferedProducts: { paywallInfo, includeInAppSetIfWebEmpty in
+            if let web = paywallInfo.webProductsOfferedPaddle, !web.isEmpty {
+                return web
+            }
+            return includeInAppSetIfWebEmpty ? paywallInfo.productsOfferedPaddle : nil
+        },
         purchaseEventPaymentProcessor: .paddle
     )
 }

--- a/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
+++ b/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
@@ -552,6 +552,7 @@ extension HeliumPaywallPresenter {
             }
             
             let hasPaddleProducts = !(templatePaywallInfo.productsOfferedPaddle ?? []).isEmpty
+                || !(templatePaywallInfo.webProductsOfferedPaddle ?? []).isEmpty
             let hasStripeProducts = !(templatePaywallInfo.productsOfferedStripe ?? []).isEmpty
             let hasAppToWebProducts = hasPaddleProducts || hasStripeProducts
             if hasAppToWebProducts && !HeliumIdentityManager.shared.hasCustomUserId() && !Helium.config.allowWebCheckoutWithoutUserId {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes web-checkout product selection and purchase-detection logic for Paddle/Stripe, which can affect entitlement recognition and paywall dismissal flows. Adds new config fields that must stay in sync with server responses to avoid missing or misattributing purchases.
> 
> **Overview**
> Adds first-class support for **Paddle web-checkout product IDs** by extending `HeliumPaywallInfo` with `webProductsOfferedPaddle`, threading this through control-panel preview models/config injection, and treating web Paddle products as valid for web-checkout gating and entitlement checks.
> 
> Enhances external web checkout by embedding `introOfferEligible` in the enriched checkout `ctx` payload (based on localized price metadata), and refines post-checkout entitlement detection: the success-redirect path now widens Paddle “offered products” to fall back to the in-app Paddle set when the web set is missing, and the observation-scanning logic avoids dropping sessions when offered products can’t be resolved.
> 
> Adds clarifying documentation around pooled `WKWebView` reuse/reset expectations and explicitly documents `hasPersonallyPurchased` as StoreKit-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43856b45f7e6bfef4837b63f45f5dfd729bb57f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added intro-offer eligibility detection for web checkout.
  * Enhanced support for Paddle web product offerings.

* **Bug Fixes**
  * Improved web checkout entitlement detection and restoration flow for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->