### PR TITLE
Sdk 24 segment migration fix

### DIFF
--- a/Sources/Helium/HeliumCore/Segment/SegmentCore/Utilities/Storage/Types/DirectoryStore.swift
+++ b/Sources/Helium/HeliumCore/Segment/SegmentCore/Utilities/Storage/Types/DirectoryStore.swift
@@ -164,6 +164,10 @@ extension DirectoryStore {
         // if the app was killed after finishFile() wrote the closing bracket but before
         // the rename to .temp succeeded. Appending to a finalized file corrupts the batch.
         if isFinalized(url: fileURL) {
+            // Complete the interrupted finishFile() rename so the batch becomes visible
+            // to the flush pipeline; otherwise these events are orphaned on disk.
+            let tempURL = fileURL.appendingPathExtension(Self.tempExtension)
+            try? FileManager.default.moveItem(at: fileURL, to: tempURL)
             self.writer = nil
             incrementIndex()
             return startFileIfNeeded()

--- a/Sources/Helium/HeliumCore/Segment/SegmentCore/Utilities/Storage/Types/DirectoryStore.swift
+++ b/Sources/Helium/HeliumCore/Segment/SegmentCore/Utilities/Storage/Types/DirectoryStore.swift
@@ -154,15 +154,35 @@ extension DirectoryStore {
         let index = getIndex()
         let fileURL = config.storageLocation.appendingPathComponent("\(index)-\(config.baseFilename)")
         writer = LineStreamWriter(url: fileURL)
-        // we might be reopening this file .. so only do this if it's empty.
         if let writer, writer.bytesWritten == 0 {
+            // Brand new file, write the batch header.
             let contents = "{ \"batch\": ["
             try? writer.writeLine(contents)
             return true
         }
+        // File exists with content. Check if it was already finalized — this can happen
+        // if the app was killed after finishFile() wrote the closing bracket but before
+        // the rename to .temp succeeded. Appending to a finalized file corrupts the batch.
+        if isFinalized(url: fileURL) {
+            self.writer = nil
+            incrementIndex()
+            return startFileIfNeeded()
+        }
         return false
     }
-    
+
+    func isFinalized(url: URL) -> Bool {
+        guard let reader = LineStreamReader(url: url) else { return false }
+        var lastLine: String? = nil
+        while let line = reader.readLine() {
+            if !line.isEmpty { lastLine = line }
+        }
+        // Match the exact prefix finishFile() writes. `],` is impossible inside an
+        // event line (events are JSON objects), so this can't false-positive on
+        // host-controlled trait keys that happen to be named "sentAt".
+        return lastLine?.hasPrefix("],\"sentAt\"") == true
+    }
+
     func finishFile() {
         guard let writer else {
             #if DEBUG

--- a/Sources/Helium/HeliumCore/Segment/SegmentCore/Utilities/Utils.swift
+++ b/Sources/Helium/HeliumCore/Segment/SegmentCore/Utilities/Utils.swift
@@ -52,9 +52,11 @@ extension Optional: Flattenable {
 }
 
 internal func eventStorageDirectory(writeKey: String) -> URL {
-    let urls = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
-    let appSupportURL = urls[0]
-    let storageURL = appSupportURL.appendingPathComponent("helium/analytics/\(writeKey)/")
+    // Application Support is always resolvable on real Apple devices; the guard is belt-and-suspenders
+    // so this SDK can never trap inside a host app. Temp dir is a session-only safety net.
+    let baseURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+        ?? URL(fileURLWithPath: NSTemporaryDirectory())
+    let storageURL = baseURL.appendingPathComponent("helium/analytics/\(writeKey)/")
 
     // Handle one-time migration from old locations
     migrateFromOldLocations(writeKey: writeKey, to: storageURL)
@@ -70,7 +72,7 @@ private func migrateFromOldLocations(writeKey: String, to newLocation: URL) {
 
     guard !fm.fileExists(atPath: newLocation.path) else { return }
 
-    let appSupportURL = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+    guard let appSupportURL = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else { return }
     let appSupportSegmentDir = appSupportURL.appendingPathComponent("segment/\(writeKey)/")
 
     #if (os(iOS) || os(watchOS)) && !targetEnvironment(macCatalyst)

--- a/Sources/Helium/HeliumCore/Segment/SegmentCore/Utilities/Utils.swift
+++ b/Sources/Helium/HeliumCore/Segment/SegmentCore/Utilities/Utils.swift
@@ -56,7 +56,7 @@ internal func eventStorageDirectory(writeKey: String) -> URL {
     // so this SDK can never trap inside a host app. Temp dir is a session-only safety net.
     let baseURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
         ?? URL(fileURLWithPath: NSTemporaryDirectory())
-    let storageURL = baseURL.appendingPathComponent("helium/analytics/\(writeKey)/")
+    let storageURL = baseURL.appendingPathComponent("Helium/analytics/\(writeKey)/")
 
     // Handle one-time migration from old locations
     migrateFromOldLocations(writeKey: writeKey, to: storageURL)

--- a/Sources/Helium/HeliumCore/Segment/SegmentCore/Utilities/Utils.swift
+++ b/Sources/Helium/HeliumCore/Segment/SegmentCore/Utilities/Utils.swift
@@ -54,43 +54,49 @@ extension Optional: Flattenable {
 internal func eventStorageDirectory(writeKey: String) -> URL {
     let urls = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
     let appSupportURL = urls[0]
-    let segmentURL = appSupportURL.appendingPathComponent("segment/\(writeKey)/")
+    let storageURL = appSupportURL.appendingPathComponent("helium/analytics/\(writeKey)/")
 
     // Handle one-time migration from old locations
-    migrateFromOldLocations(writeKey: writeKey, to: segmentURL)
+    migrateFromOldLocations(writeKey: writeKey, to: storageURL)
 
     // try to create it, will fail if already exists, nbd.
     // tvOS, watchOS regularly clear out data.
-    try? FileManager.default.createDirectory(at: segmentURL, withIntermediateDirectories: true, attributes: nil)
-    return segmentURL
+    try? FileManager.default.createDirectory(at: storageURL, withIntermediateDirectories: true, attributes: nil)
+    return storageURL
 }
 
 private func migrateFromOldLocations(writeKey: String, to newLocation: URL) {
     let fm = FileManager.default
 
-    // Get the parent of where our new segment directory should live
+    guard !fm.fileExists(atPath: newLocation.path) else { return }
+
     let appSupportURL = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-    let newSegmentDir = appSupportURL.appendingPathComponent("segment")
+    let appSupportSegmentDir = appSupportURL.appendingPathComponent("segment/\(writeKey)/")
 
-    // If segment dir already exists in app support, we're done
-    guard !fm.fileExists(atPath: newSegmentDir.path) else { return }
-
-    // Only check the old location that was actually used on this platform
     #if (os(iOS) || os(watchOS)) && !targetEnvironment(macCatalyst)
-    let oldSearchPath = FileManager.SearchPathDirectory.documentDirectory
+    let legacySearchPath = FileManager.SearchPathDirectory.documentDirectory
     #else
-    let oldSearchPath = FileManager.SearchPathDirectory.cachesDirectory
+    let legacySearchPath = FileManager.SearchPathDirectory.cachesDirectory
     #endif
+    let legacySegmentDir = fm.urls(for: legacySearchPath, in: .userDomainMask)
+        .first?
+        .appendingPathComponent("segment/\(writeKey)/")
 
-    guard let oldBaseURL = fm.urls(for: oldSearchPath, in: .userDomainMask).first else { return }
-    let oldSegmentDir = oldBaseURL.appendingPathComponent("segment")
+    let source: URL? = {
+        if fm.fileExists(atPath: appSupportSegmentDir.path) { return appSupportSegmentDir }
+        if let legacy = legacySegmentDir, fm.fileExists(atPath: legacy.path) { return legacy }
+        return nil
+    }()
 
-    guard fm.fileExists(atPath: oldSegmentDir.path) else { return }
+    guard let sourceURL = source else { return }
+
+    // moveItem requires the destination's parent to already exist.
+    try? fm.createDirectory(at: newLocation.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)
 
     do {
-        try fm.moveItem(at: oldSegmentDir, to: newSegmentDir)
-        Analytics.segmentLog(message: "Migrated analytics data from \(oldSegmentDir.path)", kind: .debug)
+        try fm.moveItem(at: sourceURL, to: newLocation)
+        Analytics.segmentLog(message: "Migrated analytics data from \(sourceURL.path) to \(newLocation.path)", kind: .debug)
     } catch {
-        Analytics.segmentLog(message: "Failed to migrate from \(oldSegmentDir.path): \(error)", kind: .error)
+        Analytics.segmentLog(message: "Failed to migrate analytics data from \(sourceURL.path): \(error)", kind: .error)
     }
 }


### PR DESCRIPTION
Inspired by #251 - ensuring safe migration of segment files but also isolating Helium segment files completely from host app integration. And applying a fix from https://github.com/segmentio/analytics-swift/pull/421

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes on-disk storage paths and migration behavior, and alters batch file rollover logic; could impact event persistence/flush if edge cases are missed.
> 
> **Overview**
> Improves on-disk batch integrity by detecting when a batch file was already finalized but not renamed (e.g., crash between `finishFile()` write and rename), renaming it to `.temp`, and starting a fresh file to avoid corrupting the batch.
> 
> Moves event storage to a Helium-scoped `Application Support/Helium/analytics/<writeKey>/` directory with a defensive fallback to the temp directory, and updates the one-time migration logic to pull from the prior `segment/<writeKey>/` locations (Application Support and legacy Documents/Caches) only when the new location doesn’t already exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94fb14cc5569af6a7993bb76ecefd5ddb051a913. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detect finalized batch files and start new batches instead of appending, preventing corrupted or mixed JSON and improving data integrity.
  * Improved storage directory selection and migration logic with safer fallbacks and clearer logging for more reliable data persistence across platforms and states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->