### PR TITLE
consolidate Helium/ app support usage

### DIFF
--- a/Sources/Helium/HeliumCore/ExperimentAllocationTracker.swift
+++ b/Sources/Helium/HeliumCore/ExperimentAllocationTracker.swift
@@ -46,10 +46,7 @@ class ExperimentAllocationTracker {
     
     /// File URL for allocations storage, as a backup to UserDefaults
     private var allocationsFileURL: URL? {
-        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
-            .first?
-            .appendingPathComponent("Helium", isDirectory: true)
-            .appendingPathComponent(allocationsFileName)
+        heliumAppSupportDirectory?.appendingPathComponent(allocationsFileName)
     }
     
     /// Loads stored allocations - tries UserDefaults first, falls back to file

--- a/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
@@ -77,10 +77,7 @@ actor HeliumEntitlementsManager {
     
     /// File URL for entitlements storage.
     private nonisolated var entitlementsFileURL: URL? {
-        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
-            .first?
-            .appendingPathComponent("Helium", isDirectory: true)
-            .appendingPathComponent(entitlementsFileName)
+        heliumAppSupportDirectory?.appendingPathComponent(entitlementsFileName)
     }
     
     /// Loads persisted entitlements from file storage

--- a/Sources/Helium/HeliumCore/HeliumStorage.swift
+++ b/Sources/Helium/HeliumCore/HeliumStorage.swift
@@ -5,6 +5,19 @@
 
 import Foundation
 
+/// Helium-owned subdirectory of Application Support. All Helium SDK file persistence
+/// lives under this root so it stays isolated from host-app data and any other
+/// Segment/third-party SDKs the host may ship.
+///
+/// Returns nil only if the user-domain Application Support URL cannot be resolved,
+/// which doesn't happen on real Apple devices; callers should tolerate the optional
+/// rather than force-unwrapping.
+internal var heliumAppSupportDirectory: URL? {
+    FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
+        .first?
+        .appendingPathComponent("Helium", isDirectory: true)
+}
+
 /// Centralized persistence layer for the Helium SDK.
 ///
 /// Backed by a dedicated UserDefaults suite (`com.tryhelium.sdk`) to avoid

--- a/Sources/Helium/HeliumCore/HeliumStorage.swift
+++ b/Sources/Helium/HeliumCore/HeliumStorage.swift
@@ -12,6 +12,11 @@ import Foundation
 /// Returns nil only if the user-domain Application Support URL cannot be resolved,
 /// which doesn't happen on real Apple devices; callers should tolerate the optional
 /// rather than force-unwrapping.
+///
+/// Future consideration: the `Helium` directory name could collide with a host app
+/// that happens to use the same subdirectory for its own data. Consider migrating
+/// to a reverse-DNS name like `com.tryhelium.sdk` (matching the UserDefaults suite)
+/// to guarantee uniqueness. Would require a one-time migration of existing files.
 internal var heliumAppSupportDirectory: URL? {
     FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
         .first?

--- a/Sources/Helium/HeliumCore/Segment/SegmentCore/Utilities/Utils.swift
+++ b/Sources/Helium/HeliumCore/Segment/SegmentCore/Utilities/Utils.swift
@@ -54,9 +54,9 @@ extension Optional: Flattenable {
 internal func eventStorageDirectory(writeKey: String) -> URL {
     // Application Support is always resolvable on real Apple devices; the guard is belt-and-suspenders
     // so this SDK can never trap inside a host app. Temp dir is a session-only safety net.
-    let baseURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-        ?? URL(fileURLWithPath: NSTemporaryDirectory())
-    let storageURL = baseURL.appendingPathComponent("Helium/analytics/\(writeKey)/")
+    let baseURL = heliumAppSupportDirectory
+        ?? URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("Helium", isDirectory: true)
+    let storageURL = baseURL.appendingPathComponent("analytics/\(writeKey)/")
 
     // Handle one-time migration from old locations
     migrateFromOldLocations(writeKey: writeKey, to: storageURL)

--- a/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
@@ -184,10 +184,7 @@ open class HeliumPaymentEntitlementsSource: ThirdPartyEntitlementsSource, @unche
     // MARK: - Persistence
 
     private var persistenceFileURL: URL? {
-        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
-            .first?
-            .appendingPathComponent("Helium", isDirectory: true)
-            .appendingPathComponent(provider.entitlementsPersistenceFileName)
+        heliumAppSupportDirectory?.appendingPathComponent(provider.entitlementsPersistenceFileName)
     }
 
     private func loadPersistedData() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes Application Support path construction; main risk is unexpected persistence path mismatches affecting cached entitlements/allocations/analytics data if directory resolution differs on edge platforms.
> 
> **Overview**
> Introduces a shared `heliumAppSupportDirectory` helper in `HeliumStorage.swift` to standardize where the SDK writes files under Application Support.
> 
> Updates experiment allocation tracking, StoreKit entitlements persistence, Stripe/Paddle entitlements persistence, and Segment analytics event storage to build their file URLs from this shared root (keeping all Helium-owned data under the same `Helium/` directory and preserving existing on-disk locations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25185042b03148ece3df71f398f75d3775eb2542. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->