### PR TITLE
Hel 5221 paddle embedded paywall

### DIFF
--- a/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
@@ -7,29 +7,29 @@
 
 import Foundation
 
-// Tracks dismiss actions for SwiftUI-presented paywalls (`.triggered` /
-// `.embedded`), keyed by `paywallSession.sessionId`. The UIKit-based
-// `HeliumPaywallPresenter` handles `.presented` paywalls; this covers the
-// gap for paywalls shown via the `.heliumPaywall` modifier or inline
-// embedding, which the external web checkout flow needs to close after a
-// successful purchase or restore.
+// Tracks dismiss actions for inline paywalls (`.triggered` / `.embedded`
+// viewTypes — i.e. shown via the `.heliumPaywall` modifier or inlined
+// directly into the host's view hierarchy), keyed by `paywallSession.sessionId`.
+// The UIKit-based `HeliumPaywallPresenter` handles `.presented` paywalls;
+// this covers the gap so the external web checkout flow can close inline
+// paywalls after a successful purchase or restore.
 @MainActor
-private var swiftUIPaywallDismissActions: [String: () -> Void] = [:]
+private var inlinePaywallDismissActions: [String: () -> Void] = [:]
 
 @MainActor
-func registerSwiftUIPaywallDismiss(sessionId: String, _ action: @escaping () -> Void) {
-    swiftUIPaywallDismissActions[sessionId] = action
+func registerInlinePaywallDismiss(sessionId: String, _ action: @escaping () -> Void) {
+    inlinePaywallDismissActions[sessionId] = action
 }
 
 @MainActor
-func unregisterSwiftUIPaywallDismiss(sessionId: String) {
-    swiftUIPaywallDismissActions.removeValue(forKey: sessionId)
+func unregisterInlinePaywallDismiss(sessionId: String) {
+    inlinePaywallDismissActions.removeValue(forKey: sessionId)
 }
 
 @MainActor
-func dismissAllSwiftUIPaywalls() {
-    let snapshot = swiftUIPaywallDismissActions
-    swiftUIPaywallDismissActions.removeAll()
+func dismissAllInlinePaywalls() {
+    let snapshot = inlinePaywallDismissActions
+    inlinePaywallDismissActions.removeAll()
     for action in snapshot.values { action() }
 }
 

--- a/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
@@ -7,6 +7,32 @@
 
 import Foundation
 
+// Tracks dismiss actions for SwiftUI-presented paywalls (`.triggered` /
+// `.embedded`), keyed by `paywallSession.sessionId`. The UIKit-based
+// `HeliumPaywallPresenter` handles `.presented` paywalls; this covers the
+// gap for paywalls shown via the `.heliumPaywall` modifier or inline
+// embedding, which the external web checkout flow needs to close after a
+// successful purchase or restore.
+@MainActor
+private var swiftUIPaywallDismissActions: [String: () -> Void] = [:]
+
+@MainActor
+func registerSwiftUIPaywallDismiss(sessionId: String, _ action: @escaping () -> Void) {
+    swiftUIPaywallDismissActions[sessionId] = action
+}
+
+@MainActor
+func unregisterSwiftUIPaywallDismiss(sessionId: String) {
+    swiftUIPaywallDismissActions.removeValue(forKey: sessionId)
+}
+
+@MainActor
+func dismissAllSwiftUIPaywalls() {
+    let snapshot = swiftUIPaywallDismissActions
+    swiftUIPaywallDismissActions.removeAll()
+    for action in snapshot.values { action() }
+}
+
 class ActionsDelegateWrapper: ObservableObject {
     let delegate: HeliumActionsDelegate
     

--- a/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
@@ -14,23 +14,22 @@ import Foundation
 // this covers the gap so the external web checkout flow can close inline
 // paywalls after a successful purchase or restore.
 @MainActor
-private var inlinePaywallDismissActions: [String: () -> Void] = [:]
+enum InlinePaywallDismissRegistry {
+    private static var actions: [String: () -> Void] = [:]
 
-@MainActor
-func registerInlinePaywallDismiss(sessionId: String, _ action: @escaping () -> Void) {
-    inlinePaywallDismissActions[sessionId] = action
-}
+    static func register(sessionId: String, _ action: @escaping () -> Void) {
+        actions[sessionId] = action
+    }
 
-@MainActor
-func unregisterInlinePaywallDismiss(sessionId: String) {
-    inlinePaywallDismissActions.removeValue(forKey: sessionId)
-}
+    static func unregister(sessionId: String) {
+        actions.removeValue(forKey: sessionId)
+    }
 
-@MainActor
-func dismissAllInlinePaywalls() {
-    let snapshot = inlinePaywallDismissActions
-    inlinePaywallDismissActions.removeAll()
-    for action in snapshot.values { action() }
+    static func dismissAll() {
+        let snapshot = actions
+        actions.removeAll()
+        for action in snapshot.values { action() }
+    }
 }
 
 class ActionsDelegateWrapper: ObservableObject {

--- a/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
+++ b/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
@@ -59,6 +59,9 @@ public struct DynamicBaseTemplateView: View {
                 dismiss()
             }
             if presentationState.viewType != .presented {
+                registerSwiftUIPaywallDismiss(sessionId: actionsDelegate.paywallSession.sessionId) {
+                    dismiss()
+                }
                 if !presentationState.isOpen {
                     presentationState.isOpen = true
                     actionsDelegateWrapper.logImpression(viewType: presentationState.viewType, fallbackReason: fallbackReason, loadTimeTakenMS: loadTimeTakenMS)
@@ -67,6 +70,7 @@ public struct DynamicBaseTemplateView: View {
         }
         .onDisappear {
             if presentationState.viewType != .presented {
+                unregisterSwiftUIPaywallDismiss(sessionId: actionsDelegate.paywallSession.sessionId)
                 if presentationState.isOpen {
                     presentationState.isOpen = false
                     actionsDelegateWrapper.logClosure()

--- a/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
+++ b/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
@@ -59,7 +59,7 @@ public struct DynamicBaseTemplateView: View {
                 dismiss()
             }
             if presentationState.viewType != .presented {
-                registerInlinePaywallDismiss(sessionId: actionsDelegate.paywallSession.sessionId) {
+                InlinePaywallDismissRegistry.register(sessionId: actionsDelegate.paywallSession.sessionId) {
                     dismiss()
                 }
                 if !presentationState.isOpen {
@@ -70,7 +70,7 @@ public struct DynamicBaseTemplateView: View {
         }
         .onDisappear {
             if presentationState.viewType != .presented {
-                unregisterInlinePaywallDismiss(sessionId: actionsDelegate.paywallSession.sessionId)
+                InlinePaywallDismissRegistry.unregister(sessionId: actionsDelegate.paywallSession.sessionId)
                 if presentationState.isOpen {
                     presentationState.isOpen = false
                     actionsDelegateWrapper.logClosure()

--- a/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
+++ b/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
@@ -59,7 +59,7 @@ public struct DynamicBaseTemplateView: View {
                 dismiss()
             }
             if presentationState.viewType != .presented {
-                registerSwiftUIPaywallDismiss(sessionId: actionsDelegate.paywallSession.sessionId) {
+                registerInlinePaywallDismiss(sessionId: actionsDelegate.paywallSession.sessionId) {
                     dismiss()
                 }
                 if !presentationState.isOpen {
@@ -70,7 +70,7 @@ public struct DynamicBaseTemplateView: View {
         }
         .onDisappear {
             if presentationState.viewType != .presented {
-                unregisterSwiftUIPaywallDismiss(sessionId: actionsDelegate.paywallSession.sessionId)
+                unregisterInlinePaywallDismiss(sessionId: actionsDelegate.paywallSession.sessionId)
                 if presentationState.isOpen {
                     presentationState.isOpen = false
                     actionsDelegateWrapper.logClosure()

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -366,7 +366,7 @@ public class ExternalWebCheckoutManager: NSObject {
                 )
                 activeCheckoutObservations.removeAll()
                 Helium.shared.hideAllPaywalls()
-                dismissAllInlinePaywalls()
+                InlinePaywallDismissRegistry.dismissAll()
                 return true
             }
 
@@ -393,7 +393,7 @@ public class ExternalWebCheckoutManager: NSObject {
             )
             activeCheckoutObservations.removeAll()
             Helium.shared.hideAllPaywalls()
-            dismissAllInlinePaywalls()
+            InlinePaywallDismissRegistry.dismissAll()
             return true
         }
 

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -366,7 +366,7 @@ public class ExternalWebCheckoutManager: NSObject {
                 )
                 activeCheckoutObservations.removeAll()
                 Helium.shared.hideAllPaywalls()
-                dismissAllSwiftUIPaywalls()
+                dismissAllInlinePaywalls()
                 return true
             }
 
@@ -393,7 +393,7 @@ public class ExternalWebCheckoutManager: NSObject {
             )
             activeCheckoutObservations.removeAll()
             Helium.shared.hideAllPaywalls()
-            dismissAllSwiftUIPaywalls()
+            dismissAllInlinePaywalls()
             return true
         }
 

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -365,8 +365,8 @@ public class ExternalWebCheckoutManager: NSObject {
                     sendToAnalytics: false
                 )
                 activeCheckoutObservations.removeAll()
-                // TODO: Ideally call HeliumActionsDelegate.dismissAll to handle dismissAction for DynamicPaywallModifier case.....
                 Helium.shared.hideAllPaywalls()
+                dismissAllSwiftUIPaywalls()
                 return true
             }
 
@@ -393,6 +393,7 @@ public class ExternalWebCheckoutManager: NSObject {
             )
             activeCheckoutObservations.removeAll()
             Helium.shared.hideAllPaywalls()
+            dismissAllSwiftUIPaywalls()
             return true
         }
 

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -117,7 +117,12 @@ public class Helium {
         return HeliumPaywallPresenter.shared.hideUpsell();
     }
     
-    /// Hide all currently displayed paywalls, including "second try" paywalls.
+    /// Hide all paywalls shown via ``presentPaywall()``, including any
+    /// "second try" paywalls.
+    ///
+    /// This does not dismiss `.heliumPaywall` modifier or embedded paywalls —
+    /// those are driven by the host view's state (flip your `isPresented` binding
+    /// or remove the view from the hierarchy).
     public func hideAllPaywalls() {
         return HeliumPaywallPresenter.shared.hideAllUpsells()
     }

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -667,7 +667,6 @@ public class HeliumConfig {
     ///
     /// - Parameters:
     ///   - successURL: The URL to redirect to after a successful payment.
-    ///     Include `{CHECKOUT_SESSION_ID}` in the URL to receive the session ID.
     ///   - cancelURL: The URL the provider redirects to when the user cancels checkout.
     ///   - paymentProcessors: Which payment processors to enable. Defaults to `.all` (both Paddle and Stripe).
     ///     Pass `.paddle` or `.stripe` if your app only uses one to skip the unused processor's


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches paywall dismissal behavior and external checkout completion handling, so regressions could leave paywalls stuck open or dismiss the wrong instance. Scoped to UI state and does not change purchase/entitlement calculations.
> 
> **Overview**
> **Inline (non-presented) paywalls can now be programmatically dismissed after external web checkout completes.** This introduces `InlinePaywallDismissRegistry` to register per-session dismiss closures for `.heliumPaywall`/embedded paywalls and wires registration/unregistration into `DynamicBaseTemplateView` lifecycle.
> 
> When `ExternalWebCheckoutManager` detects a purchase success or restore, it now calls `InlinePaywallDismissRegistry.dismissAll()` in addition to `Helium.shared.hideAllPaywalls()`, ensuring inline paywalls close alongside presented ones. Public docs for `hideAllPaywalls()` were updated to clarify it only affects paywalls shown via `presentPaywall()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4187fb04957c1ccf73261e0f1f8cbcbf61617967. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline/embedded paywalls now automatically dismiss after successful external purchases or restores, and their dismiss handlers are registered/unregistered with the view lifecycle to avoid lingering handlers.

* **Documentation**
  * Clarified `hideAllPaywalls()` behavior: it hides paywalls presented via presentPaywall() but does not affect modifier-based or embedded paywalls driven by view state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->