### PR TITLE
Add more details to storekit delegate cannotFindProduct error

### DIFF
--- a/Sources/Helium/HeliumCore/StoreKitDelegate.swift
+++ b/Sources/Helium/HeliumCore/StoreKitDelegate.swift
@@ -95,7 +95,11 @@ public enum StoreKitDelegateError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .cannotFindProduct:
-            return "Could not find product. Please ensure products are properly configured."
+            var appIdentifierText = ""
+            if let appBundleId = Bundle.main.bundleIdentifier {
+                appIdentifierText = " (\(appBundleId))"
+            }
+            return "Could not find product. Please ensure products are properly configured in the Helium dashboard and that the product exists in App Store Connect for this app\(appIdentifierText)."
         case .unknownPurchaseResult:
             return "Purchase returned an unknown status."
         }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only updates the user-facing `cannotFindProduct` `LocalizedError` string, with no changes to purchase flow or data handling.
> 
> **Overview**
> Improves the `StoreKitDelegateError.cannotFindProduct` message to provide clearer remediation guidance (Helium dashboard + App Store Connect) and appends the current app bundle identifier when available to aid debugging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ae87ed77c83440a4e3c6b53f62b6782d4507908. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messaging for product configuration issues to provide clearer guidance, including the app's identifier and actionable instructions for configuring products in the dashboard and App Store Connect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->