### PR TITLE
Hel 5248 trial eligibility updates

### DIFF
--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -204,12 +204,18 @@ public class ExternalWebCheckoutManager: NSObject {
     /// Stops observing for purchase completion if the session matches.
     @MainActor
     func stopObserving(paywallSession: PaywallSession) {
-        activeCheckoutObservations.removeValue(forKey: paywallSession.sessionId)
+        let removed = activeCheckoutObservations.removeValue(forKey: paywallSession.sessionId)
         if activeCheckoutObservations.isEmpty {
             foregroundCheckTask?.cancel()
             foregroundCheckTask = nil
             stopForegroundObserver()
             stopPendingBackgroundObserver()
+        }
+        // We're no longer auto-refreshing entitlements on foreground return for
+        // this session, so a purchase that completed without us seeing it would
+        // sit behind a stale cache. Force the next read to refetch.
+        if removed != nil {
+            entitlementsSource.invalidateCache()
         }
     }
 

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -99,18 +99,25 @@ public class ExternalWebCheckoutManager: NSObject {
             triggerName: triggerName,
             successURL: resolvedSuccessURL,
             cancelURL: resolvedCancelURL,
-            introOfferEligible: isIntroOfferEligibleForWebCheckout(paywallInfo: paywallSession.paywallInfoWithBackups)
+            introOfferEligible: await isIntroOfferEligibleForWebCheckout(paywallInfo: paywallSession.paywallInfoWithBackups)
         )
 
         return try await openEnrichedCheckoutURL(enrichedURL, productKey: productKey, paywallSession: paywallSession)
     }
 
     /// True if every offered product is intro-offer eligible.
-    private func isIntroOfferEligibleForWebCheckout(paywallInfo: HeliumPaywallInfo?) -> Bool {
+    /// Prefers the server's per-customer signal from `/check-entitlement` when
+    /// available — the local price map can go stale (e.g., host app sets
+    /// userId after StoreKit prices were fetched, so eligibility was computed
+    /// against the wrong identity).
+    private func isIntroOfferEligibleForWebCheckout(paywallInfo: HeliumPaywallInfo?) async -> Bool {
         guard let paywallInfo,
               let products = provider.getOfferedProducts(paywallInfo, false),
               !products.isEmpty else {
             return false
+        }
+        if let serverValue = await entitlementsSource.introOfferEligible() {
+            return serverValue
         }
         let priceMap = HeliumFetchedConfigManager.shared.getLocalizedPriceMap()
         return products.allSatisfy { priceMap[$0]?.subscriptionInfo?.introOfferEligible == true }

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -108,8 +108,7 @@ public class ExternalWebCheckoutManager: NSObject {
     /// True if every offered product is intro-offer eligible.
     /// Prefers the server's per-customer signal from `/check-entitlement` when
     /// available — the local price map can go stale (e.g., host app sets
-    /// userId after StoreKit prices were fetched, so eligibility was computed
-    /// against the wrong identity).
+    /// userId after Helium initialized, so eligibility could change).
     private func isIntroOfferEligibleForWebCheckout(paywallInfo: HeliumPaywallInfo?) async -> Bool {
         guard let paywallInfo,
               let products = provider.getOfferedProducts(paywallInfo, false),

--- a/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentAPIClient.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentAPIClient.swift
@@ -24,19 +24,21 @@ public class HeliumPaymentAPIClient {
 
         guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
             let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+            let rawBody = String(data: data, encoding: .utf8) ?? "Unknown error"
             let message: String
-            if let envelope = try? JSONDecoder().decode(PaymentAPIErrorEnvelope.self, from: data) {
-                let parts = [envelope.error.code, envelope.error.type, envelope.error.detail]
-                    .compactMap { $0 }
-                    .filter { !$0.isEmpty }
-                let core = parts.isEmpty ? "Unknown error" : parts.joined(separator: ": ")
+            if let envelope = try? JSONDecoder().decode(PaymentAPIErrorEnvelope.self, from: data),
+               case let parts = [envelope.error.code, envelope.error.type, envelope.error.detail]
+                   .compactMap({ $0 })
+                   .filter({ !$0.isEmpty }),
+               !parts.isEmpty {
+                let core = parts.joined(separator: ": ")
                 if let requestId = envelope.meta?.requestId, !requestId.isEmpty {
                     message = "\(core) (requestId: \(requestId))"
                 } else {
                     message = core
                 }
             } else {
-                message = String(data: data, encoding: .utf8) ?? "Unknown error"
+                message = rawBody
             }
             throw HeliumPaymentAPIError.serverError(statusCode: statusCode, message: message)
         }

--- a/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentAPIClient.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentAPIClient.swift
@@ -23,9 +23,22 @@ public class HeliumPaymentAPIClient {
         let (data, response) = try await URLSession.shared.data(for: request)
 
         guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
-            let http = response as? HTTPURLResponse
-            let message = String(data: data, encoding: .utf8) ?? "Unknown error"
-            throw HeliumPaymentAPIError.serverError(statusCode: http?.statusCode ?? 0, message: message)
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+            let message: String
+            if let envelope = try? JSONDecoder().decode(PaymentAPIErrorEnvelope.self, from: data) {
+                let parts = [envelope.error.code, envelope.error.type, envelope.error.detail]
+                    .compactMap { $0 }
+                    .filter { !$0.isEmpty }
+                let core = parts.isEmpty ? "Unknown error" : parts.joined(separator: ": ")
+                if let requestId = envelope.meta?.requestId, !requestId.isEmpty {
+                    message = "\(core) (requestId: \(requestId))"
+                } else {
+                    message = core
+                }
+            } else {
+                message = String(data: data, encoding: .utf8) ?? "Unknown error"
+            }
+            throw HeliumPaymentAPIError.serverError(statusCode: statusCode, message: message)
         }
 
         return try JSONDecoder().decode(T.self, from: data)

--- a/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
@@ -4,6 +4,7 @@ import Foundation
 
 private struct CachedSnapshot {
     let products: [ProductEntitlement]
+    let introOfferEligible: Bool?
     let refreshAfter: Date
 
     var needsRefresh: Bool { Date() > refreshAfter }
@@ -68,6 +69,13 @@ open class HeliumPaymentEntitlementsSource: ThirdPartyEntitlementsSource, @unche
         await fetchFromServer(forceNew: true)
     }
 
+    /// Latest server-reported intro-offer eligibility for this customer, or nil
+    /// if unknown (no fetch yet, or server omitted the field on partial failure).
+    open func introOfferEligible() async -> Bool? {
+        await refreshIfNeeded()
+        return lock.withLock { cached?.introOfferEligible }
+    }
+
     open func didCompletePurchase(productId: String, priceId: String?, subscriptionExpiresAt: Date?) {
         guard !productId.isEmpty else { return }
 
@@ -84,6 +92,7 @@ open class HeliumPaymentEntitlementsSource: ThirdPartyEntitlementsSource, @unche
             products.append(newEntitlement)
             cached = CachedSnapshot(
                 products: products,
+                introOfferEligible: cached?.introOfferEligible,
                 refreshAfter: Date().addingTimeInterval(Self.cacheTTL)
             )
             persisted = products
@@ -171,6 +180,7 @@ open class HeliumPaymentEntitlementsSource: ThirdPartyEntitlementsSource, @unche
             lock.withLock {
                 cached = CachedSnapshot(
                     products: productEntitlements,
+                    introOfferEligible: response.introOfferEligibility?.introOfferEligible,
                     refreshAfter: Date().addingTimeInterval(Self.cacheTTL)
                 )
                 persisted = productEntitlements

--- a/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
@@ -92,12 +92,26 @@ open class HeliumPaymentEntitlementsSource: ThirdPartyEntitlementsSource, @unche
             products.append(newEntitlement)
             cached = CachedSnapshot(
                 products: products,
-                introOfferEligible: cached?.introOfferEligible,
+                // NOTE - this introOfferEligible flag is determined by ANY purchase, so can simply set false here
+                introOfferEligible: false,
                 refreshAfter: Date().addingTimeInterval(Self.cacheTTL)
             )
             persisted = products
         }
         persistData()
+    }
+
+    /// Marks the cache stale so the next read triggers a refresh. Keeps current
+    /// data visible in the meantime.
+    func invalidateCache() {
+        lock.withLock {
+            guard let current = cached else { return }
+            cached = CachedSnapshot(
+                products: current.products,
+                introOfferEligible: current.introOfferEligible,
+                refreshAfter: .distantPast
+            )
+        }
     }
 
     open func clearEntitlements() {

--- a/Sources/Helium/HeliumCore/StripeCheckout/WebCheckoutModels.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/WebCheckoutModels.swift
@@ -137,6 +137,32 @@ struct PaymentEntitlementResponse: Codable, Sendable {
     let hasActiveEntitlement: Bool
     let subscriptions: [PaymentSubscriptionInfo]
     let customerId: String?
+    let customerExists: Bool?
+    let introOfferEligibility: IntroOfferEligibility?
+}
+
+struct IntroOfferEligibility: Codable, Sendable {
+    let introOfferEligible: Bool
+    let hasConsumedAnyTrial: Bool?
+    let hasConsumedAnyDiscount: Bool?
+}
+
+// MARK: - Error Envelope
+
+struct PaymentAPIErrorEnvelope: Decodable {
+    let error: Body
+    let meta: ResponseMeta?
+
+    struct Body: Decodable {
+        let type: String?
+        let code: String?
+        let detail: String?
+        let documentationUrl: String?
+    }
+}
+
+struct ResponseMeta: Decodable {
+    let requestId: String?
 }
 
 // Stripe and Paddle don't return identical shapes. Stripe emits `trialEnd`;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches purchase/entitlements logic and the data used to decide trial eligibility, so incorrect server responses or caching behavior could change checkout UX. The changes are localized and mostly additive, but affect a critical conversion path.
> 
> **Overview**
> Web checkout now determines `introOfferEligible` asynchronously, preferring a per-customer value returned from `/check-entitlement` (with a fallback to the local price map), and forces the entitlements cache stale when a checkout observation is stopped so the next read refetches.
> 
> Entitlements fetching now caches the server-provided intro-offer eligibility alongside product entitlements, sets it to `false` on completed purchases, and exposes `introOfferEligible()` plus `invalidateCache()`.
> 
> Payment API error handling is upgraded to parse a structured `PaymentAPIErrorEnvelope` (including `requestId`) for clearer `serverError` messages, and the entitlement response model is extended with `customerExists` and `introOfferEligibility` payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd7a4be837880a18a52ed0bf68a6c81031d02923. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale payment entitlements data persisting after completed purchases
  * Improved payment API error messages with detailed error codes and request IDs

* **Improvements**
  * Enhanced intro offer eligibility determination with server-provided customer signals
  * Strengthened entitlements caching and refresh logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->