### PR TITLE
HEL-5292 user traits in paywall traits

### DIFF
--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -178,7 +178,10 @@ struct DynamicWebView: View {
             
             _ = Date()
             var mergedContext = contextJSON
-            var combinedTraits = HeliumIdentityManager.shared.getUserTraits()
+            // Always include "trigger" in customPaywallTraits. customPaywallTraits are key/values that customer can actually direct
+            // paywall editor to look at.
+            var combinedTraits = HeliumUserTraits(["trigger": triggerName ?? ""])
+            combinedTraits.merge(HeliumIdentityManager.shared.getUserTraits())
             if let paywallTraits = paywallSession?.presentationContext.customPaywallTraits {
                 combinedTraits.merge(paywallTraits)
             }

--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -178,8 +178,8 @@ struct DynamicWebView: View {
             
             _ = Date()
             var mergedContext = contextJSON
-            // Always include "trigger" in customPaywallTraits. customPaywallTraits are key/values that customer can actually direct
-            // paywall editor to look at.
+            // Always include "trigger" in customPaywallTraits (can be overridden by provided values though).
+            // customPaywallTraits are key/values that Helium customer can direct paywall editor to read.
             var combinedTraits = HeliumUserTraits(["trigger": triggerName ?? ""])
             combinedTraits.merge(HeliumIdentityManager.shared.getUserTraits())
             if let paywallTraits = paywallSession?.presentationContext.customPaywallTraits {

--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -178,10 +178,12 @@ struct DynamicWebView: View {
             
             _ = Date()
             var mergedContext = contextJSON
-            if let customPaywallTraits = paywallSession?.presentationContext.customPaywallTraits {
-                let customData = try JSONEncoder().encode(customPaywallTraits)
-                mergedContext["customPaywallTraits"] = try JSON(data: customData)
+            var combinedTraits = HeliumIdentityManager.shared.getUserTraits()
+            if let paywallTraits = paywallSession?.presentationContext.customPaywallTraits {
+                combinedTraits.merge(paywallTraits)
             }
+            let combinedTraitsData = try JSONEncoder().encode(combinedTraits)
+            mergedContext["customPaywallTraits"] = try JSON(data: combinedTraitsData)
             
             // Get localized prices from HeliumFetchedConfigManager
             // Only fetch prices for products associated with this trigger

--- a/Sources/Helium/HeliumCore/Components/Web/HeliumContext.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/HeliumContext.swift
@@ -25,7 +25,7 @@ func createHeliumContext(triggerName: String?) -> JSON {
         let safeDayIndex = max(0, min(weekdayIndex, weekdays.count - 1))
         
         // Get user context from identity manager
-        let userContext = HeliumIdentityManager.shared.getUserContext()
+        let userContext = HeliumIdentityManager.shared.getUserContext(includeUserTraits: false)
         
         // Create the base context JSON from user context params
         var contextJSON = JSON(userContext.buildRequestPayload())

--- a/Sources/Helium/HeliumCore/HeliumIdentityManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumIdentityManager.swift
@@ -207,11 +207,9 @@ public class HeliumIdentityManager {
         }
     }
     
-    /// Gets the current user context, creating it if necessary
-    /// - Returns: The current user context
-    public func getUserContext() -> CodableUserContext {
-        let userContext = CodableUserContext.create(userTraits: self.heliumUserTraits)
-        return userContext
+    /// Gets the current user context
+    func getUserContext(includeUserTraits: Bool = true) -> CodableUserContext {
+        return CodableUserContext.create(userTraits: includeUserTraits ? heliumUserTraits : nil)
     }
 }
 

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -437,7 +437,8 @@ public struct PaywallPresentationConfig {
     /// Creates a new paywall presentation configuration.
     /// - Parameters:
     ///   - presentFromViewController: View controller to present from. Defaults to current top view controller. Ignored for `HeliumPaywall` embedded view.
-    ///   - customPaywallTraits: Custom traits to send to the paywall.
+    ///   - customPaywallTraits: Custom traits to send to the paywall. Note that user traits are automatically included as paywall traits, as is "trigger". If duplicate keys
+    ///   exist, the value from customPaywallTraits will be used.
     ///   - dontShowIfAlreadyEntitled: If `true`, skips showing the paywall when user is already entitled. Defaults to `false`.
     ///   - loadingBudget: Maximum time (in seconds) to show loading state before switching to fallback logic. Use zero or negative to disable loading state. Defaults to `Helium.config.defaultLoadingBudget`.
     public init(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the paywall webview context by always injecting merged `customPaywallTraits` (trigger + identity user traits + presentation overrides), which could affect paywall rendering/targeting if keys collide or consumers relied on traits being absent.
> 
> **Overview**
> Paywall webviews now always receive a `customPaywallTraits` payload that *combines* the current `trigger`, identity user traits, and any per-presentation `customPaywallTraits` (with per-presentation keys taking precedence).
> 
> To avoid duplicating this data in the main `heliumContext`, `createHeliumContext` now builds user context without user traits via a new `HeliumIdentityManager.getUserContext(includeUserTraits:)` option, and the public `PaywallPresentationConfig` docs were updated to describe the new trait-merging behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30c66c06e07b08cae8671200af54aeffdd95df93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of user traits and paywall context by refactoring how identity-derived traits are combined with presentation data and injected into web views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->