### PR TITLE
Expose a way to override the actual purchase call logic in store kit …

### DIFF
--- a/Sources/Helium/HeliumCore/BuildConstants.swift
+++ b/Sources/Helium/HeliumCore/BuildConstants.swift
@@ -8,5 +8,5 @@
  */
 public struct BuildConstants {
     /// Current SDK version
-    public static let version = "4.4.2"
+    public static let version = "4.4.3"
 }

--- a/Sources/Helium/HeliumCore/StoreKitDelegate.swift
+++ b/Sources/Helium/HeliumCore/StoreKitDelegate.swift
@@ -30,14 +30,20 @@ open class StoreKitDelegate: HeliumPaywallDelegate, HeliumDelegateReturnsTransac
         }
     }
     
+    /// Override to customize how the purchase is initiated — e.g. to pass `Product.PurchaseOption`s
+    /// like a promotional offer.
+    open func performPurchase(product: Product, productId: String) async throws -> Product.PurchaseResult {
+        return try await product.heliumPurchase()
+    }
+
     open func makePurchase(productId: String) async -> HeliumPaywallTransactionStatus {
         do {
             guard let product = try await ProductsCache.shared.getProduct(id: productId) else {
                 HeliumLogger.log(.error, category: .core, "StoreKitDelegate - makePurchase could not find product: \(productId)")
                 return .failed(StoreKitDelegateError.cannotFindProduct)
             }
-            
-            let result = try await product.heliumPurchase()
+
+            let result = try await performPurchase(product: product, productId: productId)
                 
             switch result {
             case .success(let verification):

--- a/Sources/Helium/HeliumCore/StoreKitDelegate.swift
+++ b/Sources/Helium/HeliumCore/StoreKitDelegate.swift
@@ -30,7 +30,7 @@ open class StoreKitDelegate: HeliumPaywallDelegate, HeliumDelegateReturnsTransac
         }
     }
     
-    /// Override to customize how the purchase is initiated — e.g. to pass `Product.PurchaseOption`s
+    /// (Advanced) Override to customize how the purchase is initiated — e.g. to pass `Product.PurchaseOption`s
     /// like a promotional offer.
     open func performPurchase(product: Product, productId: String) async throws -> Product.PurchaseResult {
         return try await product.heliumPurchase()


### PR DESCRIPTION
…delegate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the purchase execution path by routing purchases through an overridable method, which could affect transaction handling if subclasses implement it incorrectly; default behavior remains unchanged.
> 
> **Overview**
> Bumps the SDK version to `4.4.3`.
> 
> Adds `StoreKitDelegate.performPurchase(product:productId:)` as an *advanced* override point and updates `makePurchase` to call this hook instead of directly invoking `product.heliumPurchase()`, enabling custom purchase options (e.g., promotional offers) while keeping the default purchase behavior the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbc099de3f616c64fcec8e3e97791ebab33e035b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->