### PR TITLE
Safer triple tap

### DIFF
--- a/Sources/Helium/HeliumCore/BuildConstants.swift
+++ b/Sources/Helium/HeliumCore/BuildConstants.swift
@@ -8,5 +8,5 @@
  */
 public struct BuildConstants {
     /// Current SDK version
-    public static let version = "4.4.3"
+    public static let version = "4.4.4"
 }

--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -446,7 +446,7 @@ fileprivate struct WebViewRepresentable: UIViewRepresentable {
     class Coordinator: NSObject, UIGestureRecognizerDelegate {
         let trigger: String?
         @Binding var showControlPanel: Bool
-        var tripleTapRecognizer: FastTripleTapGestureRecognizer?
+        var tripleTapRecognizer: UITapGestureRecognizer?
 
         init(trigger: String?, showControlPanel: Binding<Bool>) {
             self.trigger = trigger

--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -446,7 +446,7 @@ fileprivate struct WebViewRepresentable: UIViewRepresentable {
     class Coordinator: NSObject, UIGestureRecognizerDelegate {
         let trigger: String?
         @Binding var showControlPanel: Bool
-        var tripleTapRecognizer: UITapGestureRecognizer?
+        var tripleTapRecognizer: UIGestureRecognizer?
 
         init(trigger: String?, showControlPanel: Binding<Bool>) {
             self.trigger = trigger

--- a/Sources/Helium/HeliumCore/ControlPanel/FastTripleTapGestureRecognizer.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/FastTripleTapGestureRecognizer.swift
@@ -28,8 +28,6 @@ final class FastTripleTapGestureRecognizer: UIGestureRecognizer {
         self.maxMovement = maxMovement
         self.maxSequenceRadius = maxSequenceRadius
         super.init(target: target, action: action)
-        cancelsTouchesInView = false
-        delaysTouchesBegan = false
         delaysTouchesEnded = false
     }
 

--- a/Sources/Helium/HeliumCore/ControlPanel/FastTripleTapGestureRecognizer.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/FastTripleTapGestureRecognizer.swift
@@ -28,6 +28,9 @@ final class FastTripleTapGestureRecognizer: UIGestureRecognizer {
         self.maxMovement = maxMovement
         self.maxSequenceRadius = maxSequenceRadius
         super.init(target: target, action: action)
+        cancelsTouchesInView = false
+        delaysTouchesBegan = false
+        delaysTouchesEnded = false
     }
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
@@ -80,6 +83,9 @@ final class FastTripleTapGestureRecognizer: UIGestureRecognizer {
         if tapCount >= requiredTaps {
             state = .recognized
         } else {
+            // Stay .possible during the inter-tap window so additional taps can
+            // accumulate; the stale timer will transition to .failed if no further
+            // tap arrives, freeing up downstream recognizers.
             scheduleStaleReset()
         }
     }
@@ -103,8 +109,14 @@ final class FastTripleTapGestureRecognizer: UIGestureRecognizer {
     private func scheduleStaleReset() {
         invalidateStaleTimer()
         staleTimer = Timer.scheduledTimer(withTimeInterval: maxIntervalBetweenTaps, repeats: false) { [weak self] _ in
-            self?.tapCount = 0
-            self?.staleTimer = nil
+            guard let self else { return }
+            staleTimer = nil
+            // Transition to .failed once the inter-tap window expires so other
+            // recognizers (e.g. WKWebView's internal click) aren't held up.
+            // reset() will zero tapCount.
+            if state == .possible {
+                state = .failed
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes touch/gesture state transitions for the control-panel triple-tap on a `WKWebView`, which can affect tap/click responsiveness and gesture interoperability. Scope is small but user-interaction sensitive.
> 
> **Overview**
> Bumps the SDK version to `4.4.4`.
> 
> Tightens the control-panel triple-tap behavior by ensuring the recognizer doesn’t delay touch delivery and transitions from `.possible` to `.failed` after the inter-tap window, helping prevent `WKWebView` taps/clicks from being held up. Also loosens `DynamicWebView`’s stored recognizer type to `UIGestureRecognizer` to simplify add/remove cleanup with the pooled webview instances.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37403340b40ba4d4c86647068b4bfc599db52059. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved triple-tap gesture recognition accuracy and responsiveness

* **Chores**
  * Version bumped to 4.4.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->