### PR TITLE
HEL-5033 increase refresh interval for debug/sandbox; expose an invalidateCach…

### DIFF
--- a/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
@@ -37,11 +37,11 @@ actor HeliumEntitlementsManager {
     }
     
     /// How long until the cache should be considered stale, in seconds.
-    private let cacheResetInterval: TimeInterval = {
+    private var cacheResetInterval: TimeInterval {
         let isProduction = AppReceiptsHelper.shared.getEnvironment() == AppReceiptsHelper.Environment.production.rawValue
         let numMinutes: TimeInterval = isProduction ? 30 : 3
         return 60 * numMinutes
-    }()
+    }
     
     /// Debounce interval for transaction updates in seconds
     private let debounceInterval: TimeInterval = 1
@@ -470,8 +470,9 @@ actor HeliumEntitlementsManager {
     func invalidateCache() async {
         cache = EntitlementsCache()
         clearPersistedEntitlements()
-        paddleEntitlementsSource.invalidateCache()
-        stripeEntitlementsSource.invalidateCache()
+        for source in allThirdPartySources {
+            source.invalidateCache()
+        }
     }
     
     func updateAfterPurchase(productID: String, transaction: Transaction?) async {

--- a/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
@@ -36,7 +36,12 @@ actor HeliumEntitlementsManager {
         return result
     }
     
-    private let cacheResetInterval: TimeInterval = 60 * 30 // in seconds
+    /// How long until the cache should be considered stale, in seconds.
+    private let cacheResetInterval: TimeInterval = {
+        let isProduction = AppReceiptsHelper.shared.getEnvironment() == AppReceiptsHelper.Environment.production.rawValue
+        let numMinutes: TimeInterval = isProduction ? 30 : 3
+        return 60 * numMinutes
+    }()
     
     /// Debounce interval for transaction updates in seconds
     private let debounceInterval: TimeInterval = 1
@@ -465,6 +470,8 @@ actor HeliumEntitlementsManager {
     func invalidateCache() async {
         cache = EntitlementsCache()
         clearPersistedEntitlements()
+        paddleEntitlementsSource.invalidateCache()
+        stripeEntitlementsSource.invalidateCache()
     }
     
     func updateAfterPurchase(productID: String, transaction: Transaction?) async {

--- a/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
@@ -131,12 +131,6 @@ actor HeliumEntitlementsManager {
         }
     }
 
-    /// Clears persisted entitlements
-    private func clearPersistedEntitlements() {
-        guard let fileURL = entitlementsFileURL else { return }
-        try? FileManager.default.removeItem(at: fileURL)
-    }
-
     deinit {
         updateListenerTask?.cancel()
         debounceTask?.cancel()
@@ -468,8 +462,8 @@ actor HeliumEntitlementsManager {
     
     /// Clears all cached data and forces a refresh on the next access.
     func invalidateCache() async {
-        cache = EntitlementsCache()
-        clearPersistedEntitlements()
+        cache.lastTransactionsLoadedTime = nil
+        cache.subscriptionStatuses.removeAll()
         for source in allThirdPartySources {
             source.invalidateCache()
         }

--- a/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
@@ -103,7 +103,7 @@ open class HeliumPaymentEntitlementsSource: ThirdPartyEntitlementsSource, @unche
 
     /// Marks the cache stale so the next read triggers a refresh. Keeps current
     /// data visible in the meantime.
-    func invalidateCache() {
+    public func invalidateCache() {
         lock.withLock {
             guard let current = cached else { return }
             cached = CachedSnapshot(

--- a/Sources/Helium/HeliumCore/ThirdPartyEntitlementsSource.swift
+++ b/Sources/Helium/HeliumCore/ThirdPartyEntitlementsSource.swift
@@ -19,4 +19,8 @@ public protocol ThirdPartyEntitlementsSource: AnyObject, Sendable {
     
     /// Returns a set of active subscriptions by product ID.
     func activeSubscriptions() async -> Set<String>
+
+    /// Called when the SDK's entitlement cache is invalidated (e.g. via `Helium.shared.invalidateEntitlementsCache()`).
+    /// Implementations should clear any cached entitlement data so the next query fetches fresh state.
+    func invalidateCache()
 }

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -921,6 +921,11 @@ public class HeliumEntitlements {
         return !productIds.isEmpty
     }
     
+    /// Clears all cached data and forces a refresh on next entitlements call.
+    public func invalidateCache() async {
+        await HeliumEntitlementsManager.shared.invalidateCache()
+    }
+    
 }
 
 @available(iOS 15.0, *)


### PR DESCRIPTION
…e function

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes entitlement caching semantics (refresh TTL and invalidate behavior) and adds a new public cache-invalidation API, which could affect when entitlement state refreshes and is relied on by paywall gating.
> 
> **Overview**
> Adjusts entitlement cache staleness to be **environment-dependent** (30 minutes in production, 3 minutes in debug/sandbox).
> 
> Adds a public `Helium.entitlements.invalidateCache()` API and updates `HeliumEntitlementsManager.invalidateCache()` to invalidate StoreKit-derived caches and **propagate invalidation to all third-party entitlement sources** via a new `ThirdPartyEntitlementsSource.invalidateCache()` requirement (including making `HeliumPaymentEntitlementsSource.invalidateCache()` public).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91b9e5934e6b6a7d9aef775eb781beaf98f88af6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new public API to manually clear cached entitlements
  * Cache reset intervals now dynamically adjust based on environment (30 minutes in production, 3 minutes otherwise)
  * Cache invalidation now comprehensively clears all related caches

<!-- end of auto-generated comment: release notes by coderabbit.ai -->