### PR TITLE
Avoid batch saves from refreshEntitledForTriggerCache

### DIFF
--- a/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
@@ -255,23 +255,6 @@ actor HeliumEntitlementsManager {
             return cache.entitledForTrigger[trigger]
         }
 
-        let changed = await computeAndCacheEntitledForTrigger(
-            trigger: trigger,
-            considerAssociatedSubscriptions: considerAssociatedSubscriptions
-        )
-        if changed {
-            saveEntitlements()
-        }
-        return cache.entitledForTrigger[trigger]
-    }
-
-    /// Computes entitlement for the given trigger and updates the in-memory cache.
-    /// Returns true if the cached value changed.
-    @discardableResult
-    private func computeAndCacheEntitledForTrigger(
-        trigger: String,
-        considerAssociatedSubscriptions: Bool
-    ) async -> Bool {
         let paywallInfo = HeliumFetchedConfigManager.shared.getPaywallInfoForTrigger(trigger) ?? HeliumFallbackViewManager.shared.getFallbackInfo(trigger: trigger)
         let productIds = paywallInfo?.productIdsIncludingWebProductIds ?? []
 
@@ -289,9 +272,11 @@ actor HeliumEntitlementsManager {
             }
         }
 
-        guard cache.entitledForTrigger[trigger] != result else { return false }
-        cache.entitledForTrigger[trigger] = result
-        return true
+        if cache.entitledForTrigger[trigger] != result {
+            cache.entitledForTrigger[trigger] = result
+            saveEntitlements()
+        }
+        return result
     }
     
     func hasAnyActiveSubscription(includeNonRenewing: Bool) async -> Bool {
@@ -469,7 +454,7 @@ actor HeliumEntitlementsManager {
         return subscriptions
     }
     
-    /// Clears all cached data and forces a refresh on the next access.
+    /// Marks caches stale so the next access refetches.
     func invalidateCache() async {
         cache.lastTransactionsLoadedTime = nil
         cache.subscriptionStatuses.removeAll()
@@ -539,16 +524,20 @@ actor HeliumEntitlementsManager {
     }
 
     /// Refreshes the entitledForTrigger cache for all known triggers.
-    /// Persists once at the end if anything changed.
     private func refreshEntitledForTriggerCache() async {
         let triggers = HeliumFetchedConfigManager.shared.getFetchedTriggerNames()
+        let purchasedIds = await purchasedProductIds()
         var anyChanged = false
         for trigger in triggers {
-            let changed = await computeAndCacheEntitledForTrigger(
-                trigger: trigger,
-                considerAssociatedSubscriptions: false
-            )
-            anyChanged = anyChanged || changed
+            guard let paywallInfo = HeliumFetchedConfigManager.shared.getPaywallInfoForTrigger(trigger) else {
+                continue
+            }
+            let productIds = paywallInfo.productIdsIncludingWebProductIds
+            let result = productIds.contains { purchasedIds.contains($0) }
+            if cache.entitledForTrigger[trigger] != result {
+                cache.entitledForTrigger[trigger] = result
+                anyChanged = true
+            }
         }
         if anyChanged {
             saveEntitlements()

--- a/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
@@ -256,12 +256,16 @@ actor HeliumEntitlementsManager {
         }
 
         let paywallInfo = HeliumFetchedConfigManager.shared.getPaywallInfoForTrigger(trigger) ?? HeliumFallbackViewManager.shared.getFallbackInfo(trigger: trigger)
+
         let productIds = paywallInfo?.productIdsIncludingWebProductIds ?? []
 
         var result: Bool
+
+        // Just see if any of the paywall products are purchased/active
         if !considerAssociatedSubscriptions {
             result = await purchasedProductIds().contains { productIds.contains($0) }
         } else {
+            // Check products and associated subscription groups
             let thirdPartyIds = await allThirdPartyEntitledProductIds()
             result = false
             for productId in productIds {
@@ -272,10 +276,12 @@ actor HeliumEntitlementsManager {
             }
         }
 
+        // Cache and persist the result for this trigger
         if cache.entitledForTrigger[trigger] != result {
             cache.entitledForTrigger[trigger] = result
             saveEntitlements()
         }
+
         return result
     }
     

--- a/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
@@ -255,17 +255,30 @@ actor HeliumEntitlementsManager {
             return cache.entitledForTrigger[trigger]
         }
 
-        let paywallInfo = HeliumFetchedConfigManager.shared.getPaywallInfoForTrigger(trigger) ?? HeliumFallbackViewManager.shared.getFallbackInfo(trigger: trigger)
+        let changed = await computeAndCacheEntitledForTrigger(
+            trigger: trigger,
+            considerAssociatedSubscriptions: considerAssociatedSubscriptions
+        )
+        if changed {
+            saveEntitlements()
+        }
+        return cache.entitledForTrigger[trigger]
+    }
 
+    /// Computes entitlement for the given trigger and updates the in-memory cache.
+    /// Returns true if the cached value changed.
+    @discardableResult
+    private func computeAndCacheEntitledForTrigger(
+        trigger: String,
+        considerAssociatedSubscriptions: Bool
+    ) async -> Bool {
+        let paywallInfo = HeliumFetchedConfigManager.shared.getPaywallInfoForTrigger(trigger) ?? HeliumFallbackViewManager.shared.getFallbackInfo(trigger: trigger)
         let productIds = paywallInfo?.productIdsIncludingWebProductIds ?? []
 
         var result: Bool
-
-        // Just see if any of the paywall products are purchased/active
         if !considerAssociatedSubscriptions {
             result = await purchasedProductIds().contains { productIds.contains($0) }
         } else {
-            // Check products and associated subscription groups
             let thirdPartyIds = await allThirdPartyEntitledProductIds()
             result = false
             for productId in productIds {
@@ -276,13 +289,9 @@ actor HeliumEntitlementsManager {
             }
         }
 
-        // Cache and persist the result for this trigger
-        if cache.entitledForTrigger[trigger] != result {
-            cache.entitledForTrigger[trigger] = result
-            saveEntitlements()
-        }
-
-        return result
+        guard cache.entitledForTrigger[trigger] != result else { return false }
+        cache.entitledForTrigger[trigger] = result
+        return true
     }
     
     func hasAnyActiveSubscription(includeNonRenewing: Bool) async -> Bool {
@@ -529,12 +538,20 @@ actor HeliumEntitlementsManager {
         }
     }
 
-    /// Refreshes the entitledForTrigger cache for all known triggers
+    /// Refreshes the entitledForTrigger cache for all known triggers.
+    /// Persists once at the end if anything changed.
     private func refreshEntitledForTriggerCache() async {
         let triggers = HeliumFetchedConfigManager.shared.getFetchedTriggerNames()
+        var anyChanged = false
         for trigger in triggers {
-            // This will compute and cache the entitlement status for each trigger
-            let _ = await hasEntitlementForPaywall(trigger: trigger, considerAssociatedSubscriptions: false)
+            let changed = await computeAndCacheEntitledForTrigger(
+                trigger: trigger,
+                considerAssociatedSubscriptions: false
+            )
+            anyChanged = anyChanged || changed
+        }
+        if anyChanged {
+            saveEntitlements()
         }
     }
     

--- a/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
@@ -61,7 +61,8 @@ actor HeliumEntitlementsManager {
         /// Entitlements from persisted data, used before real transactions are loaded
         var persistedEntitlements: [PersistedEntitlement] = []
 
-        /// Cached entitlement status per trigger, persisted for use before paywalls load
+        /// Cached entitlement status per trigger, persisted for use before paywalls load.
+        /// Only holds strict-mode results (considerAssociatedSubscriptions == false).
         var entitledForTrigger: [String: Bool] = [:]
 
         func needsTransactionsSync(resetInterval: TimeInterval) -> Bool {
@@ -250,9 +251,18 @@ actor HeliumEntitlementsManager {
         trigger: String,
         considerAssociatedSubscriptions: Bool
     ) async -> Bool? {
-        // If paywalls haven't loaded yet, use persisted trigger entitlement if available
+        // If paywalls haven't loaded yet, use persisted trigger entitlement if available (which cached should reflect)
         if !Helium.shared.paywallsLoaded() {
-            return cache.entitledForTrigger[trigger]
+            let cachedResult = cache.entitledForTrigger[trigger]
+            if !considerAssociatedSubscriptions {
+                return cachedResult
+            } else {
+                if cachedResult == true {
+                    return true
+                }
+                // We do not know for sure since we cannot look at associated subscriptions, so return nil
+                return nil
+            }
         }
 
         let paywallInfo = HeliumFetchedConfigManager.shared.getPaywallInfoForTrigger(trigger) ?? HeliumFallbackViewManager.shared.getFallbackInfo(trigger: trigger)
@@ -276,8 +286,8 @@ actor HeliumEntitlementsManager {
             }
         }
 
-        // Cache and persist the result for this trigger
-        if cache.entitledForTrigger[trigger] != result {
+        // Only cache the strict (false) mode result.
+        if !considerAssociatedSubscriptions, cache.entitledForTrigger[trigger] != result {
             cache.entitledForTrigger[trigger] = result
             saveEntitlements()
         }

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -921,7 +921,7 @@ public class HeliumEntitlements {
         return !productIds.isEmpty
     }
     
-    /// Clears all cached data and forces a refresh on next entitlements call.
+    /// Invalidates cached entitlements data and forces a refresh on next entitlements call.
     public func invalidateCache() async {
         await HeliumEntitlementsManager.shared.invalidateCache()
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes entitlement caching/persistence behavior used to gate paywall display; incorrect caching could cause false entitled/not-entitled results before paywalls load. Scope is limited to cache invalidation and trigger-level entitlement refresh logic.
> 
> **Overview**
> Optimizes how paywall-trigger entitlement results are cached and persisted to disk to avoid repeated writes during refresh.
> 
> `hasEntitlementForPaywall` now only persists results for *strict mode* (`considerAssociatedSubscriptions == false`) and returns `nil` (unknown) for non-strict checks when paywalls aren’t loaded, unless the cached strict result is already `true`.
> 
> `refreshEntitledForTriggerCache` is rewritten to compute results from `purchasedProductIds()` in-memory across all triggers and call `saveEntitlements()` once only if any trigger value changed; `invalidateCache` is clarified to mark caches stale (not fully clear all data).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e779623407985559d6b13a1af17e0dd266a544f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public purchase API that performs app-account-token validation and automatic token handling for purchases, plus a clear error for token mismatches.
* **Refactor**
  * Improved entitlement computation and in-memory caching to reduce redundant persistence and make paywall entitlement checks more efficient and reliable.
* **Documentation**
  * Clarified cache invalidation wording to reflect that cached entitlements are marked stale rather than fully cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->