### PR TITLE
HEL-5355 Ctx anon id and user id and segment context

### DIFF
--- a/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
@@ -209,7 +209,8 @@ class HeliumActionsDelegate: ObservableObject {
         let pressedEvent = PurchasePressedEvent(
             productId: selectedProductId,
             triggerName: trigger,
-            paywallName: paywallInfo.paywallTemplateName
+            paywallName: paywallInfo.paywallTemplateName,
+            paymentProcessor: HeliumPaymentProcessor.resolve(for: selectedProductId)
         )
         HeliumPaywallDelegateWrapper.shared.fireEvent(pressedEvent, paywallSession: paywallSession)
 

--- a/Sources/Helium/HeliumCore/HeliumAnalyticsManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumAnalyticsManager.swift
@@ -267,6 +267,10 @@ class HeliumAnalyticsManager {
             self?.analytics?.flush()
         }
     }
+    
+    func getActiveAnalyticsInstance() -> Analytics? {
+        return analytics
+    }
 
     // MARK: - Testing
 

--- a/Sources/Helium/HeliumCore/HeliumAnalyticsManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumAnalyticsManager.swift
@@ -269,7 +269,7 @@ class HeliumAnalyticsManager {
     }
     
     func getActiveAnalyticsInstance() -> Analytics? {
-        return analytics
+        return queue.sync { analytics }
     }
 
     // MARK: - Testing

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -68,19 +68,8 @@ class HeliumPaywallDelegateWrapper {
         
         let transactionStatus: HeliumPaywallTransactionStatus
 
-        let allStripeProductIds = Array((HeliumFetchedConfigManager.shared.getStripeProductsPriceMap() ?? [:]).keys)
+        let paymentProcessor = HeliumPaymentProcessor.resolve(for: productKey)
         let stripeApplePayFlowEnabled = ApplePayHelper.shared.getStripeApplePayAvailable()
-
-        let allPaddleProductIds = Array((HeliumFetchedConfigManager.shared.getPaddleProductsPriceMap() ?? [:]).keys)
-
-        let paymentProcessor: HeliumPaymentProcessor
-        if allStripeProductIds.contains(productKey) {
-            paymentProcessor = .stripe
-        } else if allPaddleProductIds.contains(productKey) {
-            paymentProcessor = .paddle
-        } else {
-            paymentProcessor = .appStore
-        }
 
         if paymentProcessor == .stripe && !stripeApplePayFlowEnabled {
             do {

--- a/Sources/Helium/HeliumCore/Models.swift
+++ b/Sources/Helium/HeliumCore/Models.swift
@@ -196,8 +196,8 @@ public enum HeliumPaywallEvent: Codable {
     case initializeCalled
     case ctaPressed(ctaName: String, triggerName: String, paywallTemplateName: String)
     case offerSelected(productKey: String, triggerName: String, paywallTemplateName: String)
-    case subscriptionPressed(productKey: String, triggerName: String, paywallTemplateName: String)
-    case subscriptionCancelled(productKey: String, triggerName: String, paywallTemplateName: String)
+    case subscriptionPressed(productKey: String, triggerName: String, paywallTemplateName: String, paymentProcessor: HeliumPaymentProcessor)
+    case subscriptionCancelled(productKey: String, triggerName: String, paywallTemplateName: String, paymentProcessor: HeliumPaymentProcessor)
     case subscriptionSucceeded(productKey: String, triggerName: String, paywallTemplateName: String, storeKitTransactionId: String?, storeKitOriginalTransactionId: String?, skPostPurchaseTxnTimeMS: UInt64?, canonicalJoinTransactionId: String?, paymentProcessor: HeliumPaymentProcessor)
     case subscriptionFailed(productKey: String, triggerName: String, paywallTemplateName: String, error: String? = nil, paymentProcessor: HeliumPaymentProcessor)
     case subscriptionRestored(productKey: String, triggerName: String, paywallTemplateName: String, restoreOrigin: PurchaseRestoredOrigin)
@@ -228,11 +228,11 @@ public enum HeliumPaywallEvent: Codable {
         case .ctaPressed(let ctaName, let triggerName, let paywallTemplateName):
             return triggerName;
             
-        case .offerSelected(let productKey, let triggerName, let paywallTemplateName),
-             .subscriptionPressed(let productKey, let triggerName, let paywallTemplateName),
-             .subscriptionCancelled(let productKey, let triggerName, let paywallTemplateName),
-             .subscriptionPending(let productKey, let triggerName, let paywallTemplateName),
-             .purchaseAlreadyEntitled(let productKey, let triggerName, let paywallTemplateName, let _, let _):
+        case .offerSelected(_, let triggerName, _),
+             .subscriptionPressed(_, let triggerName, _, _),
+             .subscriptionCancelled(_, let triggerName, _, _),
+             .subscriptionPending(_, let triggerName, _),
+             .purchaseAlreadyEntitled(_, let triggerName, _, _, _):
 
             return triggerName;
         case .subscriptionSucceeded(_, let triggerName, _, _, _, _, _, _):
@@ -273,11 +273,11 @@ public enum HeliumPaywallEvent: Codable {
         switch self {
         case .ctaPressed(let ctaName, let triggerName, let paywallTemplateName):
             return paywallTemplateName;
-        case .offerSelected(let productKey, let triggerName, let paywallTemplateName),
-             .subscriptionPressed(let productKey, let triggerName, let paywallTemplateName),
-             .subscriptionCancelled(let productKey, let triggerName, let paywallTemplateName),
-             .subscriptionPending(let productKey, let triggerName, let paywallTemplateName),
-             .purchaseAlreadyEntitled(let productKey, let triggerName, let paywallTemplateName, let _, let _):
+        case .offerSelected(_, _, let paywallTemplateName),
+             .subscriptionPressed(_, _, let paywallTemplateName, _),
+             .subscriptionCancelled(_, _, let paywallTemplateName, _),
+             .subscriptionPending(_, _, let paywallTemplateName),
+             .purchaseAlreadyEntitled(_, _, let paywallTemplateName, _, _):
             return paywallTemplateName;
         case .subscriptionSucceeded(_, _, let paywallTemplateName, _, _, _, _, _):
             return paywallTemplateName
@@ -332,13 +332,18 @@ public enum HeliumPaywallEvent: Codable {
             try container.encode(paywallTemplateName, forKey: .paywallTemplateName)
             try container.encode(restoreOrigin, forKey: .restoreOrigin)
         case .offerSelected(let productKey, let triggerName, let paywallTemplateName),
-             .subscriptionPressed(let productKey, let triggerName, let paywallTemplateName),
-             .subscriptionCancelled(let productKey, let triggerName, let paywallTemplateName),
              .subscriptionPending(let productKey, let triggerName, let paywallTemplateName):
             try container.encode(String(describing: self).components(separatedBy: "(")[0], forKey: .type)
             try container.encode(productKey, forKey: .productKey)
             try container.encode(triggerName, forKey: .triggerName)
             try container.encode(paywallTemplateName, forKey: .paywallTemplateName)
+        case .subscriptionPressed(let productKey, let triggerName, let paywallTemplateName, let paymentProcessor),
+             .subscriptionCancelled(let productKey, let triggerName, let paywallTemplateName, let paymentProcessor):
+            try container.encode(String(describing: self).components(separatedBy: "(")[0], forKey: .type)
+            try container.encode(productKey, forKey: .productKey)
+            try container.encode(triggerName, forKey: .triggerName)
+            try container.encode(paywallTemplateName, forKey: .paywallTemplateName)
+            try container.encode(paymentProcessor, forKey: .paymentProcessor)
         case .subscriptionFailed(let productKey, let triggerName, let paywallTemplateName, let error, let paymentProcessor):
             try container.encode(String(describing: self).components(separatedBy: "(")[0], forKey: .type)
             try container.encode(productKey, forKey: .productKey)
@@ -457,12 +462,14 @@ public enum HeliumPaywallEvent: Codable {
             let productKey = try container.decode(String.self, forKey: .productKey)
             let triggerName = try container.decode(String.self, forKey: .triggerName)
             let paywallTemplateName = try container.decode(String.self, forKey: .paywallTemplateName)
-            self = .subscriptionPressed(productKey: productKey, triggerName: triggerName, paywallTemplateName: paywallTemplateName)
+            let paymentProcessor = try container.decodeIfPresent(HeliumPaymentProcessor.self, forKey: .paymentProcessor) ?? .appStore
+            self = .subscriptionPressed(productKey: productKey, triggerName: triggerName, paywallTemplateName: paywallTemplateName, paymentProcessor: paymentProcessor)
         case "subscriptionCancelled":
             let productKey = try container.decode(String.self, forKey: .productKey)
             let triggerName = try container.decode(String.self, forKey: .triggerName)
             let paywallTemplateName = try container.decode(String.self, forKey: .paywallTemplateName)
-            self = .subscriptionCancelled(productKey: productKey, triggerName: triggerName, paywallTemplateName: paywallTemplateName)
+            let paymentProcessor = try container.decodeIfPresent(HeliumPaymentProcessor.self, forKey: .paymentProcessor) ?? .appStore
+            self = .subscriptionCancelled(productKey: productKey, triggerName: triggerName, paywallTemplateName: paywallTemplateName, paymentProcessor: paymentProcessor)
         case "subscriptionSucceeded":
             let productKey = try container.decode(String.self, forKey: .productKey)
             let triggerName = try container.decode(String.self, forKey: .triggerName)
@@ -623,13 +630,17 @@ public enum HeliumPaywallEvent: Codable {
             dict["paywallTemplateName"] = paywallTemplateName
             
         case .offerSelected(let productKey, let triggerName, let paywallTemplateName),
-             .subscriptionPressed(let productKey, let triggerName, let paywallTemplateName),
-             .subscriptionCancelled(let productKey, let triggerName, let paywallTemplateName),
              .subscriptionPending(let productKey, let triggerName, let paywallTemplateName),
              .purchaseAlreadyEntitled(let productKey, let triggerName, let paywallTemplateName, _, _):
             dict["productKey"] = productKey
             dict["triggerName"] = triggerName
             dict["paywallTemplateName"] = paywallTemplateName
+        case .subscriptionPressed(let productKey, let triggerName, let paywallTemplateName, let paymentProcessor),
+             .subscriptionCancelled(let productKey, let triggerName, let paywallTemplateName, let paymentProcessor):
+            dict["productKey"] = productKey
+            dict["triggerName"] = triggerName
+            dict["paywallTemplateName"] = paywallTemplateName
+            dict["paymentProcessor"] = paymentProcessor.rawValue
         case .subscriptionSucceeded(let productKey, let triggerName, let paywallTemplateName, _, _, _, _, let paymentProcessor):
             dict["productKey"] = productKey
             dict["triggerName"] = triggerName

--- a/Sources/Helium/HeliumCore/PaywallEvents.swift
+++ b/Sources/Helium/HeliumCore/PaywallEvents.swift
@@ -505,20 +505,24 @@ public struct PurchasePressedEvent: ProductEvent {
     /// The name/identifier of the paywall template where purchase was initiated
     /// - Note: Template name from Helium configuration
     public let paywallName: String
-    
+
+    /// Which payment processor the purchase is being initiated through.
+    public let paymentProcessor: HeliumPaymentProcessor
+
     /// When this event occurred
     /// - Note: Captured using Date() at event creation time
     public let timestamp: Date
-    
-    public init(productId: String, triggerName: String, paywallName: String, timestamp: Date = Date()) {
+
+    public init(productId: String, triggerName: String, paywallName: String, paymentProcessor: HeliumPaymentProcessor, timestamp: Date = Date()) {
         self.productId = productId
         self.triggerName = triggerName
         self.paywallName = paywallName
+        self.paymentProcessor = paymentProcessor
         self.timestamp = timestamp
     }
-    
+
     public var eventName: String { "purchasePressed" }
-    
+
     public func toDictionary() -> [String: Any] {
         return [
             "type": eventName,
@@ -526,12 +530,13 @@ public struct PurchasePressedEvent: ProductEvent {
             "triggerName": triggerName,
             "paywallName": paywallName,
             "isSecondTry": isSecondTry,
+            "paymentProcessor": paymentProcessor.rawValue,
             "timestamp": timestamp.timeIntervalSince1970
         ]
     }
-    
+
     public func toLegacyEvent() -> HeliumPaywallEvent {
-        return .subscriptionPressed(productKey: productId, triggerName: triggerName, paywallTemplateName: paywallName)
+        return .subscriptionPressed(productKey: productId, triggerName: triggerName, paywallTemplateName: paywallName, paymentProcessor: paymentProcessor)
     }
 }
 
@@ -540,6 +545,16 @@ public enum HeliumPaymentProcessor: String, Codable, Sendable {
     case appStore
     case stripe
     case paddle
+
+    static func resolve(for productKey: String) -> HeliumPaymentProcessor {
+        if HeliumFetchedConfigManager.shared.getStripeProductsPriceMap()?[productKey] != nil {
+            return .stripe
+        }
+        if HeliumFetchedConfigManager.shared.getPaddleProductsPriceMap()?[productKey] != nil {
+            return .paddle
+        }
+        return .appStore
+    }
 }
 
 /// Event fired when a purchase completes successfully.
@@ -659,7 +674,7 @@ public struct PurchaseCancelledEvent: ProductEvent {
     }
     
     public func toLegacyEvent() -> HeliumPaywallEvent {
-        return .subscriptionCancelled(productKey: productId, triggerName: triggerName, paywallTemplateName: paywallName)
+        return .subscriptionCancelled(productKey: productId, triggerName: triggerName, paywallTemplateName: paywallName, paymentProcessor: paymentProcessor)
     }
 }
 

--- a/Sources/Helium/HeliumCore/PaywallEvents.swift
+++ b/Sources/Helium/HeliumCore/PaywallEvents.swift
@@ -358,6 +358,8 @@ public struct PaywallButtonPressedEvent: PaywallContextEvent {
     /// - Note: Template name from Helium configuration
     public let paywallName: String
     
+    //add source to these...
+    
     /// When this event occurred
     /// - Note: Captured using Date() at event creation time
     public let timestamp: Date

--- a/Sources/Helium/HeliumCore/PaywallEvents.swift
+++ b/Sources/Helium/HeliumCore/PaywallEvents.swift
@@ -358,8 +358,6 @@ public struct PaywallButtonPressedEvent: PaywallContextEvent {
     /// - Note: Template name from Helium configuration
     public let paywallName: String
     
-    //add source to these...
-    
     /// When this event occurred
     /// - Note: Captured using Date() at event creation time
     public let timestamp: Date

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -143,11 +143,15 @@ public class ExternalWebCheckoutManager: NSObject {
         let analyticsJSON = try JSONSerialization.jsonObject(with: analyticsData)
         ctx["analytics"] = analyticsJSON
         
-        if let segmentAnonymousId = HeliumAnalyticsManager.shared.getActiveAnalyticsInstance()?.anonymousId {
-            ctx["anonymousId"] = segmentAnonymousId
+        var analyticsTopFields: [String: Any] = [:]
+        if let userId = Helium.identify.userId {
+            analyticsTopFields["userId"] = userId
         }
-        
-        ctx["context"] = SegmentContext.staticContextData()
+        if let segmentAnonymousId = HeliumAnalyticsManager.shared.getActiveAnalyticsInstance()?.anonymousId {
+            analyticsTopFields["anonymousId"] = segmentAnonymousId
+        }
+        analyticsTopFields["context"] = SegmentContext.staticContextData()
+        ctx["analyticsTopFields"] = analyticsTopFields
 
         ctx[provider.initialProductKey] = productKey
         ctx["successUrl"] = successURL

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -142,6 +142,12 @@ public class ExternalWebCheckoutManager: NSObject {
         let analyticsData = try JSONEncoder().encode(analyticsEvent)
         let analyticsJSON = try JSONSerialization.jsonObject(with: analyticsData)
         ctx["analytics"] = analyticsJSON
+        
+        if let segmentAnonymousId = HeliumAnalyticsManager.shared.getActiveAnalyticsInstance()?.anonymousId {
+            ctx["anonymousId"] = segmentAnonymousId
+        }
+        
+        ctx["context"] = SegmentContext.staticContextData()
 
         ctx[provider.initialProductKey] = productKey
         ctx["successUrl"] = successURL

--- a/Tests/helium-swiftTests/EventListenerTests.swift
+++ b/Tests/helium-swiftTests/EventListenerTests.swift
@@ -68,7 +68,7 @@ final class EventListenerTests: HeliumTestCase {
         XCTAssertEqual(anyEvents.count, 1)
 
         // Another PaywallContextEvent
-        handlers.handleEvent(PurchasePressedEvent(productId: "prod", triggerName: "t", paywallName: "p"))
+        handlers.handleEvent(PurchasePressedEvent(productId: "prod", triggerName: "t", paywallName: "p", paymentProcessor: .appStore))
         XCTAssertEqual(anyEvents.count, 2)
 
         // PaywallSkippedEvent is NOT a PaywallContextEvent

--- a/Tests/helium-swiftTests/EventToDictionaryTests.swift
+++ b/Tests/helium-swiftTests/EventToDictionaryTests.swift
@@ -76,7 +76,7 @@ final class EventToDictionaryTests: XCTestCase {
             PaywallButtonPressedEvent(buttonName: "btn", triggerName: "t", paywallName: "p"),
             CustomPaywallActionEvent(actionName: "a", params: [:], triggerName: "t", paywallName: "p"),
             ProductSelectedEvent(productId: "prod", triggerName: "t", paywallName: "p"),
-            PurchasePressedEvent(productId: "prod", triggerName: "t", paywallName: "p"),
+            PurchasePressedEvent(productId: "prod", triggerName: "t", paywallName: "p", paymentProcessor: .appStore),
             PurchaseSucceededEvent(productId: "prod", triggerName: "t", paywallName: "p", storeKitTransactionId: nil, storeKitOriginalTransactionId: nil),
             PurchaseCancelledEvent(productId: "prod", triggerName: "t", paywallName: "p", paymentProcessor: .appStore),
             PurchaseFailedEvent(productId: "prod", triggerName: "t", paywallName: "p", paymentProcessor: .appStore),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates purchase/analytics event schemas (adds `paymentProcessor` plus extra top-level analytics fields) and changes how payment processor is resolved, which can affect downstream analytics consumers and web-checkout attribution if mismatched.
> 
> **Overview**
> **Improves purchase analytics attribution** by adding `paymentProcessor` to `PurchasePressedEvent` and propagating it into legacy `HeliumPaywallEvent.subscriptionPressed`/`.subscriptionCancelled`, including Codable encode/decode + dictionary output changes with a default fallback to `.appStore` for older payloads.
> 
> **Refactors payment processor selection** to a shared `HeliumPaymentProcessor.resolve(for:)` helper and uses it in `HeliumPaywallDelegateWrapper.handlePurchase` and `HeliumActionsDelegate.makePurchase`.
> 
> **Enriches external web checkout ctx payloads** by adding `userId`, Segment `anonymousId` (via new `HeliumAnalyticsManager.getActiveAnalyticsInstance()` accessor), and `SegmentContext.staticContextData()` into `ctx["analyticsTopFields"]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e48488d033745c3d57d1da6fc9f06ffda6f888d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Purchase events now include payment-processor information for improved tracking.
  * Added an accessor to retrieve the active analytics instance.
  * External checkout URLs now include condensed analytics top-level fields (user and segment context).

* **Refactor**
  * Simplified payment-processor selection logic during checkout handling.

* **Tests**
  * Updated test fixtures to include the new payment-processor field.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudcaptainai/helium-swift/pull/271)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->