### PR TITLE
return redirect type to sdk integrator after external web checkout

### DIFF
--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -472,7 +472,7 @@ public class ExternalWebCheckoutManager: NSObject {
     /// so observations are kept and the foreground observer is re-armed so a later
     /// purchase still gets picked up on the next app return.
     @MainActor
-    func handleExternalReturn(redirectKind: CheckoutRedirectKind) async {
+    func handleExternalReturn(redirectKind: HeliumCheckoutRedirectType) async {
         guard !activeCheckoutObservations.isEmpty else { return }
 
         // Redirect is authoritative — suppress the foreground-observer safety net
@@ -488,8 +488,8 @@ public class ExternalWebCheckoutManager: NSObject {
             if !activeCheckoutObservations.isEmpty {
                 armForegroundObserverAfterBackground()
             }
-        case .cancel:
-            HeliumLogger.log(.debug, category: .entitlements, "\(provider.displayName) cancel redirect handled — observations kept in case user resumes checkout")
+        case .cancel, .paymentFailure:
+            HeliumLogger.log(.debug, category: .entitlements, "\(provider.displayName) \(redirectKind.rawValue) redirect handled — observations kept in case user resumes checkout")
             armForegroundObserverAfterBackground()
         }
     }

--- a/Sources/Helium/HeliumCore/StripeCheckout/WebCheckoutModels.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/WebCheckoutModels.swift
@@ -1,9 +1,10 @@
 import Foundation
 
 /// Which of the configured checkout redirect URLs the user returned through.
-enum CheckoutRedirectKind: String {
+public enum HeliumCheckoutRedirectType: String {
     case success
     case cancel
+    case paymentFailure
 }
 
 // MARK: - URL Constants
@@ -16,7 +17,7 @@ enum WebCheckoutRedirect {
     /// our checkout flow disambiguate. Returns `nil` if the URL doesn't match, or
     /// if success/cancel collide and query params aren't conclusive — those go to
     /// the didBecomeActive observer, which reconciles against real entitlement state.
-    static func classify(_ url: URL) -> CheckoutRedirectKind? {
+    static func classify(_ url: URL) -> HeliumCheckoutRedirectType? {
         let matchesSuccess = matchesBase(url, configured: Helium.config.checkoutSuccessURL)
         let matchesCancel = matchesBase(url, configured: Helium.config.checkoutCancelURL)
 
@@ -32,7 +33,7 @@ enum WebCheckoutRedirect {
         }
     }
 
-    private static func classifyByQueryParams(_ url: URL) -> CheckoutRedirectKind? {
+    private static func classifyByQueryParams(_ url: URL) -> HeliumCheckoutRedirectType? {
         let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
         func value(_ name: String) -> String? {
             queryItems.first(where: { $0.name == name })?.value
@@ -45,8 +46,7 @@ enum WebCheckoutRedirect {
             return .success
         }
         if let error = value("error"), !error.isEmpty {
-            // technically this is a payment failure but for now we treat as cancel
-            return .cancel
+            return .paymentFailure
         }
         if queryItems.isEmpty {
             return .cancel

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -404,13 +404,13 @@ public class Helium {
     /// - Parameter url: The URL the host app received.
     /// - Returns: `true` if the URL was a Helium checkout redirect and is being processed.
     @discardableResult
-    public func handleURL(_ url: URL) -> Bool {
+    public func handleURL(_ url: URL) -> HeliumCheckoutRedirectType? {
         guard Helium.config.webCheckoutEnabled else {
-            return false
+            return nil
         }
 
         guard let redirectKind = WebCheckoutRedirect.classify(url) else {
-            return false
+            return nil
         }
         
         HeliumLogger.log(.debug, category: .core, "Handling return URL from external checkout.", metadata: [
@@ -422,7 +422,7 @@ public class Helium {
             await StripeCheckoutManager.shared.handleExternalReturn(redirectKind: redirectKind)
             await PaddleCheckoutManager.shared.handleExternalReturn(redirectKind: redirectKind)
         }
-        return true
+        return redirectKind
     }
 
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Public API change: `Helium.handleURL(_:)` now returns an optional redirect type instead of `Bool`, which can break SDK integrators expecting the old signature. Behavior changes slightly by distinguishing `paymentFailure` from `cancel` in redirect classification/logging.
> 
> **Overview**
> Expose the external web checkout redirect classification to SDK integrators by changing `Helium.handleURL(_:)` to return `HeliumCheckoutRedirectType?` (instead of `Bool`).
> 
> Rename and publish the redirect enum (`HeliumCheckoutRedirectType`) and add a new `.paymentFailure` case; URL classification now maps `error=...` query params to this case, and `ExternalWebCheckoutManager.handleExternalReturn` treats `.paymentFailure` like cancel (keeps observations and re-arms the foreground observer) while improving redirect-specific logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eb75450b5c01fa04aca2bff99875534d36a5ea2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->