### PR TITLE
sdk 28 paddle block ip geo ca purchases

### DIFF
--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -115,9 +115,7 @@ public class ExternalWebCheckoutManager: NSObject {
                 return .preCheckResolved
             }
 
-            if PaddleCheckoutPrefetchCoordinator.tappedCaliforniaBlocked(
-                in: outcomes, tappedPriceId: tappedPriceId
-            ) {
+            if PaddleCheckoutPrefetchCoordinator.anyCaliforniaBlocked(in: outcomes) {
                 HeliumLogger.log(.debug, category: .entitlements,
                                  "\(provider.displayName) prefetch blocked for California IP — failing checkout")
                 throw WebCheckoutError.californiaBuyerBlocked

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -115,6 +115,14 @@ public class ExternalWebCheckoutManager: NSObject {
                 return .preCheckResolved
             }
 
+            if PaddleCheckoutPrefetchCoordinator.tappedCaliforniaBlocked(
+                in: outcomes, tappedPriceId: tappedPriceId
+            ) {
+                HeliumLogger.log(.debug, category: .entitlements,
+                                 "\(provider.displayName) prefetch blocked for California IP — failing checkout")
+                throw WebCheckoutError.californiaBuyerBlocked
+            }
+
             paddleBootstrapsDict = PaddleCheckoutPrefetchCoordinator.encodeBootstrapsToCtx(
                 outcomesByPriceId: outcomes
             )

--- a/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
@@ -23,6 +23,14 @@ struct PaddlePrefetchAwaitTimeout: LocalizedError {
     }
 }
 
+struct PaddleCaliforniaBlocked: LocalizedError {
+    let postalCode: String
+
+    var errorDescription: String? {
+        return "Paddle prefetch blocked for California IP (postal \(postalCode))"
+    }
+}
+
 enum PaddlePrefetchOutcome {
     case ready(
         bandit: PaddleCreateTransactionForPaywallResponse,
@@ -356,6 +364,17 @@ final class PaddleCheckoutPrefetchCoordinator {
         return nil
     }
 
+    nonisolated static func tappedCaliforniaBlocked(
+        in outcomes: [String: PaddlePrefetchOutcome],
+        tappedPriceId: String
+    ) -> Bool {
+        if case let .failed(error) = outcomes[tappedPriceId] ?? .notStarted,
+           error is PaddleCaliforniaBlocked {
+            return true
+        }
+        return false
+    }
+
     // MARK: - Composite key helpers
 
     /// "pro_xxx:pri_yyy" → "pri_yyy". Returns nil for malformed input.
@@ -404,9 +423,26 @@ final class PaddleCheckoutPrefetchCoordinator {
                 paddleClientToken: paddleClientToken,
                 iosBundleId: iosBundleId
             )
+            if let caPostal = californiaPostalCode(in: paddleResult.rawBody) {
+                return .failed(error: PaddleCaliforniaBlocked(postalCode: caPostal))
+            }
             return .ready(bandit: banditResponse, paddle: paddleResult)
         } catch {
             return .failed(error: error)
         }
+    }
+
+    /// Returns the postal code when the response's IP-geo is a US California
+    /// ZIP (90001–96162, contiguous; HI starts at 96701). Nil otherwise.
+    private nonisolated static func californiaPostalCode(in rawBody: Data) -> String? {
+        guard let parsed = (try? JSONSerialization.jsonObject(with: rawBody)) as? [String: Any],
+              let data = parsed["data"] as? [String: Any],
+              (data["ip_geo_country_code"] as? String) == "US",
+              let postal = data["ip_geo_postal_code"] as? String,
+              let zip = Int(postal.prefix(5)),
+              (90001...96162).contains(zip) else {
+            return nil
+        }
+        return postal
     }
 }

--- a/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
@@ -364,15 +364,15 @@ final class PaddleCheckoutPrefetchCoordinator {
         return nil
     }
 
-    nonisolated static func tappedCaliforniaBlocked(
-        in outcomes: [String: PaddlePrefetchOutcome],
-        tappedPriceId: String
+    nonisolated static func anyCaliforniaBlocked(
+        in outcomes: [String: PaddlePrefetchOutcome]
     ) -> Bool {
-        if case let .failed(error) = outcomes[tappedPriceId] ?? .notStarted,
-           error is PaddleCaliforniaBlocked {
-            return true
+        return outcomes.values.contains { outcome in
+            if case let .failed(error) = outcome, error is PaddleCaliforniaBlocked {
+                return true
+            }
+            return false
         }
-        return false
     }
 
     // MARK: - Composite key helpers

--- a/Sources/Helium/HeliumCore/StripeCheckout/WebCheckoutModels.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/WebCheckoutModels.swift
@@ -258,6 +258,7 @@ enum WebCheckoutError: LocalizedError {
     case failedToBuildEnrichedURL
     case failedToOpenEnrichedURL
     case webPaywallBundleUrlMissing
+    case californiaBuyerBlocked
 
     var errorDescription: String? {
         switch self {
@@ -271,6 +272,8 @@ enum WebCheckoutError: LocalizedError {
             return "Could not open enriched checkout URL in browser."
         case .webPaywallBundleUrlMissing:
             return "No web paywall bundle URL available for this paywall."
+        case .californiaBuyerBlocked:
+            return "Checkout not available for California buyers."
         }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds geo-based blocking logic to the Paddle web checkout path by parsing Paddle BFF responses for US/CA postal codes and failing checkout early; incorrect parsing/ranges could wrongly block or allow buyers.
> 
> **Overview**
> Adds a California IP restriction to the Paddle external web checkout flow.
> 
> `PaddleCheckoutPrefetchCoordinator` now inspects the Paddle BFF `createTransactionCheckout` response for US postal codes in the California ZIP range and records a `PaddleCaliforniaBlocked` failure; `ExternalWebCheckoutManager` detects this outcome and aborts checkout by throwing a new `WebCheckoutError.californiaBuyerBlocked` with a user-facing message instead of opening the browser.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d5ecf2e5d7211b7b4585a9b3f81d70796aaca20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added geographic restriction to block checkout for users in California, displaying an appropriate error message when checkout is unavailable due to regional compliance requirements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudcaptainai/helium-swift/pull/273)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->