### PR TITLE
hel 5381 paddle checkout fetch observability

### DIFF
--- a/Sources/Helium/HeliumCore/Observability/ExternalWebCheckoutManager+Observability.swift
+++ b/Sources/Helium/HeliumCore/Observability/ExternalWebCheckoutManager+Observability.swift
@@ -2,10 +2,6 @@ import Foundation
 
 extension ExternalWebCheckoutManager {
 
-    /// Wraps a checkout-flow body with start/resolve telemetry. The body runs
-    /// inside a do/catch: a normal return emits `web_checkout_flow_resolved`
-    /// with the mapped success outcome; a thrown error emits it with
-    /// `.error` + errorClass/errorMessage and re-throws.
     @MainActor
     func withFlowTelemetry(
         productKey: String,
@@ -52,7 +48,6 @@ extension ExternalWebCheckoutManager {
         }
     }
 
-    /// Tallies prefetch outcomes by kind and emits `paddle_prefetch_await_resolved`.
     func emitPaddleAwaitResolved(
         tappedPriceId: String,
         awaitDurationMs: Int,

--- a/Sources/Helium/HeliumCore/Observability/ExternalWebCheckoutManager+Observability.swift
+++ b/Sources/Helium/HeliumCore/Observability/ExternalWebCheckoutManager+Observability.swift
@@ -9,9 +9,10 @@ extension ExternalWebCheckoutManager {
         _ body: () async throws -> WebCheckoutOutcome
     ) async throws -> WebCheckoutOutcome {
         let flowStart = Date()
+        let scope = paywallSession.observabilityScope
         HeliumObservabilityManager.shared.track(
             WebCheckoutFlowStarted(provider: provider.providerSlug, productKey: productKey),
-            paywallSession: paywallSession
+            scope: scope
         )
         do {
             let result = try await body()
@@ -28,7 +29,7 @@ extension ExternalWebCheckoutManager {
                     errorClass: nil, errorMessage: nil,
                     totalDurationMs: msSince(flowStart)
                 ),
-                paywallSession: paywallSession
+                scope: scope
             )
             return result
         } catch {
@@ -42,7 +43,7 @@ extension ExternalWebCheckoutManager {
                     errorMessage: decomposed.errorMessage,
                     totalDurationMs: msSince(flowStart)
                 ),
-                paywallSession: paywallSession
+                scope: scope
             )
             throw error
         }
@@ -79,7 +80,7 @@ extension ExternalWebCheckoutManager {
                 notStartedCount: notStarted,
                 shortCircuited: shortCircuited
             ),
-            paywallSession: paywallSession
+            scope: paywallSession.observabilityScope
         )
     }
 }

--- a/Sources/Helium/HeliumCore/Observability/ExternalWebCheckoutManager+Observability.swift
+++ b/Sources/Helium/HeliumCore/Observability/ExternalWebCheckoutManager+Observability.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+extension ExternalWebCheckoutManager {
+
+    /// Wraps a checkout-flow body with start/resolve telemetry. The body runs
+    /// inside a do/catch: a normal return emits `web_checkout_flow_resolved`
+    /// with the mapped success outcome; a thrown error emits it with
+    /// `.error` + errorClass/errorMessage and re-throws.
+    @MainActor
+    func withFlowTelemetry(
+        productKey: String,
+        paywallSession: PaywallSession,
+        _ body: () async throws -> WebCheckoutOutcome
+    ) async throws -> WebCheckoutOutcome {
+        let flowStart = Date()
+        HeliumObservabilityManager.shared.track(
+            WebCheckoutFlowStarted(provider: provider.providerSlug, productKey: productKey),
+            paywallSession: paywallSession
+        )
+        do {
+            let result = try await body()
+            let outcomeKind: WebCheckoutFlowOutcomeKind
+            switch result {
+            case .opened: outcomeKind = .opened
+            case .preCheckResolved: outcomeKind = .preCheckResolved
+            }
+            HeliumObservabilityManager.shared.track(
+                WebCheckoutFlowResolved(
+                    provider: provider.providerSlug,
+                    productKey: productKey,
+                    outcome: outcomeKind,
+                    errorClass: nil, errorMessage: nil,
+                    totalDurationMs: msSince(flowStart)
+                ),
+                paywallSession: paywallSession
+            )
+            return result
+        } catch {
+            let decomposed = decomposeError(error)
+            HeliumObservabilityManager.shared.track(
+                WebCheckoutFlowResolved(
+                    provider: provider.providerSlug,
+                    productKey: productKey,
+                    outcome: .error,
+                    errorClass: decomposed.errorClass,
+                    errorMessage: decomposed.errorMessage,
+                    totalDurationMs: msSince(flowStart)
+                ),
+                paywallSession: paywallSession
+            )
+            throw error
+        }
+    }
+
+    /// Tallies prefetch outcomes by kind and emits `paddle_prefetch_await_resolved`.
+    func emitPaddleAwaitResolved(
+        tappedPriceId: String,
+        awaitDurationMs: Int,
+        outcomes: [String: PaddlePrefetchOutcome],
+        shortCircuited: Bool,
+        paywallSession: PaywallSession
+    ) {
+        var ready = 0, alreadyEntitled = 0, failed = 0, caBlocked = 0, timedOut = 0, notStarted = 0
+        for outcome in outcomes.values {
+            switch outcome {
+            case .ready: ready += 1
+            case .alreadyEntitled: alreadyEntitled += 1
+            case .failed(let error):
+                if error is PaddleCaliforniaBlocked { caBlocked += 1 }
+                else if error is PaddlePrefetchAwaitTimeout { timedOut += 1 }
+                else { failed += 1 }
+            case .notStarted: notStarted += 1
+            }
+        }
+        HeliumObservabilityManager.shared.track(
+            PaddlePrefetchAwaitResolved(
+                tappedPriceId: tappedPriceId,
+                awaitDurationMs: awaitDurationMs,
+                readyCount: ready,
+                alreadyEntitledCount: alreadyEntitled,
+                failedCount: failed,
+                caBlockedCount: caBlocked,
+                timedOutCount: timedOut,
+                notStartedCount: notStarted,
+                shortCircuited: shortCircuited
+            ),
+            paywallSession: paywallSession
+        )
+    }
+}

--- a/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
+++ b/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
@@ -18,8 +18,6 @@ func msSince(_ start: Date) -> Int {
     Int(Date().timeIntervalSince(start) * 1000)
 }
 
-/// Pulls httpStatus out of the SDK's two transport error types when available.
-/// Falls back to runtime type name + localized description for other errors.
 func decomposeError(_ error: Error) -> (httpStatus: Int?, errorClass: String, errorMessage: String?) {
     if let bff = error as? PaddleBFFError {
         switch bff {

--- a/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
+++ b/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
@@ -1,0 +1,281 @@
+import Foundation
+
+/// Event for the observability pipeline. Per-event payload only — common
+/// props (identity, paywall scope, platform) are attached by the manager.
+protocol HeliumObservabilityEvent {
+    var name: String { get }
+    var properties: [String: Any] { get }
+}
+
+/// Truncates strings before they hit the wire so a stack-trace-heavy error
+/// can't blow up payload size on a per-event basis.
+func truncatedForObservability(_ s: String?, maxLength: Int = 500) -> String? {
+    guard let s, s.count > maxLength else { return s }
+    return String(s.prefix(maxLength)) + "…(truncated)"
+}
+
+func msSince(_ start: Date) -> Int {
+    Int(Date().timeIntervalSince(start) * 1000)
+}
+
+/// Pulls httpStatus out of the SDK's two transport error types when available.
+/// Falls back to runtime type name + localized description for other errors.
+func decomposeError(_ error: Error) -> (httpStatus: Int?, errorClass: String, errorMessage: String?) {
+    if let bff = error as? PaddleBFFError {
+        switch bff {
+        case .requestFailed(let statusCode, let rawBody):
+            return (statusCode, "PaddleBFFError.requestFailed", rawBody)
+        }
+    }
+    if let apiErr = error as? HeliumPaymentAPIError {
+        switch apiErr {
+        case .serverError(let statusCode, let message):
+            return (statusCode, "HeliumPaymentAPIError.serverError", message)
+        case .invalidEndpoint(let path):
+            return (nil, "HeliumPaymentAPIError.invalidEndpoint", path)
+        case .checkoutSessionNotCompleted:
+            return (nil, "HeliumPaymentAPIError.checkoutSessionNotCompleted", nil)
+        case .notInitialized:
+            return (nil, "HeliumPaymentAPIError.notInitialized", nil)
+        }
+    }
+    if let webErr = error as? WebCheckoutError {
+        return (nil, "WebCheckoutError.\(webErr)", webErr.errorDescription)
+    }
+    let className = String(describing: type(of: error))
+    let message = (error as? LocalizedError)?.errorDescription ?? "\(error)"
+    return (nil, className, message)
+}
+
+/// Shared shape for any outbound API call we instrument.
+struct EndpointCallTelemetry {
+    let durationMs: Int
+    let success: Bool
+    let httpStatus: Int?
+    let errorClass: String?
+    let errorMessage: String?
+
+    init(
+        durationMs: Int,
+        success: Bool,
+        httpStatus: Int? = nil,
+        errorClass: String? = nil,
+        errorMessage: String? = nil
+    ) {
+        self.durationMs = durationMs
+        self.success = success
+        self.httpStatus = httpStatus
+        self.errorClass = errorClass
+        self.errorMessage = truncatedForObservability(errorMessage)
+    }
+
+    var properties: [String: Any] {
+        var p: [String: Any] = [
+            "durationMs": durationMs,
+            "success": success,
+        ]
+        if let httpStatus { p["httpStatus"] = httpStatus }
+        if let errorClass { p["errorClass"] = errorClass }
+        if let errorMessage { p["errorMessage"] = errorMessage }
+        return p
+    }
+}
+
+// MARK: - Paddle prefetch
+
+struct PaddlePrefetchStarted: HeliumObservabilityEvent {
+    let priceIds: [String]
+    var name: String { "paddle_prefetch_started" }
+    var properties: [String: Any] {
+        ["priceIds": priceIds, "priceCount": priceIds.count]
+    }
+}
+
+struct PaddlePrefetchBanditCompleted: HeliumObservabilityEvent {
+    let priceId: String
+    let endpointCall: EndpointCallTelemetry
+    let alreadyEntitledCode: String?
+
+    var name: String { "paddle_prefetch_bandit_completed" }
+    var properties: [String: Any] {
+        var p = endpointCall.properties
+        p["priceId"] = priceId
+        if let alreadyEntitledCode { p["alreadyEntitledCode"] = alreadyEntitledCode }
+        return p
+    }
+}
+
+struct PaddlePrefetchBffCompleted: HeliumObservabilityEvent {
+    let priceId: String
+    let transactionId: String?
+    let endpointCall: EndpointCallTelemetry
+
+    var name: String { "paddle_prefetch_bff_completed" }
+    var properties: [String: Any] {
+        var p = endpointCall.properties
+        p["priceId"] = priceId
+        if let transactionId { p["transactionId"] = transactionId }
+        return p
+    }
+}
+
+enum PaddlePrefetchOutcomeKind: String {
+    case ready, alreadyEntitled, caBlocked, failed
+}
+
+struct PaddlePrefetchOutcomeFinalized: HeliumObservabilityEvent {
+    let priceId: String
+    let outcome: PaddlePrefetchOutcomeKind
+    let errorClass: String?
+    let totalDurationMs: Int
+    let ipGeoCountry: String?
+
+    var name: String { "paddle_prefetch_outcome_finalized" }
+    var properties: [String: Any] {
+        var p: [String: Any] = [
+            "priceId": priceId,
+            "outcome": outcome.rawValue,
+            "totalDurationMs": totalDurationMs,
+        ]
+        if let errorClass { p["errorClass"] = errorClass }
+        if let ipGeoCountry { p["ipGeoCountry"] = ipGeoCountry }
+        return p
+    }
+}
+
+struct PaddlePrefetchAwaitResolved: HeliumObservabilityEvent {
+    let tappedPriceId: String
+    let awaitDurationMs: Int
+    let readyCount: Int
+    let alreadyEntitledCount: Int
+    let failedCount: Int
+    let caBlockedCount: Int
+    let timedOutCount: Int
+    let notStartedCount: Int
+    let shortCircuited: Bool
+
+    var name: String { "paddle_prefetch_await_resolved" }
+    var properties: [String: Any] {
+        [
+            "tappedPriceId": tappedPriceId,
+            "awaitDurationMs": awaitDurationMs,
+            "readyCount": readyCount,
+            "alreadyEntitledCount": alreadyEntitledCount,
+            "failedCount": failedCount,
+            "caBlockedCount": caBlockedCount,
+            "timedOutCount": timedOutCount,
+            "notStartedCount": notStartedCount,
+            "shortCircuited": shortCircuited,
+        ]
+    }
+}
+
+// MARK: - Web checkout flow
+
+enum WebCheckoutFlowOutcomeKind: String {
+    case opened, preCheckResolved, error
+}
+
+struct WebCheckoutFlowStarted: HeliumObservabilityEvent {
+    let provider: String
+    let productKey: String
+
+    var name: String { "web_checkout_flow_started" }
+    var properties: [String: Any] {
+        ["provider": provider, "productKey": productKey]
+    }
+}
+
+struct WebCheckoutFlowResolved: HeliumObservabilityEvent {
+    let provider: String
+    let productKey: String
+    let outcome: WebCheckoutFlowOutcomeKind
+    let errorClass: String?
+    let errorMessage: String?
+    let totalDurationMs: Int
+
+    var name: String { "web_checkout_flow_resolved" }
+    var properties: [String: Any] {
+        var p: [String: Any] = [
+            "provider": provider,
+            "productKey": productKey,
+            "outcome": outcome.rawValue,
+            "totalDurationMs": totalDurationMs,
+        ]
+        if let errorClass { p["errorClass"] = errorClass }
+        if let msg = truncatedForObservability(errorMessage) { p["errorMessage"] = msg }
+        return p
+    }
+}
+
+struct WebCheckoutBrowserOpenAttempted: HeliumObservabilityEvent {
+    let provider: String
+    let success: Bool
+
+    var name: String { "web_checkout_browser_open_attempted" }
+    var properties: [String: Any] {
+        ["provider": provider, "success": success]
+    }
+}
+
+struct WebCheckoutRedirectReceived: HeliumObservabilityEvent {
+    let provider: String
+    let redirectKind: String
+    let msSinceOpen: Int?
+    let observationCount: Int
+
+    var name: String { "web_checkout_redirect_received" }
+    var properties: [String: Any] {
+        var p: [String: Any] = [
+            "provider": provider,
+            "redirectKind": redirectKind,
+            "observationCount": observationCount,
+        ]
+        if let msSinceOpen { p["msSinceOpen"] = msSinceOpen }
+        return p
+    }
+}
+
+enum WebCheckoutPurchaseDetectionSource: String {
+    case foregroundObserver, successRedirect
+}
+
+struct WebCheckoutPurchaseDetected: HeliumObservabilityEvent {
+    let provider: String
+    let productId: String
+    let source: WebCheckoutPurchaseDetectionSource
+    let retryAttempt: Int
+    let msSinceOpen: Int?
+    let wasRestore: Bool
+
+    var name: String { "web_checkout_purchase_detected" }
+    var properties: [String: Any] {
+        var p: [String: Any] = [
+            "provider": provider,
+            "productId": productId,
+            "source": source.rawValue,
+            "retryAttempt": retryAttempt,
+            "wasRestore": wasRestore,
+        ]
+        if let msSinceOpen { p["msSinceOpen"] = msSinceOpen }
+        return p
+    }
+}
+
+struct WebCheckoutPurchaseCheckExhausted: HeliumObservabilityEvent {
+    let provider: String
+    let retries: Int
+    let msSinceOpen: Int?
+    let fromSuccessRedirect: Bool
+
+    var name: String { "web_checkout_purchase_check_exhausted" }
+    var properties: [String: Any] {
+        var p: [String: Any] = [
+            "provider": provider,
+            "retries": retries,
+            "fromSuccessRedirect": fromSuccessRedirect,
+        ]
+        if let msSinceOpen { p["msSinceOpen"] = msSinceOpen }
+        return p
+    }
+}

--- a/Sources/Helium/HeliumCore/Observability/HeliumObservabilityManager.swift
+++ b/Sources/Helium/HeliumCore/Observability/HeliumObservabilityManager.swift
@@ -6,9 +6,8 @@ import UIKit
 class HeliumObservabilityManager {
     static let shared = HeliumObservabilityManager()
 
-    // TODO: replace placeholders with the real observability Jitsu writeKey + endpoint.
-    private let observabilityWriteKey = "<TBD>"
-    private let observabilityEndpoint = "<TBD>"
+    private let observabilityWriteKey = "rd7IAMin23xZal1auumIJURjaNrHIh7t:lJ8ssvJjYfGE8FT5ItaHkVwgqvOiMQjV"
+    private let observabilityEndpoint = "cmp1v4znj00002e6pt8smcti9.d.jitsu.com"
 
     private let queue = DispatchQueue(label: "com.helium.observabilityManager")
     private var analytics: Analytics?

--- a/Sources/Helium/HeliumCore/Observability/HeliumObservabilityManager.swift
+++ b/Sources/Helium/HeliumCore/Observability/HeliumObservabilityManager.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 
 /// Ops/debug telemetry pipeline. Writes to a dedicated Jitsu connection
-/// distinct from product analytics .
+/// distinct from product analytics.
 class HeliumObservabilityManager {
     static let shared = HeliumObservabilityManager()
 

--- a/Sources/Helium/HeliumCore/Observability/HeliumObservabilityManager.swift
+++ b/Sources/Helium/HeliumCore/Observability/HeliumObservabilityManager.swift
@@ -35,16 +35,13 @@ class HeliumObservabilityManager {
 
     func track(
         _ event: any HeliumObservabilityEvent,
-        paywallSession: PaywallSession? = nil
+        scope: PaywallObservabilityScope
     ) {
         let eventName = event.name
         let eventProps = event.properties
         queue.async { [weak self] in
             guard let self else { return }
-            let enriched = enrich(
-                eventProps: eventProps,
-                paywallSession: paywallSession
-            )
+            let enriched = enrich(eventProps: eventProps, scope: scope)
             let send: (Analytics) -> Void = { analytics in
                 analytics.track(name: eventName, properties: enriched)
             }
@@ -58,7 +55,7 @@ class HeliumObservabilityManager {
 
     private func enrich(
         eventProps: [String: Any],
-        paywallSession: PaywallSession?
+        scope: PaywallObservabilityScope
     ) -> [String: Any] {
         var p = eventProps
         p["sdkVersion"] = BuildConstants.version
@@ -69,12 +66,10 @@ class HeliumObservabilityManager {
             p["revenueCatAppUserId"] = rcId
         }
         p["heliumSessionId"] = HeliumIdentityManager.shared.getHeliumSessionId()
-        if let session = paywallSession {
-            p["heliumPaywallSessionId"] = session.sessionId
-            p["triggerName"] = session.trigger
-            if let uuid = session.paywallInfoWithBackups?.paywallUUID {
-                p["paywallUUID"] = uuid
-            }
+        p["heliumPaywallSessionId"] = scope.sessionId
+        p["triggerName"] = scope.trigger
+        if let uuid = scope.paywallUUID {
+            p["paywallUUID"] = uuid
         }
         if let orgId = HeliumFetchedConfigManager.shared.getOrganizationID() {
             p["organizationId"] = orgId

--- a/Sources/Helium/HeliumCore/Observability/HeliumObservabilityManager.swift
+++ b/Sources/Helium/HeliumCore/Observability/HeliumObservabilityManager.swift
@@ -1,0 +1,96 @@
+import Foundation
+import UIKit
+
+/// Ops/debug telemetry pipeline. Writes to a dedicated Jitsu connection
+/// distinct from product analytics .
+class HeliumObservabilityManager {
+    static let shared = HeliumObservabilityManager()
+
+    // TODO: replace placeholders with the real observability Jitsu writeKey + endpoint.
+    private let observabilityWriteKey = "<TBD>"
+    private let observabilityEndpoint = "<TBD>"
+
+    private let queue = DispatchQueue(label: "com.helium.observabilityManager")
+    private var analytics: Analytics?
+    private var pendingTracks: [(Analytics) -> Void] = []
+
+    private init() {}
+
+    // MARK: - Setup
+
+    func setUp() {
+        queue.async { [weak self] in
+            guard let self, analytics == nil else { return }
+            let configuration = SegmentConfiguration(writeKey: observabilityWriteKey)
+                .apiHost(observabilityEndpoint)
+                .cdnHost(observabilityEndpoint)
+                .trackApplicationLifecycleEvents(false)
+                .flushAt(10)
+                .flushInterval(10)
+            analytics = Analytics.getOrCreateAnalytics(configuration: configuration)
+            dispatchPendingTracks()
+        }
+    }
+
+    // MARK: - Tracking
+
+    func track(
+        _ event: any HeliumObservabilityEvent,
+        paywallSession: PaywallSession? = nil
+    ) {
+        let eventName = event.name
+        let eventProps = event.properties
+        queue.async { [weak self] in
+            guard let self else { return }
+            let enriched = enrich(
+                eventProps: eventProps,
+                paywallSession: paywallSession
+            )
+            let send: (Analytics) -> Void = { analytics in
+                analytics.track(name: eventName, properties: enriched)
+            }
+            if let analytics {
+                send(analytics)
+            } else {
+                pendingTracks.append(send)
+            }
+        }
+    }
+
+    private func enrich(
+        eventProps: [String: Any],
+        paywallSession: PaywallSession?
+    ) -> [String: Any] {
+        var p = eventProps
+        p["sdkVersion"] = BuildConstants.version
+        p["heliumPersistentId"] = HeliumIdentityManager.shared.getHeliumPersistentId()
+        p["userId"] = HeliumIdentityManager.shared.getResolvedUserId()
+        p["hasCustomUserId"] = HeliumIdentityManager.shared.hasCustomUserId()
+        if let rcId = HeliumIdentityManager.shared.revenueCatAppUserId {
+            p["revenueCatAppUserId"] = rcId
+        }
+        p["heliumSessionId"] = HeliumIdentityManager.shared.getHeliumSessionId()
+        if let session = paywallSession {
+            p["heliumPaywallSessionId"] = session.sessionId
+            p["triggerName"] = session.trigger
+            if let uuid = session.paywallInfoWithBackups?.paywallUUID {
+                p["paywallUUID"] = uuid
+            }
+        }
+        if let orgId = HeliumFetchedConfigManager.shared.getOrganizationID() {
+            p["organizationId"] = orgId
+        }
+        p["platform"] = "ios"
+        p["osVersion"] = UIDevice.current.systemVersion
+        p["timestamp"] = formatAsTimestamp(date: Date())
+        return p
+    }
+
+    private func dispatchPendingTracks() {
+        guard let analytics else { return }
+        for trackClosure in pendingTracks {
+            trackClosure(analytics)
+        }
+        pendingTracks.removeAll()
+    }
+}

--- a/Sources/Helium/HeliumCore/Observability/PaddleCheckoutPrefetchCoordinator+Observability.swift
+++ b/Sources/Helium/HeliumCore/Observability/PaddleCheckoutPrefetchCoordinator+Observability.swift
@@ -16,7 +16,7 @@ extension PaddleCheckoutPrefetchCoordinator {
 
     nonisolated static func trackBanditCompletion(
         priceId: String,
-        paywallSession: PaywallSession,
+        scope: PaywallObservabilityScope,
         startedAt: Date,
         chainStartedAt: Date,
         result: PrefetchBanditStep
@@ -64,7 +64,7 @@ extension PaddleCheckoutPrefetchCoordinator {
                 endpointCall: endpointCall,
                 alreadyEntitledCode: alreadyEntitledCode
             ),
-            paywallSession: paywallSession
+            scope: scope
         )
 
         if let terminalOutcome {
@@ -76,7 +76,7 @@ extension PaddleCheckoutPrefetchCoordinator {
                     totalDurationMs: msSince(chainStartedAt),
                     ipGeoCountry: nil
                 ),
-                paywallSession: paywallSession
+                scope: scope
             )
         }
     }
@@ -84,7 +84,7 @@ extension PaddleCheckoutPrefetchCoordinator {
     nonisolated static func trackBffCompletion(
         priceId: String,
         transactionId: String,
-        paywallSession: PaywallSession,
+        scope: PaywallObservabilityScope,
         startedAt: Date,
         chainStartedAt: Date,
         result: PrefetchBffStep
@@ -129,7 +129,7 @@ extension PaddleCheckoutPrefetchCoordinator {
                 transactionId: transactionId,
                 endpointCall: endpointCall
             ),
-            paywallSession: paywallSession
+            scope: scope
         )
 
         HeliumObservabilityManager.shared.track(
@@ -140,7 +140,7 @@ extension PaddleCheckoutPrefetchCoordinator {
                 totalDurationMs: msSince(chainStartedAt),
                 ipGeoCountry: ipGeo
             ),
-            paywallSession: paywallSession
+            scope: scope
         )
     }
 }

--- a/Sources/Helium/HeliumCore/Observability/PaddleCheckoutPrefetchCoordinator+Observability.swift
+++ b/Sources/Helium/HeliumCore/Observability/PaddleCheckoutPrefetchCoordinator+Observability.swift
@@ -14,9 +14,6 @@ extension PaddleCheckoutPrefetchCoordinator {
         case failed(Error)
     }
 
-    /// Emits `paddle_prefetch_bandit_completed` always, plus
-    /// `paddle_prefetch_outcome_finalized` for terminal outcomes
-    /// (alreadyEntitled, failed).
     nonisolated static func trackBanditCompletion(
         priceId: String,
         paywallSession: PaywallSession,
@@ -84,9 +81,6 @@ extension PaddleCheckoutPrefetchCoordinator {
         }
     }
 
-    /// Emits `paddle_prefetch_bff_completed` always, plus
-    /// `paddle_prefetch_outcome_finalized` (the BFF step is always terminal —
-    /// success → .ready, caBlocked, or failed).
     nonisolated static func trackBffCompletion(
         priceId: String,
         transactionId: String,

--- a/Sources/Helium/HeliumCore/Observability/PaddleCheckoutPrefetchCoordinator+Observability.swift
+++ b/Sources/Helium/HeliumCore/Observability/PaddleCheckoutPrefetchCoordinator+Observability.swift
@@ -1,0 +1,161 @@
+import Foundation
+
+extension PaddleCheckoutPrefetchCoordinator {
+
+    enum PrefetchBanditStep {
+        case success
+        case alreadyEntitled(code: String, message: String)
+        case failed(Error)
+    }
+
+    enum PrefetchBffStep {
+        case success(rawBody: Data)
+        case caBlocked(rawBody: Data)
+        case failed(Error)
+    }
+
+    /// Emits `paddle_prefetch_bandit_completed` always, plus
+    /// `paddle_prefetch_outcome_finalized` for terminal outcomes
+    /// (alreadyEntitled, failed).
+    nonisolated static func trackBanditCompletion(
+        priceId: String,
+        paywallSession: PaywallSession,
+        startedAt: Date,
+        chainStartedAt: Date,
+        result: PrefetchBanditStep
+    ) {
+        let endpointCall: EndpointCallTelemetry
+        let alreadyEntitledCode: String?
+        let terminalOutcome: PaddlePrefetchOutcomeKind?
+        let terminalErrorClass: String?
+
+        switch result {
+        case .success:
+            endpointCall = EndpointCallTelemetry(
+                durationMs: msSince(startedAt), success: true
+            )
+            alreadyEntitledCode = nil
+            terminalOutcome = nil
+            terminalErrorClass = nil
+        case let .alreadyEntitled(code, message):
+            endpointCall = EndpointCallTelemetry(
+                durationMs: msSince(startedAt),
+                success: false,
+                errorClass: "PaddlePrefetchError.alreadyEntitled",
+                errorMessage: message
+            )
+            alreadyEntitledCode = code
+            terminalOutcome = .alreadyEntitled
+            terminalErrorClass = nil
+        case let .failed(error):
+            let decomposed = decomposeError(error)
+            endpointCall = EndpointCallTelemetry(
+                durationMs: msSince(startedAt),
+                success: false,
+                httpStatus: decomposed.httpStatus,
+                errorClass: decomposed.errorClass,
+                errorMessage: decomposed.errorMessage
+            )
+            alreadyEntitledCode = nil
+            terminalOutcome = .failed
+            terminalErrorClass = decomposed.errorClass
+        }
+
+        HeliumObservabilityManager.shared.track(
+            PaddlePrefetchBanditCompleted(
+                priceId: priceId,
+                endpointCall: endpointCall,
+                alreadyEntitledCode: alreadyEntitledCode
+            ),
+            paywallSession: paywallSession
+        )
+
+        if let terminalOutcome {
+            HeliumObservabilityManager.shared.track(
+                PaddlePrefetchOutcomeFinalized(
+                    priceId: priceId,
+                    outcome: terminalOutcome,
+                    errorClass: terminalErrorClass,
+                    totalDurationMs: msSince(chainStartedAt),
+                    ipGeoCountry: nil
+                ),
+                paywallSession: paywallSession
+            )
+        }
+    }
+
+    /// Emits `paddle_prefetch_bff_completed` always, plus
+    /// `paddle_prefetch_outcome_finalized` (the BFF step is always terminal —
+    /// success → .ready, caBlocked, or failed).
+    nonisolated static func trackBffCompletion(
+        priceId: String,
+        transactionId: String,
+        paywallSession: PaywallSession,
+        startedAt: Date,
+        chainStartedAt: Date,
+        result: PrefetchBffStep
+    ) {
+        let endpointCall: EndpointCallTelemetry
+        let outcome: PaddlePrefetchOutcomeKind
+        let errorClass: String?
+        let ipGeo: String?
+
+        switch result {
+        case let .success(rawBody):
+            endpointCall = EndpointCallTelemetry(
+                durationMs: msSince(startedAt), success: true
+            )
+            outcome = .ready
+            errorClass = nil
+            ipGeo = ipGeoCountryCode(in: rawBody)
+        case let .caBlocked(rawBody):
+            endpointCall = EndpointCallTelemetry(
+                durationMs: msSince(startedAt), success: true
+            )
+            outcome = .caBlocked
+            errorClass = "PaddleCaliforniaBlocked"
+            ipGeo = ipGeoCountryCode(in: rawBody)
+        case let .failed(error):
+            let decomposed = decomposeError(error)
+            endpointCall = EndpointCallTelemetry(
+                durationMs: msSince(startedAt),
+                success: false,
+                httpStatus: decomposed.httpStatus,
+                errorClass: decomposed.errorClass,
+                errorMessage: decomposed.errorMessage
+            )
+            outcome = .failed
+            errorClass = decomposed.errorClass
+            ipGeo = nil
+        }
+
+        HeliumObservabilityManager.shared.track(
+            PaddlePrefetchBffCompleted(
+                priceId: priceId,
+                transactionId: transactionId,
+                endpointCall: endpointCall
+            ),
+            paywallSession: paywallSession
+        )
+
+        HeliumObservabilityManager.shared.track(
+            PaddlePrefetchOutcomeFinalized(
+                priceId: priceId,
+                outcome: outcome,
+                errorClass: errorClass,
+                totalDurationMs: msSince(chainStartedAt),
+                ipGeoCountry: ipGeo
+            ),
+            paywallSession: paywallSession
+        )
+    }
+}
+
+private func ipGeoCountryCode(in rawBody: Data) -> String? {
+    guard let parsed = (try? JSONSerialization.jsonObject(with: rawBody)) as? [String: Any],
+          let data = parsed["data"] as? [String: Any],
+          let cc = data["ip_geo_country_code"] as? String else {
+        return nil
+    }
+    return cc
+}

--- a/Sources/Helium/HeliumCore/Observability/PaywallObservabilityScope.swift
+++ b/Sources/Helium/HeliumCore/Observability/PaywallObservabilityScope.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Sendable extract of `PaywallSession` — the session carries non-Sendable
+/// closures (event handlers), so it can't cross actor boundaries directly.
+struct PaywallObservabilityScope: Sendable {
+    let sessionId: String
+    let trigger: String
+    let paywallUUID: String?
+}
+
+extension PaywallSession {
+    var observabilityScope: PaywallObservabilityScope {
+        PaywallObservabilityScope(
+            sessionId: sessionId,
+            trigger: trigger,
+            paywallUUID: paywallInfoWithBackups?.paywallUUID
+        )
+    }
+}

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -33,7 +33,7 @@ enum WebCheckoutOutcome {
 /// Orchestrates the external web checkout flow (browser-based) for payment providers.
 public class ExternalWebCheckoutManager: NSObject {
 
-    private let provider: PaymentProviderConfig
+    let provider: PaymentProviderConfig
     private let entitlementsSource: HeliumPaymentEntitlementsSource
 
     // Checkout state
@@ -65,6 +65,21 @@ public class ExternalWebCheckoutManager: NSObject {
     /// pre-checkout entitlement check resolved the flow without opening the browser.
     @MainActor
     func startCheckoutFlow(
+        for productKey: String,
+        triggerName: String,
+        paywallSession: PaywallSession
+    ) async throws -> WebCheckoutOutcome {
+        return try await withFlowTelemetry(productKey: productKey, paywallSession: paywallSession) {
+            try await self.runCheckoutFlow(
+                for: productKey,
+                triggerName: triggerName,
+                paywallSession: paywallSession
+            )
+        }
+    }
+
+    @MainActor
+    private func runCheckoutFlow(
         for productKey: String,
         triggerName: String,
         paywallSession: PaywallSession
@@ -101,14 +116,25 @@ public class ExternalWebCheckoutManager: NSObject {
             )
             let priceIdsToAwait = Array(Set(allPriceIds + [tappedPriceId]))
 
+            let awaitStart = Date()
             let outcomes = await PaddleCheckoutPrefetchCoordinator.shared.collectPrefetchOutcomes(
                 sessionId: paywallSession.sessionId,
                 priceIds: priceIdsToAwait
             )
+            let awaitDurationMs = msSince(awaitStart)
 
-            if let shortCircuit = PaddleCheckoutPrefetchCoordinator.tappedShortCircuit(
+            let shortCircuit = PaddleCheckoutPrefetchCoordinator.tappedShortCircuit(
                 in: outcomes, tappedPriceId: tappedPriceId
-            ) {
+            )
+            emitPaddleAwaitResolved(
+                tappedPriceId: tappedPriceId,
+                awaitDurationMs: awaitDurationMs,
+                outcomes: outcomes,
+                shortCircuited: shortCircuit != nil,
+                paywallSession: paywallSession
+            )
+
+            if let shortCircuit {
                 HeliumLogger.log(.debug, category: .entitlements,
                                  "\(provider.displayName) prefetch alreadyEntitled (\(shortCircuit.code)): \(shortCircuit.message) — skipping browser")
                 entitlementsSource.invalidateCache()
@@ -144,7 +170,6 @@ public class ExternalWebCheckoutManager: NSObject {
         return try await openEnrichedCheckoutURL(enrichedURL, productKey: productKey, paywallSession: paywallSession)
     }
 
-
     /// True if every offered product is intro-offer eligible.
     /// Prefers the server's per-customer signal from `/check-entitlement` when
     /// available — the local price map can go stale (e.g., host app sets
@@ -176,7 +201,7 @@ public class ExternalWebCheckoutManager: NSObject {
         paddleAlreadyEntitled: [String: Any]? = nil
     ) throws -> URL {
         guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
-            throw WebCheckoutError.failedToBuildEnrichedURL
+            throw WebCheckoutError.invalidBaseURLForComponents
         }
 
         var ctx: [String: Any] = [:]
@@ -223,7 +248,7 @@ public class ExternalWebCheckoutManager: NSObject {
         let ctxData = try JSONSerialization.data(withJSONObject: ctx)
 
         guard let compressed = CtxCompression.deflateRaw(ctxData) else {
-            throw WebCheckoutError.failedToBuildEnrichedURL
+            throw WebCheckoutError.failedToCompressCtx
         }
 
         var queryItems = components.queryItems ?? []
@@ -236,7 +261,7 @@ public class ExternalWebCheckoutManager: NSObject {
         components.fragment = "ctx=" + compressed.base64URLEncodedString()
 
         guard let url = components.url else {
-            throw WebCheckoutError.failedToBuildEnrichedURL
+            throw WebCheckoutError.failedToAssembleEnrichedURL
         }
         return url
     }
@@ -262,6 +287,10 @@ public class ExternalWebCheckoutManager: NSObject {
         activeCheckoutObservations[paywallSession.sessionId] = observation
 
         let opened = await UIApplication.shared.open(url)
+        HeliumObservabilityManager.shared.track(
+            WebCheckoutBrowserOpenAttempted(provider: provider.providerSlug, success: opened),
+            paywallSession: paywallSession
+        )
         guard opened else {
             activeCheckoutObservations.removeValue(forKey: paywallSession.sessionId)
             throw WebCheckoutError.failedToOpenEnrichedURL
@@ -374,6 +403,9 @@ public class ExternalWebCheckoutManager: NSObject {
     private func checkForNewPurchaseWithRetry(fromSuccessRedirect: Bool = false) async -> Bool {
         let delays: [UInt64] = [0, 2_000_000_000]
 
+        let oldestOpenedAt = activeCheckoutObservations.values.min(by: { $0.addedAt < $1.addedAt })?.addedAt
+        let newestObservation = activeCheckoutObservations.values.max(by: { $0.addedAt < $1.addedAt })
+
         for (i, delay) in delays.enumerated() {
             if delay > 0 {
                 try? await Task.sleep(nanoseconds: delay)
@@ -381,11 +413,23 @@ public class ExternalWebCheckoutManager: NSObject {
             if Task.isCancelled { return false }
             guard !activeCheckoutObservations.isEmpty else { return false }
 
-            let purchaseDetected = await checkForNewPurchase(fromSuccessRedirect: fromSuccessRedirect)
+            let purchaseDetected = await checkForNewPurchase(
+                fromSuccessRedirect: fromSuccessRedirect,
+                retryAttempt: i + 1
+            )
             if Task.isCancelled { return false }
             HeliumLogger.log(.debug, category: .entitlements, "Detected new \(provider.displayName) purchase? \(purchaseDetected) (attempt #\(i + 1))")
             if purchaseDetected { return true }
         }
+        HeliumObservabilityManager.shared.track(
+            WebCheckoutPurchaseCheckExhausted(
+                provider: provider.providerSlug,
+                retries: delays.count,
+                msSinceOpen: oldestOpenedAt.map { msSince($0) },
+                fromSuccessRedirect: fromSuccessRedirect
+            ),
+            paywallSession: newestObservation?.paywallSession
+        )
         return false
     }
 
@@ -399,7 +443,7 @@ public class ExternalWebCheckoutManager: NSObject {
     /// offered on the same paywall. In either case, observations are cleared
     /// and paywalls hidden. Succeeded wins over Restored across all sessions.
     @MainActor
-    private func checkForNewPurchase(fromSuccessRedirect: Bool = false) async -> Bool {
+    private func checkForNewPurchase(fromSuccessRedirect: Bool = false, retryAttempt: Int = 1) async -> Bool {
         await entitlementsSource.refreshEntitlements()
         let currentEntitledIds = await entitlementsSource.purchasedHeliumProductIds()
         HeliumLogger.log(.debug, category: .entitlements, "\(provider.displayName) checkForNewPurchase", metadata: [
@@ -444,6 +488,17 @@ public class ExternalWebCheckoutManager: NSObject {
                     paywallSession: observation.paywallSession,
                     sendToAnalytics: false
                 )
+                HeliumObservabilityManager.shared.track(
+                    WebCheckoutPurchaseDetected(
+                        provider: provider.providerSlug,
+                        productId: purchasedProductId,
+                        source: fromSuccessRedirect ? .successRedirect : .foregroundObserver,
+                        retryAttempt: retryAttempt,
+                        msSinceOpen: msSince(observation.addedAt),
+                        wasRestore: false
+                    ),
+                    paywallSession: observation.paywallSession
+                )
                 activeCheckoutObservations.removeAll()
                 Helium.shared.hideAllPaywalls()
                 InlinePaywallDismissRegistry.dismissAll()
@@ -472,6 +527,17 @@ public class ExternalWebCheckoutManager: NSObject {
                 paywallSession: restored.observation.paywallSession,
                 sendToAnalytics: false
             )
+            HeliumObservabilityManager.shared.track(
+                WebCheckoutPurchaseDetected(
+                    provider: provider.providerSlug,
+                    productId: restored.productId,
+                    source: fromSuccessRedirect ? .successRedirect : .foregroundObserver,
+                    retryAttempt: retryAttempt,
+                    msSinceOpen: msSince(restored.observation.addedAt),
+                    wasRestore: true
+                ),
+                paywallSession: restored.observation.paywallSession
+            )
             activeCheckoutObservations.removeAll()
             Helium.shared.hideAllPaywalls()
             InlinePaywallDismissRegistry.dismissAll()
@@ -490,6 +556,17 @@ public class ExternalWebCheckoutManager: NSObject {
     @MainActor
     func handleExternalReturn(redirectKind: HeliumCheckoutRedirectType) async {
         guard !activeCheckoutObservations.isEmpty else { return }
+
+        let newest = activeCheckoutObservations.values.max(by: { $0.addedAt < $1.addedAt })
+        HeliumObservabilityManager.shared.track(
+            WebCheckoutRedirectReceived(
+                provider: provider.providerSlug,
+                redirectKind: redirectKind.rawValue,
+                msSinceOpen: newest.map { msSince($0.addedAt) },
+                observationCount: activeCheckoutObservations.count
+            ),
+            paywallSession: newest?.paywallSession
+        )
 
         // Redirect is authoritative — suppress the foreground-observer safety net
         // while we run explicit logic for this redirect.

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -289,7 +289,7 @@ public class ExternalWebCheckoutManager: NSObject {
         let opened = await UIApplication.shared.open(url)
         HeliumObservabilityManager.shared.track(
             WebCheckoutBrowserOpenAttempted(provider: provider.providerSlug, success: opened),
-            paywallSession: paywallSession
+            scope: paywallSession.observabilityScope
         )
         guard opened else {
             activeCheckoutObservations.removeValue(forKey: paywallSession.sessionId)
@@ -403,8 +403,10 @@ public class ExternalWebCheckoutManager: NSObject {
     private func checkForNewPurchaseWithRetry(fromSuccessRedirect: Bool = false) async -> Bool {
         let delays: [UInt64] = [0, 2_000_000_000]
 
+        guard let newestObservation = activeCheckoutObservations.values.max(by: { $0.addedAt < $1.addedAt }) else {
+            return false
+        }
         let oldestOpenedAt = activeCheckoutObservations.values.min(by: { $0.addedAt < $1.addedAt })?.addedAt
-        let newestObservation = activeCheckoutObservations.values.max(by: { $0.addedAt < $1.addedAt })
 
         for (i, delay) in delays.enumerated() {
             if delay > 0 {
@@ -428,7 +430,7 @@ public class ExternalWebCheckoutManager: NSObject {
                 msSinceOpen: oldestOpenedAt.map { msSince($0) },
                 fromSuccessRedirect: fromSuccessRedirect
             ),
-            paywallSession: newestObservation?.paywallSession
+            scope: newestObservation.paywallSession.observabilityScope
         )
         return false
     }
@@ -497,7 +499,7 @@ public class ExternalWebCheckoutManager: NSObject {
                         msSinceOpen: msSince(observation.addedAt),
                         wasRestore: false
                     ),
-                    paywallSession: observation.paywallSession
+                    scope: observation.paywallSession.observabilityScope
                 )
                 activeCheckoutObservations.removeAll()
                 Helium.shared.hideAllPaywalls()
@@ -536,7 +538,7 @@ public class ExternalWebCheckoutManager: NSObject {
                     msSinceOpen: msSince(restored.observation.addedAt),
                     wasRestore: true
                 ),
-                paywallSession: restored.observation.paywallSession
+                scope: restored.observation.paywallSession.observabilityScope
             )
             activeCheckoutObservations.removeAll()
             Helium.shared.hideAllPaywalls()
@@ -555,17 +557,18 @@ public class ExternalWebCheckoutManager: NSObject {
     /// purchase still gets picked up on the next app return.
     @MainActor
     func handleExternalReturn(redirectKind: HeliumCheckoutRedirectType) async {
-        guard !activeCheckoutObservations.isEmpty else { return }
+        guard let newest = activeCheckoutObservations.values.max(by: { $0.addedAt < $1.addedAt }) else {
+            return
+        }
 
-        let newest = activeCheckoutObservations.values.max(by: { $0.addedAt < $1.addedAt })
         HeliumObservabilityManager.shared.track(
             WebCheckoutRedirectReceived(
                 provider: provider.providerSlug,
                 redirectKind: redirectKind.rawValue,
-                msSinceOpen: newest.map { msSince($0.addedAt) },
+                msSinceOpen: msSince(newest.addedAt),
                 observationCount: activeCheckoutObservations.count
             ),
-            paywallSession: newest?.paywallSession
+            scope: newest.paywallSession.observabilityScope
         )
 
         // Redirect is authoritative — suppress the foreground-observer safety net

--- a/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
@@ -99,6 +99,7 @@ final class PaddleCheckoutPrefetchCoordinator {
         iosBundleId: String?
     ) {
         let sessionId = paywallSession.sessionId
+        let scope = paywallSession.observabilityScope
         var startedPriceIds: [String] = []
         for priceId in priceIds {
             let key = CacheKey(sessionId: sessionId, priceId: priceId)
@@ -114,7 +115,7 @@ final class PaddleCheckoutPrefetchCoordinator {
                     iosBundleId: iosBundleId,
                     banditClient: bandit,
                     bffClient: bff,
-                    paywallSession: paywallSession
+                    scope: scope
                 )
             }
             startedPriceIds.append(priceId)
@@ -122,7 +123,7 @@ final class PaddleCheckoutPrefetchCoordinator {
         if !startedPriceIds.isEmpty {
             HeliumObservabilityManager.shared.track(
                 PaddlePrefetchStarted(priceIds: startedPriceIds),
-                paywallSession: paywallSession
+                scope: scope
             )
         }
     }
@@ -417,19 +418,19 @@ final class PaddleCheckoutPrefetchCoordinator {
         iosBundleId: String?,
         banditClient: HeliumPaymentAPIClient,
         bffClient: PaddleBFFClient,
-        paywallSession: PaywallSession
+        scope: PaywallObservabilityScope
     ) async -> PaddlePrefetchOutcome {
         let chainStart = Date()
         let banditStart = Date()
         let banditResponse: PaddleCreateTransactionForPaywallResponse
         do {
             banditResponse = try await banditClient.createPaddleTransactionForPaywall(priceId: priceId)
-            trackBanditCompletion(priceId: priceId, paywallSession: paywallSession, startedAt: banditStart, chainStartedAt: chainStart, result: .success)
+            trackBanditCompletion(priceId: priceId, scope: scope, startedAt: banditStart, chainStartedAt: chainStart, result: .success)
         } catch let PaddlePrefetchError.alreadyEntitled(code, message, existingSubscriptionId) {
-            trackBanditCompletion(priceId: priceId, paywallSession: paywallSession, startedAt: banditStart, chainStartedAt: chainStart, result: .alreadyEntitled(code: code, message: message))
+            trackBanditCompletion(priceId: priceId, scope: scope, startedAt: banditStart, chainStartedAt: chainStart, result: .alreadyEntitled(code: code, message: message))
             return .alreadyEntitled(code: code, message: message, existingSubscriptionId: existingSubscriptionId)
         } catch {
-            trackBanditCompletion(priceId: priceId, paywallSession: paywallSession, startedAt: banditStart, chainStartedAt: chainStart, result: .failed(error))
+            trackBanditCompletion(priceId: priceId, scope: scope, startedAt: banditStart, chainStartedAt: chainStart, result: .failed(error))
             return .failed(error: error)
         }
 
@@ -441,13 +442,13 @@ final class PaddleCheckoutPrefetchCoordinator {
                 iosBundleId: iosBundleId
             )
             if let caPostal = californiaPostalCode(in: paddleResult.rawBody) {
-                trackBffCompletion(priceId: priceId, transactionId: banditResponse.transactionId, paywallSession: paywallSession, startedAt: bffStart, chainStartedAt: chainStart, result: .caBlocked(rawBody: paddleResult.rawBody))
+                trackBffCompletion(priceId: priceId, transactionId: banditResponse.transactionId, scope: scope, startedAt: bffStart, chainStartedAt: chainStart, result: .caBlocked(rawBody: paddleResult.rawBody))
                 return .failed(error: PaddleCaliforniaBlocked(postalCode: caPostal))
             }
-            trackBffCompletion(priceId: priceId, transactionId: banditResponse.transactionId, paywallSession: paywallSession, startedAt: bffStart, chainStartedAt: chainStart, result: .success(rawBody: paddleResult.rawBody))
+            trackBffCompletion(priceId: priceId, transactionId: banditResponse.transactionId, scope: scope, startedAt: bffStart, chainStartedAt: chainStart, result: .success(rawBody: paddleResult.rawBody))
             return .ready(bandit: banditResponse, paddle: paddleResult)
         } catch {
-            trackBffCompletion(priceId: priceId, transactionId: banditResponse.transactionId, paywallSession: paywallSession, startedAt: bffStart, chainStartedAt: chainStart, result: .failed(error))
+            trackBffCompletion(priceId: priceId, transactionId: banditResponse.transactionId, scope: scope, startedAt: bffStart, chainStartedAt: chainStart, result: .failed(error))
             return .failed(error: error)
         }
     }

--- a/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
@@ -78,7 +78,7 @@ final class PaddleCheckoutPrefetchCoordinator {
         guard !priceIds.isEmpty else { return }
 
         prefetch(
-            sessionId: paywallSession.sessionId,
+            paywallSession: paywallSession,
             priceIds: priceIds,
             paddleClientToken: clientToken,
             iosBundleId: Bundle.main.bundleIdentifier
@@ -93,11 +93,13 @@ final class PaddleCheckoutPrefetchCoordinator {
 
     /// Re-calling for the same `(sessionId, priceId)` is a no-op.
     func prefetch(
-        sessionId: String,
+        paywallSession: PaywallSession,
         priceIds: [String],
         paddleClientToken: String,
         iosBundleId: String?
     ) {
+        let sessionId = paywallSession.sessionId
+        var startedPriceIds: [String] = []
         for priceId in priceIds {
             let key = CacheKey(sessionId: sessionId, priceId: priceId)
             if cache[key] != nil { continue }
@@ -111,9 +113,17 @@ final class PaddleCheckoutPrefetchCoordinator {
                     paddleClientToken: paddleClientToken,
                     iosBundleId: iosBundleId,
                     banditClient: bandit,
-                    bffClient: bff
+                    bffClient: bff,
+                    paywallSession: paywallSession
                 )
             }
+            startedPriceIds.append(priceId)
+        }
+        if !startedPriceIds.isEmpty {
+            HeliumObservabilityManager.shared.track(
+                PaddlePrefetchStarted(priceIds: startedPriceIds),
+                paywallSession: paywallSession
+            )
         }
     }
 
@@ -406,17 +416,24 @@ final class PaddleCheckoutPrefetchCoordinator {
         paddleClientToken: String,
         iosBundleId: String?,
         banditClient: HeliumPaymentAPIClient,
-        bffClient: PaddleBFFClient
+        bffClient: PaddleBFFClient,
+        paywallSession: PaywallSession
     ) async -> PaddlePrefetchOutcome {
+        let chainStart = Date()
+        let banditStart = Date()
         let banditResponse: PaddleCreateTransactionForPaywallResponse
         do {
             banditResponse = try await banditClient.createPaddleTransactionForPaywall(priceId: priceId)
+            trackBanditCompletion(priceId: priceId, paywallSession: paywallSession, startedAt: banditStart, chainStartedAt: chainStart, result: .success)
         } catch let PaddlePrefetchError.alreadyEntitled(code, message, existingSubscriptionId) {
+            trackBanditCompletion(priceId: priceId, paywallSession: paywallSession, startedAt: banditStart, chainStartedAt: chainStart, result: .alreadyEntitled(code: code, message: message))
             return .alreadyEntitled(code: code, message: message, existingSubscriptionId: existingSubscriptionId)
         } catch {
+            trackBanditCompletion(priceId: priceId, paywallSession: paywallSession, startedAt: banditStart, chainStartedAt: chainStart, result: .failed(error))
             return .failed(error: error)
         }
 
+        let bffStart = Date()
         do {
             let paddleResult = try await bffClient.createTransactionCheckout(
                 transactionId: banditResponse.transactionId,
@@ -424,10 +441,13 @@ final class PaddleCheckoutPrefetchCoordinator {
                 iosBundleId: iosBundleId
             )
             if let caPostal = californiaPostalCode(in: paddleResult.rawBody) {
+                trackBffCompletion(priceId: priceId, transactionId: banditResponse.transactionId, paywallSession: paywallSession, startedAt: bffStart, chainStartedAt: chainStart, result: .caBlocked(rawBody: paddleResult.rawBody))
                 return .failed(error: PaddleCaliforniaBlocked(postalCode: caPostal))
             }
+            trackBffCompletion(priceId: priceId, transactionId: banditResponse.transactionId, paywallSession: paywallSession, startedAt: bffStart, chainStartedAt: chainStart, result: .success(rawBody: paddleResult.rawBody))
             return .ready(bandit: banditResponse, paddle: paddleResult)
         } catch {
+            trackBffCompletion(priceId: priceId, transactionId: banditResponse.transactionId, paywallSession: paywallSession, startedAt: bffStart, chainStartedAt: chainStart, result: .failed(error))
             return .failed(error: error)
         }
     }

--- a/Sources/Helium/HeliumCore/StripeCheckout/WebCheckoutModels.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/WebCheckoutModels.swift
@@ -255,7 +255,9 @@ public enum PaddlePrefetchError: LocalizedError {
 enum WebCheckoutError: LocalizedError {
     case cannotPresentCheckout
     case checkoutURLsNotConfigured
-    case failedToBuildEnrichedURL
+    case invalidBaseURLForComponents
+    case failedToCompressCtx
+    case failedToAssembleEnrichedURL
     case failedToOpenEnrichedURL
     case webPaywallBundleUrlMissing
     case californiaBuyerBlocked
@@ -266,8 +268,12 @@ enum WebCheckoutError: LocalizedError {
             return "Could not present the checkout view"
         case .checkoutURLsNotConfigured:
             return "Checkout URLs not configured. Call Helium.config.enableExternalWebCheckout() before presenting a paywall."
-        case .failedToBuildEnrichedURL:
-            return "Failed to build enriched checkout URL."
+        case .invalidBaseURLForComponents:
+            return "Web paywall bundle URL could not be parsed into URLComponents."
+        case .failedToCompressCtx:
+            return "Failed to compress the ctx payload for the enriched checkout URL."
+        case .failedToAssembleEnrichedURL:
+            return "Failed to assemble the final enriched checkout URL from its components."
         case .failedToOpenEnrichedURL:
             return "Could not open enriched checkout URL in browser."
         case .webPaywallBundleUrlMissing:

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -45,7 +45,9 @@ public class Helium {
             HeliumLogger.log(.warn, category: .core, "Helium already initialized, ignoring subsequent call. Use resetHelium if you need to initialize again.")
             return
         }
-        
+
+        HeliumObservabilityManager.shared.setUp()
+
         // Start store country code fetch immediately
         _ = AppStoreCountryHelper.shared
         

--- a/Tests/helium-swiftTests/PaddleCheckoutPrefetchCoordinatorTests.swift
+++ b/Tests/helium-swiftTests/PaddleCheckoutPrefetchCoordinatorTests.swift
@@ -4,7 +4,8 @@ import XCTest
 @MainActor
 final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
 
-    private let testSessionId = "test_session_default"
+    private var testSession: PaywallSession!
+    private var testSessionId: String { testSession.sessionId }
 
     private var session: URLSession!
     private var banditClient: HeliumPaymentAPIClient!
@@ -13,6 +14,8 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+
+        testSession = makeTestSession()
 
         let config = URLSessionConfiguration.ephemeral
         config.protocolClasses = [MockURLProtocol.self]
@@ -112,7 +115,7 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
         MockURLProtocol.requestHandler = bothSucceedHandler()
 
         coordinator.prefetch(
-            sessionId: testSessionId,
+            paywallSession: testSession,
             priceIds: ["pri_x"],
             paddleClientToken: "test_xyz",
             iosBundleId: "com.example.test"
@@ -145,7 +148,7 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
                           userInfo: [NSLocalizedDescriptionKey: "BFF was called after bandit 409 — should have short-circuited"])
         }
 
-        coordinator.prefetch(sessionId: testSessionId, priceIds: ["pri_x"], paddleClientToken: "test_xyz", iosBundleId: nil)
+        coordinator.prefetch(paywallSession: testSession, priceIds: ["pri_x"], paddleClientToken: "test_xyz", iosBundleId: nil)
         let outcome = await coordinator.awaitOutcome(sessionId: testSessionId, priceId: "pri_x")
 
         guard case .alreadyEntitled(let code, let message, _) = outcome else {
@@ -173,7 +176,7 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
             throw NSError(domain: "test", code: 0)
         }
 
-        coordinator.prefetch(sessionId: testSessionId, priceIds: ["pri_x"], paddleClientToken: "test_xyz", iosBundleId: nil)
+        coordinator.prefetch(paywallSession: testSession, priceIds: ["pri_x"], paddleClientToken: "test_xyz", iosBundleId: nil)
         let outcome = await coordinator.awaitOutcome(sessionId: testSessionId, priceId: "pri_x")
 
         guard case .failed = outcome else {
@@ -195,7 +198,7 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
             throw NSError(domain: "test", code: 0)
         }
 
-        coordinator.prefetch(sessionId: testSessionId, priceIds: ["pri_x"], paddleClientToken: "test_xyz", iosBundleId: nil)
+        coordinator.prefetch(paywallSession: testSession, priceIds: ["pri_x"], paddleClientToken: "test_xyz", iosBundleId: nil)
         let outcome = await coordinator.awaitOutcome(sessionId: testSessionId, priceId: "pri_x")
 
         guard case .failed = outcome else {
@@ -218,7 +221,7 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
     func testAwaitOutcome_returnsNotStarted_forPriceIdNotInPrefetchSet() async throws {
         MockURLProtocol.requestHandler = bothSucceedHandler()
 
-        coordinator.prefetch(sessionId: testSessionId, priceIds: ["pri_x"], paddleClientToken: "test_xyz", iosBundleId: nil)
+        coordinator.prefetch(paywallSession: testSession, priceIds: ["pri_x"], paddleClientToken: "test_xyz", iosBundleId: nil)
 
         let outcome = await coordinator.awaitOutcome(sessionId: testSessionId, priceId: "pri_y_not_prefetched")
 
@@ -231,9 +234,12 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
     func testAwaitOutcome_returnsNotStarted_whenSessionIdDoesNotMatch() async throws {
         MockURLProtocol.requestHandler = bothSucceedHandler()
 
-        coordinator.prefetch(sessionId: "session_a", priceIds: ["pri_x"], paddleClientToken: "test_xyz", iosBundleId: nil)
+        let sessionA = makeTestSession()
+        let sessionB = makeTestSession()
 
-        let outcome = await coordinator.awaitOutcome(sessionId: "session_b", priceId: "pri_x")
+        coordinator.prefetch(paywallSession: sessionA, priceIds: ["pri_x"], paddleClientToken: "test_xyz", iosBundleId: nil)
+
+        let outcome = await coordinator.awaitOutcome(sessionId: sessionB.sessionId, priceId: "pri_x")
 
         guard case .notStarted = outcome else {
             XCTFail("Different session id should be a cache miss; got \(outcome)")
@@ -246,7 +252,7 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
     func testCancelAll_clearsCache_subsequentAwaitsReturnNotStarted() async throws {
         MockURLProtocol.requestHandler = bothSucceedHandler()
 
-        coordinator.prefetch(sessionId: testSessionId, priceIds: ["pri_x"], paddleClientToken: "test_xyz", iosBundleId: nil)
+        coordinator.prefetch(paywallSession: testSession, priceIds: ["pri_x"], paddleClientToken: "test_xyz", iosBundleId: nil)
         coordinator.cancelAll()
 
         let outcome = await coordinator.awaitOutcome(sessionId: testSessionId, priceId: "pri_x")
@@ -268,7 +274,7 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
             return (response, "{}".data(using: .utf8)!)
         }
 
-        coordinator.prefetch(sessionId: testSessionId, priceIds: ["pri_slow"], paddleClientToken: "test_xyz", iosBundleId: nil)
+        coordinator.prefetch(paywallSession: testSession, priceIds: ["pri_slow"], paddleClientToken: "test_xyz", iosBundleId: nil)
 
         let start = Date()
         let outcome = await coordinator.awaitOutcome(sessionId: testSessionId, priceId: "pri_slow", timeout: 0.1)
@@ -299,7 +305,7 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
             throw NSError(domain: "test", code: 0)
         }
 
-        coordinator.prefetch(sessionId: testSessionId, priceIds: ["pri_fast"], paddleClientToken: "test_xyz", iosBundleId: nil)
+        coordinator.prefetch(paywallSession: testSession, priceIds: ["pri_fast"], paddleClientToken: "test_xyz", iosBundleId: nil)
 
         let outcome = await coordinator.awaitOutcome(sessionId: testSessionId, priceId: "pri_fast", timeout: 5.0)
 
@@ -315,7 +321,7 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
         MockURLProtocol.requestHandler = bothSucceedHandler()
 
         coordinator.prefetch(
-            sessionId: testSessionId,
+            paywallSession: testSession,
             priceIds: ["pri_a", "pri_b", "pri_c"],
             paddleClientToken: "test_xyz",
             iosBundleId: nil
@@ -347,7 +353,7 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
         MockURLProtocol.requestHandler = bothSucceedHandler()
 
         coordinator.prefetch(
-            sessionId: testSessionId,
+            paywallSession: testSession,
             priceIds: ["pri_only"],
             paddleClientToken: "test_xyz",
             iosBundleId: nil
@@ -370,15 +376,18 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
     func testCancelForSession_removesEntriesOwnedByThatSessionOnly() async throws {
         MockURLProtocol.requestHandler = bothSucceedHandler()
 
-        coordinator.prefetch(sessionId: "session_a", priceIds: ["pri_shared", "pri_a_only"], paddleClientToken: "test_xyz", iosBundleId: nil)
-        coordinator.prefetch(sessionId: "session_b", priceIds: ["pri_shared", "pri_b_only"], paddleClientToken: "test_xyz", iosBundleId: nil)
+        let sessionA = makeTestSession()
+        let sessionB = makeTestSession()
 
-        coordinator.cancelForSession(sessionId: "session_a")
+        coordinator.prefetch(paywallSession: sessionA, priceIds: ["pri_shared", "pri_a_only"], paddleClientToken: "test_xyz", iosBundleId: nil)
+        coordinator.prefetch(paywallSession: sessionB, priceIds: ["pri_shared", "pri_b_only"], paddleClientToken: "test_xyz", iosBundleId: nil)
 
-        let aShared = await coordinator.awaitOutcome(sessionId: "session_a", priceId: "pri_shared", timeout: 5.0)
-        let aOnly = await coordinator.awaitOutcome(sessionId: "session_a", priceId: "pri_a_only", timeout: 5.0)
-        let bShared = await coordinator.awaitOutcome(sessionId: "session_b", priceId: "pri_shared", timeout: 5.0)
-        let bOnly = await coordinator.awaitOutcome(sessionId: "session_b", priceId: "pri_b_only", timeout: 5.0)
+        coordinator.cancelForSession(sessionId: sessionA.sessionId)
+
+        let aShared = await coordinator.awaitOutcome(sessionId: sessionA.sessionId, priceId: "pri_shared", timeout: 5.0)
+        let aOnly = await coordinator.awaitOutcome(sessionId: sessionA.sessionId, priceId: "pri_a_only", timeout: 5.0)
+        let bShared = await coordinator.awaitOutcome(sessionId: sessionB.sessionId, priceId: "pri_shared", timeout: 5.0)
+        let bOnly = await coordinator.awaitOutcome(sessionId: sessionB.sessionId, priceId: "pri_b_only", timeout: 5.0)
 
         guard case .notStarted = aShared else {
             XCTFail("session_a/pri_shared should have been wiped by cancelForSession(session_a); got \(aShared)")
@@ -835,7 +844,7 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
         }
 
         coordinator.prefetch(
-            sessionId: testSessionId,
+            paywallSession: testSession,
             priceIds: ["pri_a", "pri_b"],
             paddleClientToken: "test_xyz",
             iosBundleId: nil


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new background telemetry pipeline (Segment/Jitsu) and wires it into Paddle prefetch + external web checkout flows; while behavior should be unchanged, it touches purchase/entitlement detection paths and introduces new async tracking that could affect timing or crash on edge cases.
> 
> **Overview**
> Introduces a dedicated **observability/ops telemetry pipeline** (`HeliumObservabilityManager`) with shared event types/utilities (`HeliumObservabilityEvent`, error decomposition, string truncation) and a sendable `PaywallObservabilityScope` derived from `PaywallSession`.
> 
> Adds end-to-end instrumentation for **Paddle prefetch** (started/completed/outcome events, including CA-blocked and IP geo extraction) and for the **external web checkout flow** (flow start/resolution, browser open attempt, redirect receipt, purchase detection + retry exhaustion), including minor refactors to wrap `startCheckoutFlow` and pass scope through detached tasks.
> 
> Improves error granularity in `WebCheckoutError` by splitting the previous generic enriched-URL build failure into more specific cases, and updates Paddle prefetch APIs/tests to accept `PaywallSession` instead of raw `sessionId` so observability scope can be propagated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c84c2f61ef5cff4e250e31e40dfd6361758c5ea7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced checkout error handling with more specific failure messages for improved troubleshooting.
  * Strengthened Paddle prefetch coordination with better support for various checkout scenarios.

* **Improvements**
  * Refined purchase detection with improved retry logic and session-based tracking during checkout operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudcaptainai/helium-swift/pull/274)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->