### PR TITLE
add paddle checkout generatedAt to ctx and per-open cache-bust query …

### DIFF
--- a/Sources/Helium/HeliumCore/BuildConstants.swift
+++ b/Sources/Helium/HeliumCore/BuildConstants.swift
@@ -8,5 +8,5 @@
  */
 public struct BuildConstants {
     /// Current SDK version
-    public static let version = "4.4.5"
+    public static let version = "4.4.6"
 }

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -260,8 +260,8 @@ public class ExternalWebCheckoutManager: NSObject {
         // so if the bundle is already open from a prior tap it would render
         // stale ctx (wrong selected product, stale entitled-banner state).
         // A unique query item forces a fresh navigation each time.
-        queryItems.removeAll { $0.name == "_t" }
-        queryItems.append(URLQueryItem(name: "_t", value: String(Int64(Date().timeIntervalSince1970 * 1000))))
+        queryItems.removeAll { $0.name == "hlm_ts" }
+        queryItems.append(URLQueryItem(name: "hlm_ts", value: String(Int64(Date().timeIntervalSince1970 * 1000))))
         components.queryItems = queryItems
 
         components.fragment = "ctx=" + compressed.base64URLEncodedString()

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -255,8 +255,14 @@ public class ExternalWebCheckoutManager: NSObject {
         if !queryItems.contains(where: { $0.name == "helium_ios_bundle_id" }) {
             let bundleId = Bundle.main.bundleIdentifier ?? "unknown"
             queryItems.append(URLQueryItem(name: "helium_ios_bundle_id", value: bundleId))
-            components.queryItems = queryItems
         }
+        // Cache-bust per open: a fragment-only change doesn't reload the page,
+        // so if the bundle is already open from a prior tap it would render
+        // stale ctx (wrong selected product, stale entitled-banner state).
+        // A unique query item forces a fresh navigation each time.
+        queryItems.removeAll { $0.name == "_t" }
+        queryItems.append(URLQueryItem(name: "_t", value: String(Int64(Date().timeIntervalSince1970 * 1000))))
+        components.queryItems = queryItems
 
         components.fragment = "ctx=" + compressed.base64URLEncodedString()
 

--- a/Sources/Helium/HeliumCore/StripeCheckout/PaddleBFFClient.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/PaddleBFFClient.swift
@@ -15,6 +15,7 @@ public struct PaddleTransactionCheckoutResult {
     public let rawBody: Data
     public let checkoutId: String
     public let transactionId: String
+    public let generatedAt: Date
 }
 
 final class PaddleBFFClient {
@@ -75,7 +76,8 @@ final class PaddleBFFClient {
         return PaddleTransactionCheckoutResult(
             rawBody: data,
             checkoutId: envelope.data.id,
-            transactionId: envelope.data.transactionId
+            transactionId: envelope.data.transactionId,
+            generatedAt: Date()
         )
     }
 

--- a/Sources/Helium/HeliumCore/StripeCheckout/PaddleBFFClient.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/PaddleBFFClient.swift
@@ -15,7 +15,6 @@ public struct PaddleTransactionCheckoutResult {
     public let rawBody: Data
     public let checkoutId: String
     public let transactionId: String
-    public let generatedAt: Date
 }
 
 final class PaddleBFFClient {
@@ -76,8 +75,7 @@ final class PaddleBFFClient {
         return PaddleTransactionCheckoutResult(
             rawBody: data,
             checkoutId: envelope.data.id,
-            transactionId: envelope.data.transactionId,
-            generatedAt: Date()
+            transactionId: envelope.data.transactionId
         )
     }
 

--- a/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
@@ -276,6 +276,7 @@ final class PaddleCheckoutPrefetchCoordinator {
         return [
             "banditResponse": banditDict,
             "paddleCheckoutResponse": trimmedPaddleResponse,
+            "paddleCheckoutGeneratedAt": formatAsTimestamp(date: paddle.generatedAt),
         ]
     }
 

--- a/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
@@ -276,7 +276,6 @@ final class PaddleCheckoutPrefetchCoordinator {
         return [
             "banditResponse": banditDict,
             "paddleCheckoutResponse": trimmedPaddleResponse,
-            "paddleCheckoutGeneratedAt": formatAsTimestamp(date: paddle.generatedAt),
         ]
     }
 
@@ -297,6 +296,7 @@ final class PaddleCheckoutPrefetchCoordinator {
         for key in [
             "id", "transaction_id", "status", "currency_code",
             "ip_geo_country_code", "ip_geo_postal_code",
+            "created_at",
         ] {
             if let value = raw[key] { trimmed[key] = value }
         }

--- a/Tests/helium-swiftTests/PaddleCheckoutPrefetchCoordinatorTests.swift
+++ b/Tests/helium-swiftTests/PaddleCheckoutPrefetchCoordinatorTests.swift
@@ -90,8 +90,7 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
         return PaddleTransactionCheckoutResult(
             rawBody: "{}".data(using: .utf8)!,
             checkoutId: "che_x",
-            transactionId: "txn_x",
-            generatedAt: Date()
+            transactionId: "txn_x"
         )
     }
 
@@ -502,13 +501,13 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
             transactionId: "txn_a", paddleCustomerId: "ctm_a", isKnownCustomer: true, requestId: "req_a")
         let paddle1 = PaddleTransactionCheckoutResult(
             rawBody: try paddleResponseFixtureWithCruft(checkoutId: "che_a", transactionId: "txn_a"),
-            checkoutId: "che_a", transactionId: "txn_a", generatedAt: Date())
+            checkoutId: "che_a", transactionId: "txn_a")
 
         let bandit2 = PaddleCreateTransactionForPaywallResponse(
             transactionId: "txn_b", paddleCustomerId: nil, isKnownCustomer: false, requestId: "req_b")
         let paddle2 = PaddleTransactionCheckoutResult(
             rawBody: try paddleResponseFixtureWithCruft(checkoutId: "che_b", transactionId: "txn_b"),
-            checkoutId: "che_b", transactionId: "txn_b", generatedAt: Date())
+            checkoutId: "che_b", transactionId: "txn_b")
 
         let outcomes: [String: PaddlePrefetchOutcome] = [
             "pri_a": .ready(bandit: bandit1, paddle: paddle1),
@@ -531,7 +530,7 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
             transactionId: "txn_x", paddleCustomerId: nil, isKnownCustomer: false, requestId: "req_x")
         let paddle = PaddleTransactionCheckoutResult(
             rawBody: try paddleResponseFixtureWithCruft(),
-            checkoutId: "che_x", transactionId: "txn_x", generatedAt: Date())
+            checkoutId: "che_x", transactionId: "txn_x")
 
         let outcomes: [String: PaddlePrefetchOutcome] = [
             "pri_ready": .ready(bandit: bandit, paddle: paddle),
@@ -559,7 +558,7 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
             transactionId: "txn_test", paddleCustomerId: "ctm_x", isKnownCustomer: true, requestId: "req_test")
         let paddle = PaddleTransactionCheckoutResult(
             rawBody: try paddleResponseFixtureWithCruft(),
-            checkoutId: "che_x", transactionId: "txn_test", generatedAt: Date())
+            checkoutId: "che_x", transactionId: "txn_test")
 
         let map = try XCTUnwrap(
             PaddleCheckoutPrefetchCoordinator.encodeBootstrapsToCtx(
@@ -575,6 +574,7 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
         XCTAssertEqual(data["currency_code"] as? String, "USD")
         XCTAssertEqual(data["ip_geo_country_code"] as? String, "US")
         XCTAssertEqual(data["ip_geo_postal_code"] as? String, "94102")
+        XCTAssertEqual(data["created_at"] as? String, "2026-05-07T02:53:11+00:00")
 
         let customer = try XCTUnwrap(data["customer"] as? [String: Any])
         XCTAssertEqual(customer["email"] as? String, "u@e.com")
@@ -618,7 +618,7 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
             transactionId: "txn_x", paddleCustomerId: nil, isKnownCustomer: false, requestId: "req_x")
         let paddle = PaddleTransactionCheckoutResult(
             rawBody: try paddleResponseFixtureWithCruft(),
-            checkoutId: "che_x", transactionId: "txn_x", generatedAt: Date())
+            checkoutId: "che_x", transactionId: "txn_x")
 
         let map = try XCTUnwrap(
             PaddleCheckoutPrefetchCoordinator.encodeBootstrapsToCtx(
@@ -632,7 +632,7 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
             "experimentation",
             "settings",
             "custom_data",
-            "type", "is_free", "environment", "created_at",
+            "type", "is_free", "environment",
             "ip_geo_region", "source_page", "messages", "subscription",
         ] {
             XCTAssertNil(data[key], "Field `\(key)` should be dropped by the trim")

--- a/Tests/helium-swiftTests/PaddleCheckoutPrefetchCoordinatorTests.swift
+++ b/Tests/helium-swiftTests/PaddleCheckoutPrefetchCoordinatorTests.swift
@@ -90,7 +90,8 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
         return PaddleTransactionCheckoutResult(
             rawBody: "{}".data(using: .utf8)!,
             checkoutId: "che_x",
-            transactionId: "txn_x"
+            transactionId: "txn_x",
+            generatedAt: Date()
         )
     }
 
@@ -501,13 +502,13 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
             transactionId: "txn_a", paddleCustomerId: "ctm_a", isKnownCustomer: true, requestId: "req_a")
         let paddle1 = PaddleTransactionCheckoutResult(
             rawBody: try paddleResponseFixtureWithCruft(checkoutId: "che_a", transactionId: "txn_a"),
-            checkoutId: "che_a", transactionId: "txn_a")
+            checkoutId: "che_a", transactionId: "txn_a", generatedAt: Date())
 
         let bandit2 = PaddleCreateTransactionForPaywallResponse(
             transactionId: "txn_b", paddleCustomerId: nil, isKnownCustomer: false, requestId: "req_b")
         let paddle2 = PaddleTransactionCheckoutResult(
             rawBody: try paddleResponseFixtureWithCruft(checkoutId: "che_b", transactionId: "txn_b"),
-            checkoutId: "che_b", transactionId: "txn_b")
+            checkoutId: "che_b", transactionId: "txn_b", generatedAt: Date())
 
         let outcomes: [String: PaddlePrefetchOutcome] = [
             "pri_a": .ready(bandit: bandit1, paddle: paddle1),
@@ -530,7 +531,7 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
             transactionId: "txn_x", paddleCustomerId: nil, isKnownCustomer: false, requestId: "req_x")
         let paddle = PaddleTransactionCheckoutResult(
             rawBody: try paddleResponseFixtureWithCruft(),
-            checkoutId: "che_x", transactionId: "txn_x")
+            checkoutId: "che_x", transactionId: "txn_x", generatedAt: Date())
 
         let outcomes: [String: PaddlePrefetchOutcome] = [
             "pri_ready": .ready(bandit: bandit, paddle: paddle),
@@ -558,7 +559,7 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
             transactionId: "txn_test", paddleCustomerId: "ctm_x", isKnownCustomer: true, requestId: "req_test")
         let paddle = PaddleTransactionCheckoutResult(
             rawBody: try paddleResponseFixtureWithCruft(),
-            checkoutId: "che_x", transactionId: "txn_test")
+            checkoutId: "che_x", transactionId: "txn_test", generatedAt: Date())
 
         let map = try XCTUnwrap(
             PaddleCheckoutPrefetchCoordinator.encodeBootstrapsToCtx(
@@ -617,7 +618,7 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
             transactionId: "txn_x", paddleCustomerId: nil, isKnownCustomer: false, requestId: "req_x")
         let paddle = PaddleTransactionCheckoutResult(
             rawBody: try paddleResponseFixtureWithCruft(),
-            checkoutId: "che_x", transactionId: "txn_x")
+            checkoutId: "che_x", transactionId: "txn_x", generatedAt: Date())
 
         let map = try XCTUnwrap(
             PaddleCheckoutPrefetchCoordinator.encodeBootstrapsToCtx(


### PR DESCRIPTION
…for web checkout

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies external web checkout URL construction and the Paddle prefetch ctx payload, which can affect checkout navigation and downstream bundle parsing. Changes are small and covered by updated unit tests for the Paddle trimming behavior.
> 
> **Overview**
> Bumps the SDK version to `4.4.6`.
> 
> Ensures each external web checkout open triggers a fresh navigation by adding a per-open cache-busting `hlm_ts` query parameter when building the enriched checkout URL (preventing stale fragment-only `ctx` reuse).
> 
> Extends the Paddle prefetch ctx bootstrap trimming allow-list to include `created_at`, and updates tests to assert the field is preserved while other large/unused fields remain dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27e51ba6e87d3a7263c3908e6e7cc8343dd7c4f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Version 4.4.6**

* **Bug Fixes**
  * Improved checkout page loading to ensure fresh navigation on every checkout initiation
  * Enhanced checkout timestamp tracking to include generation timestamps

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudcaptainai/helium-swift/pull/275)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->