### PR TITLE
fail external paddle checkout when prefetch not ready for offered pro…

### DIFF
--- a/Sources/Helium/HeliumCore/BuildConstants.swift
+++ b/Sources/Helium/HeliumCore/BuildConstants.swift
@@ -8,5 +8,5 @@
  */
 public struct BuildConstants {
     /// Current SDK version
-    public static let version = "4.4.7"
+    public static let version = "4.4.8"
 }

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -147,6 +147,19 @@ public class ExternalWebCheckoutManager: NSObject {
                 throw WebCheckoutError.californiaBuyerBlocked
             }
 
+            // Every offered product must be in a renderable state.
+            let notReadyOffered = allPriceIds.filter { priceId in
+                switch outcomes[priceId] ?? .notStarted {
+                case .ready, .alreadyEntitled: return false
+                case .failed, .notStarted: return true
+                }
+            }
+            if !notReadyOffered.isEmpty {
+                HeliumLogger.log(.debug, category: .entitlements,
+                                 "\(provider.displayName) prefetch not ready for offered priceIds: \(notReadyOffered) — failing checkout")
+                throw WebCheckoutError.paddlePrefetchNotReady(priceIds: notReadyOffered)
+            }
+
             paddleBootstrapsDict = PaddleCheckoutPrefetchCoordinator.encodeBootstrapsToCtx(
                 outcomesByPriceId: outcomes
             )

--- a/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
@@ -280,8 +280,7 @@ final class PaddleCheckoutPrefetchCoordinator {
     }
 
     /// Allow-list trim of the Paddle BFF response. On parse failure
-    /// returns `{ "data": [:] }` rather than throwing — the bundle's
-    /// null-checks then default to its live-fetch path.
+    /// returns `{ "data": [:] }` rather than throwing.
     private nonisolated static func trimPaddleCheckoutResponse(rawBody: Data) -> [String: Any] {
         guard let parsed = (try? JSONSerialization.jsonObject(with: rawBody)) as? [String: Any],
               let rawData = parsed["data"] as? [String: Any] else {

--- a/Sources/Helium/HeliumCore/StripeCheckout/WebCheckoutModels.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/WebCheckoutModels.swift
@@ -261,6 +261,7 @@ enum WebCheckoutError: LocalizedError {
     case failedToOpenEnrichedURL
     case webPaywallBundleUrlMissing
     case californiaBuyerBlocked
+    case paddlePrefetchNotReady(priceIds: [String])
 
     var errorDescription: String? {
         switch self {
@@ -280,6 +281,8 @@ enum WebCheckoutError: LocalizedError {
             return "No web paywall bundle URL available for this paywall."
         case .californiaBuyerBlocked:
             return "Checkout not available for California buyers."
+        case .paddlePrefetchNotReady(let priceIds):
+            return "Paddle prefetch did not complete successfully for offered priceIds: \(priceIds.joined(separator: ", "))."
         }
     }
 }


### PR DESCRIPTION
…ducts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pre-checkout gating for Paddle external web checkout, which can block checkout initiation if prefetch is incomplete or fails. Low code footprint, but impacts a revenue-critical flow and adds a new surfaced error case.
> 
> **Overview**
> Prevents Paddle external web checkout from opening when *any offered Paddle priceId* is not in a renderable prefetch state (`.ready`/`.alreadyEntitled`), logging the set of problematic priceIds and throwing a new `WebCheckoutError.paddlePrefetchNotReady`.
> 
> Adds the new `WebCheckoutError` case (with description and stable `caseName`) and bumps `BuildConstants.version` to `4.4.8`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b775adca5796c717d9e01c80a7a588d9ac3c2d12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a readiness check that prevents web checkout from proceeding when payment prefetches are incomplete, improving checkout stability and preventing failures.
  * Improved checkout error messages and diagnostics to surface which price IDs were affected for easier troubleshooting.

* **Chores**
  * Version updated to 4.4.8.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudcaptainai/helium-swift/pull/277)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->