### PR TITLE
Surface postal/region in CA-block error + observability

### DIFF
--- a/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
+++ b/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
@@ -38,7 +38,7 @@ func decomposeError(_ error: Error) -> (httpStatus: Int?, errorClass: String, er
         }
     }
     if let webErr = error as? WebCheckoutError {
-        return (nil, "WebCheckoutError.\(webErr)", webErr.errorDescription)
+        return (nil, "WebCheckoutError.\(webErr.caseName)", webErr.errorDescription)
     }
     let className = String(describing: type(of: error))
     let message = (error as? LocalizedError)?.errorDescription ?? "\(error)"
@@ -127,6 +127,8 @@ struct PaddlePrefetchOutcomeFinalized: HeliumObservabilityEvent {
     let errorClass: String?
     let totalDurationMs: Int
     let ipGeoCountry: String?
+    let ipGeoRegion: String?
+    let ipGeoPostal: String?
 
     var name: String { "paddle_prefetch_outcome_finalized" }
     var properties: [String: Any] {
@@ -137,6 +139,8 @@ struct PaddlePrefetchOutcomeFinalized: HeliumObservabilityEvent {
         ]
         if let errorClass { p["errorClass"] = errorClass }
         if let ipGeoCountry { p["ipGeoCountry"] = ipGeoCountry }
+        if let ipGeoRegion { p["ipGeoRegion"] = ipGeoRegion }
+        if let ipGeoPostal { p["ipGeoPostal"] = ipGeoPostal }
         return p
     }
 }

--- a/Sources/Helium/HeliumCore/Observability/PaddleCheckoutPrefetchCoordinator+Observability.swift
+++ b/Sources/Helium/HeliumCore/Observability/PaddleCheckoutPrefetchCoordinator+Observability.swift
@@ -74,7 +74,9 @@ extension PaddleCheckoutPrefetchCoordinator {
                     outcome: terminalOutcome,
                     errorClass: terminalErrorClass,
                     totalDurationMs: msSince(chainStartedAt),
-                    ipGeoCountry: nil
+                    ipGeoCountry: nil,
+                    ipGeoRegion: nil,
+                    ipGeoPostal: nil
                 ),
                 scope: scope
             )
@@ -92,7 +94,7 @@ extension PaddleCheckoutPrefetchCoordinator {
         let endpointCall: EndpointCallTelemetry
         let outcome: PaddlePrefetchOutcomeKind
         let errorClass: String?
-        let ipGeo: String?
+        let ipGeo: (country: String?, region: String?, postal: String?)
 
         switch result {
         case let .success(rawBody):
@@ -101,14 +103,14 @@ extension PaddleCheckoutPrefetchCoordinator {
             )
             outcome = .ready
             errorClass = nil
-            ipGeo = ipGeoCountryCode(in: rawBody)
+            ipGeo = ipGeoFields(in: rawBody)
         case let .caBlocked(rawBody):
             endpointCall = EndpointCallTelemetry(
                 durationMs: msSince(startedAt), success: true
             )
             outcome = .caBlocked
             errorClass = "PaddleCaliforniaBlocked"
-            ipGeo = ipGeoCountryCode(in: rawBody)
+            ipGeo = ipGeoFields(in: rawBody)
         case let .failed(error):
             let decomposed = decomposeError(error)
             endpointCall = EndpointCallTelemetry(
@@ -120,7 +122,7 @@ extension PaddleCheckoutPrefetchCoordinator {
             )
             outcome = .failed
             errorClass = decomposed.errorClass
-            ipGeo = nil
+            ipGeo = (nil, nil, nil)
         }
 
         HeliumObservabilityManager.shared.track(
@@ -138,18 +140,23 @@ extension PaddleCheckoutPrefetchCoordinator {
                 outcome: outcome,
                 errorClass: errorClass,
                 totalDurationMs: msSince(chainStartedAt),
-                ipGeoCountry: ipGeo
+                ipGeoCountry: ipGeo.country,
+                ipGeoRegion: ipGeo.region,
+                ipGeoPostal: ipGeo.postal
             ),
             scope: scope
         )
     }
 }
 
-private func ipGeoCountryCode(in rawBody: Data) -> String? {
+private func ipGeoFields(in rawBody: Data) -> (country: String?, region: String?, postal: String?) {
     guard let parsed = (try? JSONSerialization.jsonObject(with: rawBody)) as? [String: Any],
-          let data = parsed["data"] as? [String: Any],
-          let cc = data["ip_geo_country_code"] as? String else {
-        return nil
+          let data = parsed["data"] as? [String: Any] else {
+        return (nil, nil, nil)
     }
-    return cc
+    return (
+        data["ip_geo_country_code"] as? String,
+        data["ip_geo_region"] as? String,
+        data["ip_geo_postal_code"] as? String
+    )
 }

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -141,10 +141,10 @@ public class ExternalWebCheckoutManager: NSObject {
                 return .preCheckResolved
             }
 
-            if PaddleCheckoutPrefetchCoordinator.anyCaliforniaBlocked(in: outcomes) {
+            if let caPostal = PaddleCheckoutPrefetchCoordinator.californiaBlockedPostalCode(in: outcomes) {
                 HeliumLogger.log(.debug, category: .entitlements,
-                                 "\(provider.displayName) prefetch blocked for California IP — failing checkout")
-                throw WebCheckoutError.californiaBuyerBlocked
+                                 "\(provider.displayName) prefetch blocked for California IP (postal \(caPostal)) — failing checkout")
+                throw WebCheckoutError.californiaBuyerBlocked(postalCode: caPostal)
             }
 
             paddleBootstrapsDict = PaddleCheckoutPrefetchCoordinator.encodeBootstrapsToCtx(

--- a/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
@@ -376,15 +376,15 @@ final class PaddleCheckoutPrefetchCoordinator {
         return nil
     }
 
-    nonisolated static func anyCaliforniaBlocked(
+    nonisolated static func californiaBlockedPostalCode(
         in outcomes: [String: PaddlePrefetchOutcome]
-    ) -> Bool {
-        return outcomes.values.contains { outcome in
-            if case let .failed(error) = outcome, error is PaddleCaliforniaBlocked {
-                return true
+    ) -> String? {
+        for outcome in outcomes.values {
+            if case let .failed(error) = outcome, let ca = error as? PaddleCaliforniaBlocked {
+                return ca.postalCode
             }
-            return false
         }
+        return nil
     }
 
     // MARK: - Composite key helpers

--- a/Sources/Helium/HeliumCore/StripeCheckout/WebCheckoutModels.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/WebCheckoutModels.swift
@@ -260,7 +260,7 @@ enum WebCheckoutError: LocalizedError {
     case failedToAssembleEnrichedURL
     case failedToOpenEnrichedURL
     case webPaywallBundleUrlMissing
-    case californiaBuyerBlocked
+    case californiaBuyerBlocked(postalCode: String)
 
     var errorDescription: String? {
         switch self {
@@ -278,8 +278,23 @@ enum WebCheckoutError: LocalizedError {
             return "Could not open enriched checkout URL in browser."
         case .webPaywallBundleUrlMissing:
             return "No web paywall bundle URL available for this paywall."
-        case .californiaBuyerBlocked:
-            return "Checkout not available for California buyers."
+        case .californiaBuyerBlocked(let postalCode):
+            return "Checkout not available for California buyers (detected ZIP \(postalCode))."
+        }
+    }
+
+    /// Stable case name for observability. Excludes associated values so
+    /// errorClass groupings don't fragment per-payload.
+    var caseName: String {
+        switch self {
+        case .cannotPresentCheckout: return "cannotPresentCheckout"
+        case .checkoutURLsNotConfigured: return "checkoutURLsNotConfigured"
+        case .invalidBaseURLForComponents: return "invalidBaseURLForComponents"
+        case .failedToCompressCtx: return "failedToCompressCtx"
+        case .failedToAssembleEnrichedURL: return "failedToAssembleEnrichedURL"
+        case .failedToOpenEnrichedURL: return "failedToOpenEnrichedURL"
+        case .webPaywallBundleUrlMissing: return "webPaywallBundleUrlMissing"
+        case .californiaBuyerBlocked: return "californiaBuyerBlocked"
         }
     }
 }

--- a/Sources/Helium/HeliumCore/StripeCheckout/WebCheckoutModels.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/WebCheckoutModels.swift
@@ -283,8 +283,7 @@ enum WebCheckoutError: LocalizedError {
         }
     }
 
-    /// Stable case name for observability. Excludes associated values so
-    /// errorClass groupings don't fragment per-payload.
+    /// Stable case name for observability.
     var caseName: String {
         switch self {
         case .cannotPresentCheckout: return "cannotPresentCheckout"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the external web checkout preflight path and error typing; incorrect wiring could change when checkout is blocked or how errors are reported/aggregated in observability.
> 
> **Overview**
> Enhances Paddle prefetch observability by expanding `paddle_prefetch_outcome_finalized` to include `ipGeoRegion` and `ipGeoPostal`, and parsing these fields from the BFF response.
> 
> Updates the Paddle CA-block precheck in `ExternalWebCheckoutManager` to extract and propagate the detected postal code, changing `WebCheckoutError.californiaBuyerBlocked` to carry a `postalCode` and emit a more specific message.
> 
> Makes `WebCheckoutError` observability-stable by reporting `WebCheckoutError.<caseName>` (instead of interpolating the full enum) via a new `caseName` property.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca24f4304beef370506430a409a884068d3ea3ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messaging for California-based purchase restrictions with specific postal code details

* **Improvements**
  * Expanded geographic data collection in observability tracking for better insights into user location patterns

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudcaptainai/helium-swift/pull/278)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->