### PR TITLE
Kyle/sdk 30 indicate loading post external web checkout

### DIFF
--- a/Sources/Helium/HeliumCore/Components/Web/BackgroundConfig.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/BackgroundConfig.swift
@@ -7,6 +7,19 @@
 
 import Foundation
 import SwiftUI
+import UIKit
+
+extension Color {
+    /// WCAG relative luminance in sRGB. nil if components can't be resolved.
+    var relativeLuminance: CGFloat? {
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        guard UIColor(self).getRed(&r, green: &g, blue: &b, alpha: &a) else { return nil }
+        func linearize(_ c: CGFloat) -> CGFloat {
+            c <= 0.03928 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b)
+    }
+}
 
 // Represents a color stop in a gradient
 public struct GradientStop: Equatable {
@@ -90,6 +103,28 @@ public struct BackgroundConfig {
         return UnitPoint(x: x, y: y)
     }
     
+    var representativeColor: Color? {
+        switch type {
+        case .color(let c):
+            return c
+        case .linearGradient(let stops, _, _):
+            guard !stops.isEmpty else { return nil }
+            return stops[stops.count / 2].color
+        case .image:
+            return nil
+        }
+    }
+
+    var preferredContrastColor: Color {
+        // Default to white for image backgrounds — photographic content varies
+        // and white reads on more of it than black does.
+        guard let color = representativeColor,
+              let luminance = color.relativeLuminance else {
+            return .white
+        }
+        return luminance > 0.5 ? .black : .white
+    }
+
     // Generate the background view
     public func makeBackgroundView() -> some View {
         switch type {

--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -9,6 +9,7 @@ enum FileLoadAttempt {
 
 extension Notification.Name {
     static let heliumEmbeddedPaywallRenderFail = Notification.Name("heliumEmbeddedPaywallRenderFail")
+    static let heliumWebCheckoutProcessingChanged = Notification.Name("heliumWebCheckoutProcessingChanged")
 }
 
 struct DynamicWebView: View {
@@ -35,6 +36,7 @@ struct DynamicWebView: View {
     @State private var webView: WKWebView? = nil
     @State private var showControlPanel = false
     @State private var viewLoadStartTime: Date?
+    @State private var processingVisible = false
     @Environment(\.paywallPresentationState) var presentationState: HeliumPaywallPresentationState
     @Environment(\.colorScheme) private var colorScheme
     
@@ -116,6 +118,27 @@ struct DynamicWebView: View {
                    .ignoresSafeArea()
                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
            }
+
+           if processingVisible {
+               let activeBgConfig = effectiveColorScheme == .dark && darkModePostLoadBackgroundConfig != nil
+                   ? darkModePostLoadBackgroundConfig : postLoadBackgroundConfig
+               ZStack {
+                   if let activeBgConfig {
+                       activeBgConfig.makeBackgroundView()
+                           .opacity(0.65)
+                           .ignoresSafeArea()
+                   } else {
+                       Color.black.opacity(0.3)
+                           .ignoresSafeArea()
+                   }
+                   ProgressView()
+                       .progressViewStyle(.circular)
+                       .controlSize(.large)
+                       .tint(activeBgConfig?.preferredContrastColor ?? .white)
+               }
+               .transition(.opacity)
+               .allowsHitTesting(true)
+           }
        }
        .edgesIgnoringSafeArea(.all)
        .sheet(isPresented: $showControlPanel) {
@@ -155,6 +178,10 @@ struct DynamicWebView: View {
           if !isContentLoaded && res.object as? WKNavigationDelegate === webView?.navigationDelegate {
               webViewLoadFail(reason: "Failed to render paywall.")
           }
+      }
+      .onReceive(NotificationCenter.default.publisher(for: .heliumWebCheckoutProcessingChanged)) { notification in
+          guard let visible = notification.userInfo?["visible"] as? Bool else { return }
+          withAnimation(.easeInOut(duration: 0.15)) { processingVisible = visible }
       }
     }
 

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -586,6 +586,10 @@ public class ExternalWebCheckoutManager: NSObject {
         switch redirectKind {
         case .success:
             HeliumLogger.log(.debug, category: .entitlements, "\(provider.displayName) success redirect handled — checking for new purchase")
+            NotificationCenter.default.post(name: .heliumWebCheckoutProcessingChanged, object: nil, userInfo: ["visible": true])
+            defer {
+                NotificationCenter.default.post(name: .heliumWebCheckoutProcessingChanged, object: nil, userInfo: ["visible": false])
+            }
             _ = await checkForNewPurchaseWithRetry(fromSuccessRedirect: true)
             if !activeCheckoutObservations.isEmpty {
                 armForegroundObserverAfterBackground()

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -590,6 +590,7 @@ public class ExternalWebCheckoutManager: NSObject {
             // Cap the spinner — a slow network call could leave app in unusable state.
             let overlayTimeoutTask = Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 8_000_000_000)
+                if Task.isCancelled { return }
                 NotificationCenter.default.post(name: .heliumWebCheckoutProcessingChanged, object: nil, userInfo: ["visible": false])
             }
             defer {

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -587,7 +587,13 @@ public class ExternalWebCheckoutManager: NSObject {
         case .success:
             HeliumLogger.log(.debug, category: .entitlements, "\(provider.displayName) success redirect handled — checking for new purchase")
             NotificationCenter.default.post(name: .heliumWebCheckoutProcessingChanged, object: nil, userInfo: ["visible": true])
+            // Cap the spinner — a slow network call could leave app in unusable state.
+            let overlayTimeoutTask = Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 8_000_000_000)
+                NotificationCenter.default.post(name: .heliumWebCheckoutProcessingChanged, object: nil, userInfo: ["visible": false])
+            }
             defer {
+                overlayTimeoutTask.cancel()
                 NotificationCenter.default.post(name: .heliumWebCheckoutProcessingChanged, object: nil, userInfo: ["visible": false])
             }
             _ = await checkForNewPurchaseWithRetry(fromSuccessRedirect: true)

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -421,8 +421,8 @@ public class Helium {
         ])
 
         Task { @MainActor in
-            await StripeCheckoutManager.shared.handleExternalReturn(redirectKind: redirectKind)
             await PaddleCheckoutManager.shared.handleExternalReturn(redirectKind: redirectKind)
+            await StripeCheckoutManager.shared.handleExternalReturn(redirectKind: redirectKind)
         }
         return redirectKind
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches external web checkout success-redirect handling and paywall UI rendering; incorrect notification timing or overlay dismissal could block interaction or regress post-checkout UX.
> 
> **Overview**
> Shows a full-screen, blocking `ProgressView` overlay in `DynamicWebView` whenever `.heliumWebCheckoutProcessingChanged` is posted, tinting the spinner for readability based on the active paywall background.
> 
> On external web checkout *success* redirects, `ExternalWebCheckoutManager.handleExternalReturn` now posts this notification before running the entitlement refresh, and guarantees the overlay is dismissed via `defer` plus an 8s timeout fail-safe.
> 
> `BackgroundConfig` gains luminance/contrast helpers (including a `Color.relativeLuminance` implementation) to pick black/white overlay tint, and `Helium.handleURL` reorders Paddle vs Stripe redirect handling calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6daf7a0aa83b70a094a7f2dde1df1f75980b08d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic contrast color selection optimizes text readability against custom backgrounds.
  * Processing indicator now displays during checkout with intelligent timeout handling to prevent stuck spinners.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudcaptainai/helium-swift/pull/279)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->