### PR TITLE
add another retry for post-purchase entitlement check

### DIFF
--- a/Sources/Helium/HeliumCore/BuildConstants.swift
+++ b/Sources/Helium/HeliumCore/BuildConstants.swift
@@ -8,5 +8,5 @@
  */
 public struct BuildConstants {
     /// Current SDK version
-    public static let version = "4.4.8"
+    public static let version = "4.4.9"
 }

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -420,7 +420,10 @@ public class ExternalWebCheckoutManager: NSObject {
     /// purchase was detected.
     @MainActor
     private func checkForNewPurchaseWithRetry(fromSuccessRedirect: Bool = false) async -> Bool {
-        let delays: [UInt64] = [0, 2_000_000_000]
+        var delays: [UInt64] = [0, 2_000_000_000]
+        if fromSuccessRedirect {
+            delays.append(3_000_000_000)
+        }
 
         guard let newestObservation = activeCheckoutObservations.values.max(by: { $0.addedAt < $1.addedAt }) else {
             return false


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches purchase/entitlement detection timing in the external web checkout flow, which can affect whether purchases are recognized promptly. Change is small but in a revenue-critical path and could impact UX if the added delay behaves unexpectedly.
> 
> **Overview**
> Bumps `BuildConstants.version` from `4.4.8` to `4.4.9`.
> 
> Updates `ExternalWebCheckoutManager.checkForNewPurchaseWithRetry` to add a **third retry delay** (additional `3s` sleep) *only when invoked from a success redirect*, improving reliability of detecting newly available entitlements immediately after completing an external checkout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 713f4ee9b4f0325a5697611394db21e07cc613a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 4.4.9

* **Bug Fixes**
  * Improved retry timing for purchase detection during payment redirects with extended wait period

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudcaptainai/helium-swift/pull/280)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->