### PR TITLE
add Helium.config.paywallPreviewsAutoEnabledInDevBuilds flag to disab…

### DIFF
--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelService.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelService.swift
@@ -8,6 +8,9 @@ class HeliumControlPanelService {
         if HeliumFetchedConfigManager.shared.fetchedConfig?.enableProductionPaywallPreviews == true {
             return true
         }
+        guard Helium.config.paywallPreviewsAutoEnabledInDevBuilds else {
+            return false
+        }
         let env = AppReceiptsHelper.shared.getEnvironment()
         return env == AppReceiptsHelper.Environment.debug.rawValue
             || env == AppReceiptsHelper.Environment.sandbox.rawValue

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -654,6 +654,16 @@ public class HeliumConfig {
     /// Set this to `false` to disable the diagnostic view for all users in DEBUG builds.
     public var paywallNotShownDiagnosticDisplayEnabled: Bool = true
 
+    /// Controls whether the triple-tap paywall previews UI is automatically enabled in DEBUG and TestFlight builds.
+    ///
+    /// When `true` (default), anyone running a DEBUG or TestFlight build can triple-tap a paywall to browse previews.
+    /// Set this to `false` to suppress the env-based enable — useful if you ship TestFlight builds to non-technical testers
+    /// who are confused by the preview UI.
+    ///
+    /// Independent of this flag, you can still grant preview access to specific users in any environment by configuring
+    /// a target audience for paywall previews in the Helium dashboard.
+    public var paywallPreviewsAutoEnabledInDevBuilds: Bool = true
+
     // MARK: - External Web Checkout Configuration
 
     /// Which External Web Checkout payment processors are enabled. Empty means disabled.


### PR DESCRIPTION
…le triple-tap previews in DEBUG/TestFlight builds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single configuration flag gating the DEBUG/TestFlight paywall preview UI, with default preserving existing behavior.
> 
> **Overview**
> Adds `Helium.config.paywallPreviewsAutoEnabledInDevBuilds` (default `true`) to let apps suppress the triple-tap paywall previews UI in DEBUG/TestFlight builds.
> 
> Updates `HeliumControlPanelService.allowPaywallControlPanel` to respect this flag before enabling previews based on receipt environment, while still allowing production preview access when enabled via fetched config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73729f0cff14865b98c36a7f77f8e0a44aff7be2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new configuration flag for controlling paywall preview visibility in development environments. The feature automatically enables preview functionality in DEBUG and TestFlight builds by default, supporting backward compatibility. It can be disabled per application needs, with manual access to previews remaining available through dashboard audience targeting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudcaptainai/helium-swift/pull/281?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->