### PR TITLE
new release; public-facing copy adjustments; stricter web checkout en…

### DIFF
--- a/HeliumExample/HeliumExample/HeliumExampleApp.swift
+++ b/HeliumExample/HeliumExample/HeliumExampleApp.swift
@@ -28,8 +28,6 @@ struct HeliumExampleApp: App {
         let fallbackTestMode = ProcessInfo.processInfo.environment["FALLBACK_TEST_MODE"]
         preInitializeTestSetup(loadStateTestTrigger: loadStateTestTrigger, fallbackTestMode: fallbackTestMode)
         
-        Helium.shared.addHeliumEventListener(LogHeliumEventListener.shared)
-        
         let apiKey: String = if fallbackTestMode == FallbackTestMode.downloadFailure.rawValue {
             "invalid_api_key_for_testing"
         } else {
@@ -87,14 +85,6 @@ struct HeliumExampleApp: App {
                 print("[Helium Example] fallback loading_budget - Could not show paywall. \(reason)")
             }
         }
-    }
-}
-
-fileprivate class LogHeliumEventListener: HeliumEventListener {
-    static let shared = LogHeliumEventListener()
-
-    func onHeliumEvent(event: any HeliumEvent) {
-        print("[Helium Example] Helium event - \(event.toDictionary())")
     }
 }
 

--- a/Sources/Helium/HeliumCore/BuildConstants.swift
+++ b/Sources/Helium/HeliumCore/BuildConstants.swift
@@ -8,5 +8,5 @@
  */
 public struct BuildConstants {
     /// Current SDK version
-    public static let version = "4.4.8"
+    public static let version = "4.4.9"
 }

--- a/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
+++ b/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
@@ -559,9 +559,9 @@ extension HeliumPaywallPresenter {
                 return fallbackViewFor(trigger: trigger, paywallInfo: templatePaywallInfo, fallbackReason: .webCheckoutNoCustomUserId, presentationContext: presentationContext)
             }
             let processors = Helium.config.webCheckoutProcessors
-            let paddleUsable = hasPaddleProducts && processors.contains(.paddle)
-            let stripeUsable = hasStripeProducts && processors.contains(.stripe)
-            if hasAppToWebProducts && !(paddleUsable || stripeUsable) {
+            let paddleBroken = hasPaddleProducts && !processors.contains(.paddle)
+            let stripeBroken = hasStripeProducts && !processors.contains(.stripe)
+            if paddleBroken || stripeBroken {
                 return fallbackViewFor(trigger: trigger, paywallInfo: templatePaywallInfo, fallbackReason: .webCheckoutNotEnabled, presentationContext: presentationContext)
             }
             

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -654,14 +654,9 @@ public class HeliumConfig {
     /// Set this to `false` to disable the diagnostic view for all users in DEBUG builds.
     public var paywallNotShownDiagnosticDisplayEnabled: Bool = true
 
-    /// Controls whether the triple-tap paywall previews UI is automatically enabled in DEBUG and TestFlight builds.
+    /// Controls whether the triple-tap paywall previews UI is automatically enabled in DEBUG and TestFlight builds..
     ///
-    /// When `true` (default), anyone running a DEBUG or TestFlight build can triple-tap a paywall to browse previews.
-    /// Set this to `false` to suppress the env-based enable — useful if you ship TestFlight builds to non-technical testers
-    /// who are confused by the preview UI.
-    ///
-    /// Independent of this flag, you can still grant preview access to specific users in any environment by configuring
-    /// a target audience for paywall previews in the Helium dashboard.
+    /// Defaults to `true`.
     public var paywallPreviewsAutoEnabledInDevBuilds: Bool = true
 
     // MARK: - External Web Checkout Configuration

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -654,7 +654,7 @@ public class HeliumConfig {
     /// Set this to `false` to disable the diagnostic view for all users in DEBUG builds.
     public var paywallNotShownDiagnosticDisplayEnabled: Bool = true
 
-    /// Controls whether the triple-tap paywall previews UI is automatically enabled in DEBUG and TestFlight builds..
+    /// Controls whether the triple-tap paywall previews UI is automatically enabled in DEBUG and TestFlight builds.
     ///
     /// Defaults to `true`.
     public var paywallPreviewsAutoEnabledInDevBuilds: Bool = true

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -654,7 +654,7 @@ public class HeliumConfig {
     /// Set this to `false` to disable the diagnostic view for all users in DEBUG builds.
     public var paywallNotShownDiagnosticDisplayEnabled: Bool = true
 
-    /// Controls whether the triple-tap paywall previews UI is automatically enabled in DEBUG and TestFlight builds.
+    /// Controls whether the triple-tap paywall previews gesture is enabled in DEBUG and TestFlight builds.
     ///
     /// Defaults to `true`.
     public var paywallPreviewsAutoEnabledInDevBuilds: Bool = true


### PR DESCRIPTION
…abled check; remove superfluous example app logging

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Paywall presentation logic for Paddle/Stripe changed so apps with only one processor enabled may now see fallbacks on paywalls that list both provider product types.
> 
> **Overview**
> Releases **4.4.9** and tightens how paywalls with **Paddle/Stripe** products behave when external web checkout is only partly configured.
> 
> **Web checkout:** Presentation now treats each processor separately—if a paywall includes Paddle products but Paddle isn’t in `webCheckoutProcessors` (or Stripe products without Stripe), it falls back with `.webCheckoutNotEnabled` instead of only failing when *no* configured processor can serve the paywall. Mixed Paddle + Stripe templates require both processors enabled when both product types are present.
> 
> **Docs & sample app:** `paywallPreviewsAutoEnabledInDevBuilds` public comments are shortened to describe the triple-tap preview gesture default. The example app no longer registers a `LogHeliumEventListener` that printed every Helium event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1e046fab4635cac142626f6734ada720f5629ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Version Update**
  * Released version 4.4.9

* **Bug Fixes**
  * Improved web-checkout paywall fallback handling

* **Documentation**
  * Updated paywall preview configuration documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudcaptainai/helium-swift/pull/282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->