### PR TITLE
Forward Paddle defaultDiscountId to create-transaction so discounts apply (HEL-5609)

### DIFF
--- a/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
+++ b/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
@@ -91,6 +91,7 @@ struct PaddlePrefetchStarted: HeliumObservabilityEvent {
 
 struct PaddlePrefetchBanditCompleted: HeliumObservabilityEvent {
     let priceId: String
+    let discountId: String?
     let endpointCall: EndpointCallTelemetry
     let alreadyEntitledCode: String?
 
@@ -98,6 +99,7 @@ struct PaddlePrefetchBanditCompleted: HeliumObservabilityEvent {
     var properties: [String: Any] {
         var p = endpointCall.properties
         p["priceId"] = priceId
+        if let discountId { p["discountId"] = discountId }
         if let alreadyEntitledCode { p["alreadyEntitledCode"] = alreadyEntitledCode }
         return p
     }

--- a/Sources/Helium/HeliumCore/Observability/PaddleCheckoutPrefetchCoordinator+Observability.swift
+++ b/Sources/Helium/HeliumCore/Observability/PaddleCheckoutPrefetchCoordinator+Observability.swift
@@ -16,6 +16,7 @@ extension PaddleCheckoutPrefetchCoordinator {
 
     nonisolated static func trackBanditCompletion(
         priceId: String,
+        discountId: String?,
         scope: PaywallObservabilityScope,
         startedAt: Date,
         chainStartedAt: Date,
@@ -61,6 +62,7 @@ extension PaddleCheckoutPrefetchCoordinator {
         HeliumObservabilityManager.shared.track(
             PaddlePrefetchBanditCompleted(
                 priceId: priceId,
+                discountId: discountId,
                 endpointCall: endpointCall,
                 alreadyEntitledCode: alreadyEntitledCode
             ),

--- a/Sources/Helium/HeliumCore/PriceFetcher.swift
+++ b/Sources/Helium/HeliumCore/PriceFetcher.swift
@@ -136,6 +136,11 @@ public struct ServerProductPrice: Codable {
     public let productType: String?
     public let subscriptionPeriod: String?
     public let subscription: ServerSubscriptionDetail?
+    /// Bucket-level Paddle discount id (dsc_xxx) the creator attached to this
+    /// price in the dashboard. Forwarded to /paddle/create-transaction-for-paywall
+    /// so the bandit can attach it (subject to the bandit's intro-offer
+    /// eligibility gate). Nil when no discount is configured. Paddle-only.
+    public let defaultDiscountId: String?
 
     public func toLocalizedPrice() -> LocalizedPrice {
         let baseInfo = BasePriceInfo(

--- a/Sources/Helium/HeliumCore/PriceFetcher.swift
+++ b/Sources/Helium/HeliumCore/PriceFetcher.swift
@@ -136,10 +136,10 @@ public struct ServerProductPrice: Codable {
     public let productType: String?
     public let subscriptionPeriod: String?
     public let subscription: ServerSubscriptionDetail?
-    /// Bucket-level Paddle discount id (dsc_xxx) the creator attached to this
-    /// price in the dashboard. Forwarded to /paddle/create-transaction-for-paywall
-    /// so the bandit can attach it (subject to the bandit's intro-offer
-    /// eligibility gate). Nil when no discount is configured. Paddle-only.
+    /// Bucket-level Paddle discount id (dsc_xxx) configured by the creator.
+    /// Forwarded to the create-transaction endpoint, which decides whether to
+    /// apply it based on the customer's eligibility. Nil when no discount is
+    /// configured. Paddle-only.
     public let defaultDiscountId: String?
 
     public func toLocalizedPrice() -> LocalizedPrice {

--- a/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentAPIClient.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentAPIClient.swift
@@ -101,12 +101,20 @@ public class HeliumPaymentAPIClient {
     /// `HeliumPaymentAPIError.serverError`. `priceId` is the bare
     /// `pri_xxx` form.
     func createPaddleTransactionForPaywall(
-        priceId: String
+        priceId: String,
+        discountId: String? = nil
     ) async throws -> PaddleCreateTransactionForPaywallResponse {
         var body = try baseRequestBody(provider: .paddle)
         body["priceId"] = priceId
         if let orgId = HeliumFetchedConfigManager.shared.getOrganizationID(), !orgId.isEmpty {
             body["orgId"] = orgId
+        }
+        // Forward the creator-configured discount id when present. The bandit
+        // treats an empty/absent discountId as a no-op, so omit it entirely
+        // rather than sending "" — the attach decision (incl. intro-offer
+        // eligibility) is enforced server-side in shouldAttachDiscount.
+        if let discountId, !discountId.isEmpty {
+            body["discountId"] = discountId
         }
 
         let request = try makePostRequest(path: "paddle/create-transaction-for-paywall", body: body)

--- a/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentAPIClient.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentAPIClient.swift
@@ -109,10 +109,9 @@ public class HeliumPaymentAPIClient {
         if let orgId = HeliumFetchedConfigManager.shared.getOrganizationID(), !orgId.isEmpty {
             body["orgId"] = orgId
         }
-        // Forward the creator-configured discount id when present. The bandit
-        // treats an empty/absent discountId as a no-op, so omit it entirely
-        // rather than sending "" — the attach decision (incl. intro-offer
-        // eligibility) is enforced server-side in shouldAttachDiscount.
+        // Forward the creator-configured discount id when present; omit it
+        // entirely rather than sending "". The backend decides whether to
+        // apply it based on the customer's eligibility.
         if let discountId, !discountId.isEmpty {
             body["discountId"] = discountId
         }

--- a/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
@@ -77,10 +77,9 @@ final class PaddleCheckoutPrefetchCoordinator {
         let priceIds = Self.extractPriceIds(from: webProducts)
         guard !priceIds.isEmpty else { return }
 
-        // Map each composite key ("pro_xxx:pri_yyy") to its creator-configured
-        // discount id, so the prefetch transaction is created WITH the discount
-        // attached. The bandit applies its own intro-offer eligibility gate
-        // (shouldAttachDiscount), so we forward unconditionally here.
+        // Map each offered price to its creator-configured discount id and
+        // forward it with the prefetch. The backend decides whether to apply
+        // it, so we forward whenever a discount is configured.
         let discountIdByPriceId = Self.discountIdByPriceId(
             from: webProducts,
             priceMap: HeliumFetchedConfigManager.shared.getPaddleProductsPriceMap() ?? [:]
@@ -471,12 +470,12 @@ final class PaddleCheckoutPrefetchCoordinator {
                 PaymentProviderConfig.paddle.setCustomerId(customerId)
             }
             
-            trackBanditCompletion(priceId: priceId, scope: scope, startedAt: banditStart, chainStartedAt: chainStart, result: .success)
+            trackBanditCompletion(priceId: priceId, discountId: discountId, scope: scope, startedAt: banditStart, chainStartedAt: chainStart, result: .success)
         } catch let PaddlePrefetchError.alreadyEntitled(code, message, existingSubscriptionId) {
-            trackBanditCompletion(priceId: priceId, scope: scope, startedAt: banditStart, chainStartedAt: chainStart, result: .alreadyEntitled(code: code, message: message))
+            trackBanditCompletion(priceId: priceId, discountId: discountId, scope: scope, startedAt: banditStart, chainStartedAt: chainStart, result: .alreadyEntitled(code: code, message: message))
             return .alreadyEntitled(code: code, message: message, existingSubscriptionId: existingSubscriptionId)
         } catch {
-            trackBanditCompletion(priceId: priceId, scope: scope, startedAt: banditStart, chainStartedAt: chainStart, result: .failed(error))
+            trackBanditCompletion(priceId: priceId, discountId: discountId, scope: scope, startedAt: banditStart, chainStartedAt: chainStart, result: .failed(error))
             return .failed(error: error)
         }
 

--- a/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
@@ -83,7 +83,7 @@ final class PaddleCheckoutPrefetchCoordinator {
         // (shouldAttachDiscount), so we forward unconditionally here.
         let discountIdByPriceId = Self.discountIdByPriceId(
             from: webProducts,
-            priceMap: HeliumFetchedConfigManager.shared.getPaddleProductsPriceMap()
+            priceMap: HeliumFetchedConfigManager.shared.getPaddleProductsPriceMap() ?? [:]
         )
 
         prefetch(
@@ -426,14 +426,14 @@ final class PaddleCheckoutPrefetchCoordinator {
     ///
     /// The price map is keyed by the same "pro:pri" composite the on-launch
     /// `paddleProducts` object uses, so we look up by composite first and
-    /// fall back to the bare priceId for resilience to key-shape drift.
+    /// otherwise use the bare priceId for resilience to key-shape drift.
     /// Pure: no SDK / network. Returns priceId-keyed so callers can index by
     /// the bare priceId they already iterate.
     nonisolated static func discountIdByPriceId(
         from composites: [String],
-        priceMap: [String: ServerProductPrice]?
+        priceMap: [String: ServerProductPrice] = [:]
     ) -> [String: String] {
-        guard let priceMap, !priceMap.isEmpty else { return [:] }
+        guard !priceMap.isEmpty else { return [:] }
         var result: [String: String] = [:]
         for composite in composites {
             guard let priceId = extractPriceId(from: composite) else { continue }

--- a/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
@@ -77,9 +77,19 @@ final class PaddleCheckoutPrefetchCoordinator {
         let priceIds = Self.extractPriceIds(from: webProducts)
         guard !priceIds.isEmpty else { return }
 
+        // Map each composite key ("pro_xxx:pri_yyy") to its creator-configured
+        // discount id, so the prefetch transaction is created WITH the discount
+        // attached. The bandit applies its own intro-offer eligibility gate
+        // (shouldAttachDiscount), so we forward unconditionally here.
+        let discountIdByPriceId = Self.discountIdByPriceId(
+            from: webProducts,
+            priceMap: HeliumFetchedConfigManager.shared.getPaddleProductsPriceMap()
+        )
+
         prefetch(
             paywallSession: paywallSession,
             priceIds: priceIds,
+            discountIdByPriceId: discountIdByPriceId,
             paddleClientToken: clientToken,
             iosBundleId: Bundle.main.bundleIdentifier
         )
@@ -95,6 +105,7 @@ final class PaddleCheckoutPrefetchCoordinator {
     func prefetch(
         paywallSession: PaywallSession,
         priceIds: [String],
+        discountIdByPriceId: [String: String] = [:],
         paddleClientToken: String,
         iosBundleId: String?
     ) {
@@ -107,10 +118,12 @@ final class PaddleCheckoutPrefetchCoordinator {
 
             let bandit = banditClient
             let bff = bffClient
+            let discountId = discountIdByPriceId[priceId]
 
             cache[key] = Task.detached(priority: .userInitiated) {
                 await Self.runPrefetchChain(
                     priceId: priceId,
+                    discountId: discountId,
                     paddleClientToken: paddleClientToken,
                     iosBundleId: iosBundleId,
                     banditClient: bandit,
@@ -407,6 +420,31 @@ final class PaddleCheckoutPrefetchCoordinator {
         return composites.compactMap(extractPriceId)
     }
 
+    /// Builds a `priceId → discountId` map by looking up each composite key
+    /// ("pro_xxx:pri_yyy") in the Paddle products price map and reading its
+    /// `defaultDiscountId`. Keys with no configured discount are omitted.
+    ///
+    /// The price map is keyed by the same "pro:pri" composite the on-launch
+    /// `paddleProducts` object uses, so we look up by composite first and
+    /// fall back to the bare priceId for resilience to key-shape drift.
+    /// Pure: no SDK / network. Returns priceId-keyed so callers can index by
+    /// the bare priceId they already iterate.
+    nonisolated static func discountIdByPriceId(
+        from composites: [String],
+        priceMap: [String: ServerProductPrice]?
+    ) -> [String: String] {
+        guard let priceMap, !priceMap.isEmpty else { return [:] }
+        var result: [String: String] = [:]
+        for composite in composites {
+            guard let priceId = extractPriceId(from: composite) else { continue }
+            let entry = priceMap[composite] ?? priceMap[priceId]
+            if let discountId = entry?.defaultDiscountId, !discountId.isEmpty {
+                result[priceId] = discountId
+            }
+        }
+        return result
+    }
+
     // MARK: - Internal chain runner
 
     /// `nonisolated` is load-bearing: without it, this static method
@@ -414,6 +452,7 @@ final class PaddleCheckoutPrefetchCoordinator {
     /// the main actor, defeating off-actor URLSession dispatch.
     private nonisolated static func runPrefetchChain(
         priceId: String,
+        discountId: String?,
         paddleClientToken: String,
         iosBundleId: String?,
         banditClient: HeliumPaymentAPIClient,
@@ -424,7 +463,10 @@ final class PaddleCheckoutPrefetchCoordinator {
         let banditStart = Date()
         let banditResponse: PaddleCreateTransactionForPaywallResponse
         do {
-            banditResponse = try await banditClient.createPaddleTransactionForPaywall(priceId: priceId)
+            banditResponse = try await banditClient.createPaddleTransactionForPaywall(
+                priceId: priceId,
+                discountId: discountId
+            )
             if let customerId = banditResponse.paddleCustomerId, !customerId.isEmpty {
                 PaymentProviderConfig.paddle.setCustomerId(customerId)
             }

--- a/Tests/helium-swiftTests/PaddleCheckoutPrefetchClientTests.swift
+++ b/Tests/helium-swiftTests/PaddleCheckoutPrefetchClientTests.swift
@@ -331,7 +331,7 @@ final class PaddleCheckoutPrefetchClientTests: XCTestCase {
         XCTAssertEqual(bodyDict["heliumPersistentId"] as? String, HeliumIdentityManager.shared.getHeliumPersistentId())
     }
 
-    // MARK: - createPaddleTransactionForPaywall — discountId forwarding
+    // MARK: - createPaddleTransactionForPaywall discountId forwarding
 
     func testCreatePaddleTransactionForPaywall_includesDiscountIdWhenProvided() async throws {
         let bodyJSON = """
@@ -355,7 +355,7 @@ final class PaddleCheckoutPrefetchClientTests: XCTestCase {
         XCTAssertEqual(
             bodyDict["discountId"] as? String,
             "dsc_01kt7y5xsh94z97bwfq4de1f7k",
-            "Expected the bucket-level discount id to be forwarded to /paddle/create-transaction-for-paywall so the bandit can attach it"
+            "Expected the bucket-level discount id to be forwarded in the create-transaction request body"
         )
     }
 
@@ -397,11 +397,11 @@ final class PaddleCheckoutPrefetchClientTests: XCTestCase {
         )
         XCTAssertNil(
             bodyDict["discountId"],
-            "An empty discountId must not be sent — the bandit treats empty as no-op, so omit it entirely"
+            "An empty discountId must not be sent; omit it entirely when no discount is configured"
         )
     }
 
-    // MARK: - ServerProductPrice — defaultDiscountId decoding
+    // MARK: - ServerProductPrice defaultDiscountId decoding
 
     func testServerProductPrice_decodesDefaultDiscountId() throws {
         let json = """

--- a/Tests/helium-swiftTests/PaddleCheckoutPrefetchClientTests.swift
+++ b/Tests/helium-swiftTests/PaddleCheckoutPrefetchClientTests.swift
@@ -330,4 +330,96 @@ final class PaddleCheckoutPrefetchClientTests: XCTestCase {
 
         XCTAssertEqual(bodyDict["heliumPersistentId"] as? String, HeliumIdentityManager.shared.getHeliumPersistentId())
     }
+
+    // MARK: - createPaddleTransactionForPaywall — discountId forwarding
+
+    func testCreatePaddleTransactionForPaywall_includesDiscountIdWhenProvided() async throws {
+        let bodyJSON = """
+        {"transactionId": "txn_x", "isKnownCustomer": false, "requestId": "req_x"}
+        """
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, bodyJSON.data(using: .utf8)!)
+        }
+
+        _ = try await client.createPaddleTransactionForPaywall(
+            priceId: "pri_specific_price",
+            discountId: "dsc_01kt7y5xsh94z97bwfq4de1f7k"
+        )
+
+        let captured = try XCTUnwrap(MockURLProtocol.capturedRequests.first)
+        let bodyDict = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: captured.httpBody ?? Data()) as? [String: Any]
+        )
+        XCTAssertEqual(bodyDict["priceId"] as? String, "pri_specific_price")
+        XCTAssertEqual(
+            bodyDict["discountId"] as? String,
+            "dsc_01kt7y5xsh94z97bwfq4de1f7k",
+            "Expected the bucket-level discount id to be forwarded to /paddle/create-transaction-for-paywall so the bandit can attach it"
+        )
+    }
+
+    func testCreatePaddleTransactionForPaywall_omitsDiscountIdWhenNil() async throws {
+        let bodyJSON = """
+        {"transactionId": "txn_x", "isKnownCustomer": false, "requestId": "req_x"}
+        """
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, bodyJSON.data(using: .utf8)!)
+        }
+
+        _ = try await client.createPaddleTransactionForPaywall(priceId: "pri_no_discount")
+
+        let captured = try XCTUnwrap(MockURLProtocol.capturedRequests.first)
+        let bodyDict = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: captured.httpBody ?? Data()) as? [String: Any]
+        )
+        XCTAssertNil(
+            bodyDict["discountId"],
+            "discountId must be omitted (not sent empty) when the price has no configured discount"
+        )
+    }
+
+    func testCreatePaddleTransactionForPaywall_omitsDiscountIdWhenEmptyString() async throws {
+        let bodyJSON = """
+        {"transactionId": "txn_x", "isKnownCustomer": false, "requestId": "req_x"}
+        """
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, bodyJSON.data(using: .utf8)!)
+        }
+
+        _ = try await client.createPaddleTransactionForPaywall(priceId: "pri_empty", discountId: "")
+
+        let captured = try XCTUnwrap(MockURLProtocol.capturedRequests.first)
+        let bodyDict = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: captured.httpBody ?? Data()) as? [String: Any]
+        )
+        XCTAssertNil(
+            bodyDict["discountId"],
+            "An empty discountId must not be sent — the bandit treats empty as no-op, so omit it entirely"
+        )
+    }
+
+    // MARK: - ServerProductPrice — defaultDiscountId decoding
+
+    func testServerProductPrice_decodesDefaultDiscountId() throws {
+        let json = """
+        {
+            "id": "pro_01kt7406rbge4zkz8qx48dt7mh",
+            "priceId": "pri_01kt740yd827h5dweb3yxpg2x5",
+            "defaultDiscountId": "dsc_01kt7y5xsh94z97bwfq4de1f7k"
+        }
+        """
+        let price = try JSONDecoder().decode(ServerProductPrice.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(price.defaultDiscountId, "dsc_01kt7y5xsh94z97bwfq4de1f7k")
+    }
+
+    func testServerProductPrice_defaultDiscountIdAbsentWhenOmitted() throws {
+        let json = """
+        { "id": "pro_x", "priceId": "pri_x" }
+        """
+        let price = try JSONDecoder().decode(ServerProductPrice.self, from: json.data(using: .utf8)!)
+        XCTAssertNil(price.defaultDiscountId)
+    }
 }


### PR DESCRIPTION
## What

Forwards the creator-configured Paddle **discount id** from the on-launch config into the prefetch's create-transaction call, so configured discounts actually apply to the charge. Previously the discount was dropped at the SDK and every customer paid full price.

## Why (root cause)

CML attaches a Paddle discount per price; the bandit stamps it onto on-launch as `paddleProducts["pro:pri"].defaultDiscountId`. But the SDK never read or forwarded it:

- `ServerProductPrice` didn't declare a discount field, so `defaultDiscountId` was silently dropped on decode.
- `createPaddleTransactionForPaywall(priceId:)` sent `priceId` + `orgId` only.
- The bandit's `shouldAttachDiscount` short-circuits to `false` when `discountID == ""`, so nothing was ever attached.

Net: discount configured + baked everywhere upstream, but the charge was always full price.

## Changes

| File | Change |
|---|---|
| `PriceFetcher.swift` | Decode `defaultDiscountId` on `ServerProductPrice` (optional). |
| `HeliumPaymentAPIClient.swift` | `createPaddleTransactionForPaywall` gains optional `discountId`, sent in body only when non-empty. |
| `PaddleCheckoutPrefetchCoordinator.swift` | New pure helper `discountIdByPriceId(from:priceMap:)` maps each offered price to its `defaultDiscountId`; threaded `handlePaywallOpen → prefetch → runPrefetchChain → createPaddleTransactionForPaywall`. |

Both new parameters are default-valued, so existing call sites compile unchanged.

## Server contract (unchanged, already supports this)

The bandit already accepts `discountId` (`PaddleCreateTransactionForPaywallRequest.DiscountID`, `json:"discountId"`) and gates attachment behind intro-offer eligibility (`shouldAttachDiscount`). The SDK forwards unconditionally; the **bandit owns the eligibility decision**, so ineligible customers are still correctly denied the discount server-side.

## Tests

Added to `PaddleCheckoutPrefetchClientTests`:
- `discountId` included in the request body when provided.
- omitted when nil / when empty string (never sent as `""`).
- `ServerProductPrice` decodes `defaultDiscountId`, and it's nil when absent.

## Verification note

The iOS test suite (`xcodebuild test -scheme helium-swift -destination "platform=iOS Simulator,..."`) **could not be run in my local environment** (Command Line Tools only, no Xcode/iOS simulator). The pure mapping helper logic was verified independently against the real on-launch payload, but **CI must be green before merge** — please confirm the simulator test job passes.

## Related (separate PRs, not in this one)

- **CML** (display consistency): the paywall template still shows a discount to ineligible customers because the resolver doesn't gate `product.discount` on eligibility. Separate PR strips it so display matches the server-side charge.
- **bandit** (defense-in-depth): gate `defaultDiscountId` in `buildPaddleProductsMap` so ineligible customers don't even receive it in on-launch. Separate PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Paddle paywall transaction-creation path and what customers are charged, but optional parameters preserve existing call sites and the server still gates discount attachment.
> 
> **Overview**
> Fixes configured Paddle discounts being ignored at checkout by **decoding** `defaultDiscountId` on `ServerProductPrice` and **threading** it through paywall prefetch into `paddle/create-transaction-for-paywall`.
> 
> On paywall open, a new **`discountIdByPriceId`** helper maps each offered `pro:pri` composite to the bucket discount from the on-launch price map; that id is passed through **`prefetch` → `runPrefetchChain` → `createPaddleTransactionForPaywall`**, which adds **`discountId`** to the JSON body only when non-nil and non-empty (never `""`). Eligibility to apply the discount stays on the **bandit**; the SDK forwards whenever a discount is configured.
> 
> **`PaddlePrefetchBanditCompleted`** observability now optionally records **`discountId`**. Tests cover request-body forwarding (present / nil / empty) and **`ServerProductPrice`** decoding of the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8609e6af6e36edae5adca1f905f794c31776ec81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paddle discounts can be configured per product price and are now included when creating paywall transactions (mapped and forwarded when present).

* **Tests**
  * Added test coverage for discount handling, verifying discounts are forwarded when set and omitted when nil/empty, and for decoding the optional default discount field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->