### PR TITLE
HEL-5766 Fix data race on heliumUserTraits and enable TSan in unit-test CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,11 +21,12 @@ jobs:
       SIMULATOR_NAME: iPhone 17
     steps:
       - uses: actions/checkout@v4
-      - name: Run SwiftPM tests
+      - name: Run SwiftPM tests with Thread Sanitizer
         run: |
           xcodebuild test \
             -scheme helium-swift \
             -destination "platform=iOS Simulator,name=$SIMULATOR_NAME" \
+            -enableThreadSanitizer YES \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO
 

--- a/Sources/Helium/HeliumCore/HeliumIdentityManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumIdentityManager.swift
@@ -28,7 +28,7 @@ public class HeliumIdentityManager {
     // MARK: - Properties
     private let heliumSessionId: String
     private(set) var heliumInitializeId: String
-    private var heliumUserTraits: HeliumUserTraits
+    @HeliumAtomic private var heliumUserTraits: HeliumUserTraits = HeliumUserTraits([:])
     private(set) var isFirstHeliumSession: Bool = false
     
     // Used to connect StoreKit purchase events
@@ -104,7 +104,7 @@ public class HeliumIdentityManager {
     }
 
     func addToCustomUserTraits(_ additionalTraits: HeliumUserTraits) {
-        heliumUserTraits.merge(additionalTraits)
+        _heliumUserTraits.withValue { $0.merge(additionalTraits) }
         persistUserTraits()
     }
 

--- a/Tests/helium-swiftTests/ConfigIdentityTests.swift
+++ b/Tests/helium-swiftTests/ConfigIdentityTests.swift
@@ -59,4 +59,58 @@ final class ConfigIdentityTests: XCTestCase {
         let retrieved = Helium.identify.getUserTraits()
         XCTAssertEqual(retrieved["plan"] as? String, "premium")
     }
+
+    /// Regression test for an analytics-manager-queue crash reported by a customer:
+    ///   `_dictionaryDownCast` → `objc_msgSend` while encoding `HeliumUserTraits` from
+    ///   `HeliumAnalyticsManager.performIdentify`. Root cause is a data race on
+    ///   `HeliumIdentityManager.heliumUserTraits`: writers (`setUserTraits` / `addUserTraits`)
+    ///   run on caller threads while a reader on `com.helium.analyticsManager` copies the
+    ///   struct via `getUserContext()` and encodes it. Unsynchronized struct reads of a
+    ///   `Dictionary`-backed value type can tear the COW buffer pointer.
+    ///
+    /// The test reproduces the race by hammering writes on one queue and reads + encodes
+    /// on another. Without synchronization this is expected to crash or throw within a few
+    /// thousand iterations.
+    func testConcurrentTraitsMutationAndEncodingIsThreadSafe() {
+        let iterations = 5_000
+        let writerDone = XCTestExpectation(description: "writer finished")
+        let readerDone = XCTestExpectation(description: "reader finished")
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            for i in 0..<iterations {
+                switch i % 4 {
+                case 0:
+                    Helium.identify.setUserTraits([
+                        "plan": "premium",
+                        "iteration": i,
+                        "tags": ["a", "b", "c", "d"],
+                        "nested": ["k1": "v1", "k2": i]
+                    ])
+                case 1:
+                    Helium.identify.addUserTraits([
+                        "key_\(i % 50)": "value_\(i)",
+                        "score": i
+                    ])
+                case 2:
+                    Helium.identify.setUserTraits(HeliumUserTraits([:]))
+                default:
+                    Helium.identify.addUserTraits([
+                        "burst_\(i)": Array(repeating: i, count: 8)
+                    ])
+                }
+            }
+            writerDone.fulfill()
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            let encoder = JSONEncoder()
+            for _ in 0..<iterations {
+                let userContext = HeliumIdentityManager.shared.getUserContext()
+                _ = try? encoder.encode(userContext)
+            }
+            readerDone.fulfill()
+        }
+
+        wait(for: [writerDone, readerDone], timeout: 60)
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches hot-path identity/analytics state used on every identify; the fix aligns with existing `@HeliumAtomic` usage but concurrent trait access behavior changes slightly (serialized merges).
> 
> **Overview**
> Fixes a **customer-reported crash** during identify/analytics encoding caused by unsynchronized access to **`heliumUserTraits`**: app threads mutate traits while the analytics queue reads and JSON-encodes them via **`getUserContext()`**, which could tear the dictionary-backed struct.
> 
> **`HeliumIdentityManager`** now stores traits behind the existing **`@HeliumAtomic`** wrapper, and **`addToCustomUserTraits`** performs merges with **`withValue`** so read-modify-write is serialized like other atomic state in the SDK.
> 
> CI **SwiftPM unit tests** run with **Thread Sanitizer** (`-enableThreadSanitizer YES`), and a new **`testConcurrentTraitsMutationAndEncodingIsThreadSafe`** hammers concurrent writes and encode reads to guard against regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a7137de3992fc5c44c68297384e27b5f6842949. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced unit test execution with Thread Sanitizer for improved code quality assurance.
  * Added regression test to verify thread safety of concurrent user traits operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->