### PR TITLE
new version; bump fallback daysAgo warning; docstring improvements an…

### DIFF
--- a/HeliumExample/HeliumExample/ContentView.swift
+++ b/HeliumExample/HeliumExample/ContentView.swift
@@ -19,102 +19,127 @@ struct ContentView: View {
     @State private var userId: String = Helium.identify.userId ?? "nil"
 
     var body: some View {
-        VStack(spacing: 20) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Trigger").font(.caption).foregroundStyle(.secondary)
-                TextField("Trigger key", text: $trigger)
-                    .textFieldStyle(.roundedBorder)
-                
-                Spacer().frame(height: 10)
-                
-                Toggle("dontShowIfAlreadyEntitled", isOn: $dontShowIfAlreadyEntitled)
-
-                Spacer().frame(height: 10)
-
-                Text("User ID").font(.caption).foregroundStyle(.secondary)
-                Text(userId)
-                    .font(.footnote)
-                    .textSelection(.enabled)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 30)
-
-            Spacer()
-
-            Button("show paywall") {
-                Helium.shared.presentPaywall(
-                    trigger: trigger, config: PaywallPresentationConfig(dontShowIfAlreadyEntitled: dontShowIfAlreadyEntitled)
-                ) { reason in
-                    print("[Helium Example] show paywall - Could not show paywall. \(reason)")
-                }
-            }
-            .accessibilityIdentifier("presentPaywall")
-            
-            Button("show via modifier") {
-                showModifierPaywall = true
-            }
-            .accessibilityIdentifier("showPaywallViaModifier")
-            .heliumPaywall(
-                isPresented: $showModifierPaywall,
-                trigger: trigger,
-                config: PaywallPresentationConfig(dontShowIfAlreadyEntitled: dontShowIfAlreadyEntitled)
-            ) { reason in
-                Text("no show! \(reason.description)")
-            }
-            
-            Button("show via embedded") {
-                showEmbeddedPaywall = true
-            }
-            .accessibilityIdentifier("showPaywallEmbedded")
-            .fullScreenCover(isPresented: $showEmbeddedPaywall) {
-                HeliumPaywall(
-                    trigger: trigger, config: PaywallPresentationConfig(dontShowIfAlreadyEntitled: dontShowIfAlreadyEntitled)
-                ) { reason in
-                    Text("no show embedded! \(reason.description)")
-                }
-            }
-
-            Button("show fallback (invalid trigger)") {
-                Helium.shared.presentPaywall(trigger: "nonexistent_trigger_that_does_not_exist") { reason in
-                    print("[Helium Example] invalid trigger - Could not show paywall. \(reason)")
-                }
-            }
-            .accessibilityIdentifier("presentFallbackInvalidTrigger")
-            
-            Spacer().frame(height: 20)
-            
-            Button("set random user id") {
-                let newId = UUID().uuidString
-                Helium.identify.userId = newId
-                userId = newId
-            }
-
-            Button("check entitlement") {
-                Task {
-                    let hasAny = await Helium.entitlements.hasAny()
-                    let hasActiveSub = await Helium.entitlements.hasAnyActiveSubscription()
-                    let productIds = await Helium.entitlements.purchasedProductIds()
-
-                    var info = "Has Any Entitlement: \(hasAny)\n"
-                    info += "Has Active Subscription: \(hasActiveSub)\n"
-
-                    info += "\nPurchased Product IDs:\n"
-                    if productIds.isEmpty {
-                        info += "  None"
-                    } else {
-                        info += "  " + productIds.joined(separator: "\n  ")
-                    }
-
-                    entitlementInfo = info
-                    showEntitlementAlert = true
-                }
-            }
-            
-            Spacer()
+        NavigationStack {
+            formContent
+                .navigationTitle("Helium Example App")
         }
-        .padding()
+    }
+
+    private var formContent: some View {
+        Form {
+            Section("Configuration") {
+                LabeledContent("Trigger") {
+                    TextField("Trigger key", text: $trigger)
+                        .multilineTextAlignment(.trailing)
+                }
+                Toggle("dontShowIfAlreadyEntitled", isOn: $dontShowIfAlreadyEntitled)
+                LabeledContent("User ID") {
+                    Text(userId)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+
+            Section("Present Paywall") {
+                Button("show paywall") {
+                    Helium.shared.presentPaywall(
+                        trigger: trigger, config: PaywallPresentationConfig(dontShowIfAlreadyEntitled: dontShowIfAlreadyEntitled)
+                    ) { reason in
+                        print("[Helium Example] show paywall - Could not show paywall. \(reason)")
+                    }
+                }
+                .accessibilityIdentifier("presentPaywall")
+
+                Button("show via modifier") {
+                    showModifierPaywall = true
+                }
+                .accessibilityIdentifier("showPaywallViaModifier")
+                .heliumPaywall(
+                    isPresented: $showModifierPaywall,
+                    trigger: trigger,
+                    config: PaywallPresentationConfig(dontShowIfAlreadyEntitled: dontShowIfAlreadyEntitled)
+                ) { reason in
+                    Text("no show! \(reason.description)")
+                }
+
+                Button("show via embedded") {
+                    showEmbeddedPaywall = true
+                }
+                .accessibilityIdentifier("showPaywallEmbedded")
+                .fullScreenCover(isPresented: $showEmbeddedPaywall) {
+                    HeliumPaywall(
+                        trigger: trigger, config: PaywallPresentationConfig(dontShowIfAlreadyEntitled: dontShowIfAlreadyEntitled)
+                    ) { reason in
+                        Text("no show embedded! \(reason.description)")
+                    }
+                }
+            }
+
+            Section("Test Default Paywall") {
+                Button("show fallback (invalid trigger)") {
+                    Helium.shared.presentPaywall(trigger: "nonexistent_trigger_that_does_not_exist") { reason in
+                        print("[Helium Example] invalid trigger - Could not show paywall. \(reason)")
+                    }
+                }
+                .accessibilityIdentifier("presentFallbackInvalidTrigger")
+            }
+
+            Section("User & Entitlements") {
+                Button("set random user id") {
+                    let newId = UUID().uuidString
+                    Helium.identify.userId = newId
+                    userId = newId
+                }
+
+                Button("check entitlements") {
+                    Task {
+                        let hasAny = await Helium.entitlements.hasAny()
+                        let hasActiveSub = await Helium.entitlements.hasAnyActiveSubscription()
+                        let productIds = await Helium.entitlements.purchasedProductIds()
+
+                        let hasPaddle = await Helium.entitlements.hasActivePaddleEntitlement()
+                        let hasStripe = await Helium.entitlements.hasActiveStripeEntitlement()
+
+                        var info = "Has Any Entitlement: \(hasAny)\n"
+                        info += "Has Active Subscription: \(hasActiveSub)\n"
+                        
+                        info += "Paddle entitled? \(hasPaddle)\n"
+                        info += "Stripe entitled? \(hasStripe)\n"
+
+                        info += "\nPurchased Product IDs:\n"
+                        if productIds.isEmpty {
+                            info += "  None"
+                        } else {
+                            info += "  " + productIds.joined(separator: "\n  ")
+                        }
+
+                        entitlementInfo = info
+                        showEntitlementAlert = true
+                    }
+                }
+
+                Button("open paddle portal") {
+                    Task {
+                        do {
+                            let url = try await Helium.shared.createPaddlePortalSession()
+                            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                        } catch {
+                            
+                        }
+                    }
+                }
+                
+                Button("open stripe portal") {
+                    Task {
+                        let url = try await Helium.shared.createStripePortalSession(returnUrl: "")
+                        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                    }
+                }
+            }
+        }
         .alert("Entitlements", isPresented: $showEntitlementAlert) {
             Button("OK", role: .cancel) {}
         } message: {

--- a/HeliumExample/HeliumExample/ContentView.swift
+++ b/HeliumExample/HeliumExample/ContentView.swift
@@ -138,7 +138,7 @@ struct ContentView: View {
                 Button("open stripe portal") {
                     Task {
                         do {
-                            let url = try await Helium.shared.createStripePortalSession(returnUrl: "")
+                            let url = try await Helium.shared.createStripePortalSession(returnUrl: "heliumexamplestripe://openapp")
                             UIApplication.shared.open(url, options: [:], completionHandler: nil)
                         } catch {
                             errorMessage = "Could not open Stripe portal: \(error.localizedDescription)"

--- a/HeliumExample/HeliumExample/ContentView.swift
+++ b/HeliumExample/HeliumExample/ContentView.swift
@@ -15,6 +15,8 @@ struct ContentView: View {
     @State private var dontShowIfAlreadyEntitled: Bool = false
     @State private var showEntitlementAlert: Bool = false
     @State private var entitlementInfo: String = ""
+    @State private var showErrorAlert: Bool = false
+    @State private var errorMessage: String = ""
     @State private var trigger: String = AppConfig.triggerKey
     @State private var userId: String = Helium.identify.userId ?? "nil"
 
@@ -127,15 +129,21 @@ struct ContentView: View {
                             let url = try await Helium.shared.createPaddlePortalSession()
                             UIApplication.shared.open(url, options: [:], completionHandler: nil)
                         } catch {
-                            
+                            errorMessage = "Could not open Paddle portal: \(error.localizedDescription)"
+                            showErrorAlert = true
                         }
                     }
                 }
-                
+
                 Button("open stripe portal") {
                     Task {
-                        let url = try await Helium.shared.createStripePortalSession(returnUrl: "")
-                        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                        do {
+                            let url = try await Helium.shared.createStripePortalSession(returnUrl: "")
+                            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                        } catch {
+                            errorMessage = "Could not open Stripe portal: \(error.localizedDescription)"
+                            showErrorAlert = true
+                        }
                     }
                 }
             }
@@ -144,6 +152,11 @@ struct ContentView: View {
             Button("OK", role: .cancel) {}
         } message: {
             Text(entitlementInfo)
+        }
+        .alert("Error", isPresented: $showErrorAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(errorMessage)
         }
     }
 }

--- a/Sources/Helium/HeliumCore/BuildConstants.swift
+++ b/Sources/Helium/HeliumCore/BuildConstants.swift
@@ -8,5 +8,5 @@
  */
 public struct BuildConstants {
     /// Current SDK version
-    public static let version = "4.5.1"
+    public static let version = "4.5.2"
 }

--- a/Sources/Helium/HeliumCore/HeliumFallbackViewManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumFallbackViewManager.swift
@@ -56,7 +56,7 @@ public class HeliumFallbackViewManager {
                     
                     if let date = parseISODate(decodedConfig.generatedAt),
                        let daysAgo = Calendar.current.dateComponents([.day], from: date, to: Date()).day,
-                       daysAgo > 30 {
+                       daysAgo > 60 {
                         HeliumLogger.log(.warn, category: .fallback, "👷 Your fallbacks were generated \(daysAgo) days ago! ⚠️ Consider updating them\nhttps://docs.tryhelium.com/guides/fallback-bundle")
                     } else if generatedAtDisplay == invalidDateString {
                         HeliumLogger.log(.warn, category: .fallback, "👷 Your fallbacks are outdated! ⚠️ Consider updating them\nhttps://docs.tryhelium.com/guides/fallback-bundle")

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -678,17 +678,16 @@ public class HeliumConfig {
     /// will not show. Your fallback paywall/s, if provided, will show instead.
     ///
     /// You must provide redirect URLs so Helium knows where to send the user after checkout completes or is cancelled.
+    /// It is ok to use the same url for both success and cancel.
     ///
     /// - Parameters:
     ///   - successURL: The URL to redirect to after a successful payment.
     ///   - cancelURL: The URL the provider redirects to when the user cancels checkout.
-    ///   - paymentProcessors: Which payment processors to enable. Defaults to `.all` (both Paddle and Stripe).
-    ///     Pass `.paddle` or `.stripe` if your app only uses one to skip the unused processor's
-    ///     entitlement network calls.
+    ///   - paymentProcessors: Which payment processors to enable. Paddle, Stripe, or both.
     public func enableExternalWebCheckout(
         successURL: String,
         cancelURL: String,
-        paymentProcessors: WebCheckoutProcessors = .all
+        paymentProcessors: WebCheckoutProcessors
     ) {
         guard let successParsed = URL(string: successURL), successParsed.scheme != nil,
               let cancelParsed = URL(string: cancelURL), cancelParsed.scheme != nil else {


### PR DESCRIPTION
…d enforce paymentProcessors to be passed in; example app display improvements

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removing the default for `paymentProcessors` is a compile-time breaking change for integrators who relied on `.all`; runtime behavior is otherwise limited to logging thresholds and example-app UI.
> 
> **Overview**
> **Release 4.5.2** bumps the SDK version and tightens the external web checkout API: `Helium.config.enableExternalWebCheckout` no longer defaults `paymentProcessors` to `.all`—callers must pass `.paddle`, `.stripe`, or both explicitly. Doc comments note that success and cancel redirect URLs may be the same.
> 
> Stale **fallback bundle** warnings now fire when bundled paywalls are older than **60 days** (was 30).
> 
> The **Helium Example** app moves from a plain `VStack` to a `NavigationStack` + `Form` with grouped sections. Entitlement checks include Paddle/Stripe status, and new actions open Paddle/Stripe customer portals with an error alert on failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73730adb6efd1ff88910691f10c4fefab1e2c22e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Version**: Updated to 4.5.2

* **New Features**
  * Added Paddle and Stripe entitlement status checks
  * Added ability to access Paddle and Stripe customer portals

* **Breaking Changes**
  * `enableExternalWebCheckout()` now requires explicit `paymentProcessors` parameter

* **Other**
  * Adjusted fallback asset age warning threshold
  * Improved example app UI layout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->