### PR TITLE
HEL-5430 Gate California (AB 2863) checkout block behind a server-config kill switch

### DIFF
--- a/Sources/Helium/HeliumCore/Models.swift
+++ b/Sources/Helium/HeliumCore/Models.swift
@@ -92,7 +92,17 @@ public struct HeliumPaywallInfo: Codable {
         }
         return nil
     }
-    
+
+    /// Server-config kill switch for the California (AB 2863) checkout block.
+    /// When the web bundle's affirmative-consent flow is confirmed live, the
+    /// server sets this true and California buyers are allowed through to the
+    /// (consent-aware) web paywall instead of being hard-blocked upstream.
+    /// Defaults to `false` (block) so binary-shipped older SDK versions — and any
+    /// config that omits the field — keep the safety net until the server flips it.
+    var allowCaliforniaWebCheckout: Bool {
+        return additionalPaywallFields?["allowCaliforniaWebCheckout"].bool ?? false
+    }
+
     /// Local file path for the bundle - converts extractedBundleUrl to local path
     var localBundlePath: String? {
         guard let bundleUrl = extractedBundleUrl else { return nil }

--- a/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
@@ -90,7 +90,8 @@ final class PaddleCheckoutPrefetchCoordinator {
             priceIds: priceIds,
             discountIdByPriceId: discountIdByPriceId,
             paddleClientToken: clientToken,
-            iosBundleId: Bundle.main.bundleIdentifier
+            iosBundleId: Bundle.main.bundleIdentifier,
+            allowCaliforniaCheckout: info.allowCaliforniaWebCheckout
         )
     }
 
@@ -106,7 +107,8 @@ final class PaddleCheckoutPrefetchCoordinator {
         priceIds: [String],
         discountIdByPriceId: [String: String] = [:],
         paddleClientToken: String,
-        iosBundleId: String?
+        iosBundleId: String?,
+        allowCaliforniaCheckout: Bool = false
     ) {
         let sessionId = paywallSession.sessionId
         let scope = paywallSession.observabilityScope
@@ -125,6 +127,7 @@ final class PaddleCheckoutPrefetchCoordinator {
                     discountId: discountId,
                     paddleClientToken: paddleClientToken,
                     iosBundleId: iosBundleId,
+                    allowCaliforniaCheckout: allowCaliforniaCheckout,
                     banditClient: bandit,
                     bffClient: bff,
                     scope: scope
@@ -454,6 +457,7 @@ final class PaddleCheckoutPrefetchCoordinator {
         discountId: String?,
         paddleClientToken: String,
         iosBundleId: String?,
+        allowCaliforniaCheckout: Bool,
         banditClient: HeliumPaymentAPIClient,
         bffClient: PaddleBFFClient,
         scope: PaywallObservabilityScope
@@ -486,7 +490,13 @@ final class PaddleCheckoutPrefetchCoordinator {
                 paddleClientToken: paddleClientToken,
                 iosBundleId: iosBundleId
             )
-            if let caPostal = californiaPostalCode(in: paddleResult.rawBody) {
+            // California (AB 2863) hard-block. Gated behind a server-config kill
+            // switch: when `allowCaliforniaCheckout` is on, CA buyers proceed to
+            // `.ready` and reach the consent-aware web paywall. Default is off
+            // (block) so binary-shipped old versions keep blocking until the
+            // bundler consent flow is confirmed live end-to-end. The ip_geo
+            // observability below still fires either way.
+            if !allowCaliforniaCheckout, let caPostal = californiaPostalCode(in: paddleResult.rawBody) {
                 trackBffCompletion(priceId: priceId, transactionId: banditResponse.transactionId, scope: scope, startedAt: bffStart, chainStartedAt: chainStart, result: .caBlocked(rawBody: paddleResult.rawBody))
                 return .failed(error: PaddleCaliforniaBlocked(postalCode: caPostal))
             }

--- a/Tests/helium-swiftTests/OnLaunchResponseDecodingTests.swift
+++ b/Tests/helium-swiftTests/OnLaunchResponseDecodingTests.swift
@@ -34,4 +34,74 @@ final class OnLaunchResponseDecodingTests: XCTestCase {
 
         XCTAssertNil(decoded.paddleClientToken)
     }
+
+    // ---------- allowCaliforniaWebCheckout contract (AB 2863 kill switch) ----------
+
+    /// Decodes a single-trigger config whose paywall info carries the given
+    /// `additionalPaywallFields` (any JSON shape), and returns that paywall info.
+    private func decodePaywallInfo(additionalPaywallFields: Any?) throws -> HeliumPaywallInfo {
+        var paywallInfo: [String: Any] = [
+            "paywallID": 1,
+            "paywallTemplateName": "test_paywall",
+            "resolvedConfig": [:],
+        ]
+        if let additionalPaywallFields {
+            paywallInfo["additionalPaywallFields"] = additionalPaywallFields
+        }
+        let json = try makeOnLaunchJSON(extras: [
+            "triggerToPaywalls": ["test_trigger": paywallInfo],
+        ])
+        let decoded = try JSONDecoder().decode(HeliumFetchedConfig.self, from: json)
+        return try XCTUnwrap(decoded.triggerToPaywalls["test_trigger"])
+    }
+
+    func testAllowCaliforniaWebCheckout_decodesTrue_fromAdditionalPaywallFields() throws {
+        let info = try decodePaywallInfo(additionalPaywallFields: ["allowCaliforniaWebCheckout": true])
+
+        XCTAssertTrue(info.allowCaliforniaWebCheckout, "Server flips the kill switch by setting the flag true")
+    }
+
+    func testAllowCaliforniaWebCheckout_defaultsFalse_whenAbsent() throws {
+        // Absent flag => block. This is the binary-shipped default that keeps old
+        // SDK versions safe until the bundler consent flow is confirmed live.
+        let info = try decodePaywallInfo(additionalPaywallFields: nil)
+
+        XCTAssertFalse(info.allowCaliforniaWebCheckout, "Absent flag must default to the blocking behavior")
+    }
+
+    func testAllowCaliforniaWebCheckout_isFalse_whenExplicitlyFalse() throws {
+        let info = try decodePaywallInfo(additionalPaywallFields: ["allowCaliforniaWebCheckout": false])
+
+        XCTAssertFalse(info.allowCaliforniaWebCheckout)
+    }
+
+    // Fail-closed contract: ONLY a genuine JSON boolean `true` may flip the kill
+    // switch. Every ambiguous/wrong-typed shape must default to block. These pin
+    // the strict (non-coercing) `.bool` accessor — a future swap to the coercing
+    // `.boolValue` (which maps 1 / "true" / "yes" → true) would silently unblock
+    // California buyers and these tests would catch it.
+
+    func testAllowCaliforniaWebCheckout_isFalse_whenNull() throws {
+        let info = try decodePaywallInfo(additionalPaywallFields: ["allowCaliforniaWebCheckout": NSNull()])
+
+        XCTAssertFalse(info.allowCaliforniaWebCheckout, "Explicit JSON null must fail closed (block)")
+    }
+
+    func testAllowCaliforniaWebCheckout_isFalse_whenWrongTypedNumber() throws {
+        let info = try decodePaywallInfo(additionalPaywallFields: ["allowCaliforniaWebCheckout": 1])
+
+        XCTAssertFalse(info.allowCaliforniaWebCheckout, "A number must not be coerced to true — only a real JSON boolean flips the switch")
+    }
+
+    func testAllowCaliforniaWebCheckout_isFalse_whenWrongTypedString() throws {
+        let info = try decodePaywallInfo(additionalPaywallFields: ["allowCaliforniaWebCheckout": "true"])
+
+        XCTAssertFalse(info.allowCaliforniaWebCheckout, "String \"true\" must not be coerced — strict .bool fails closed")
+    }
+
+    func testAllowCaliforniaWebCheckout_isFalse_whenAdditionalFieldsNotAnObject() throws {
+        let info = try decodePaywallInfo(additionalPaywallFields: ["unexpected", "array", "shape"])
+
+        XCTAssertFalse(info.allowCaliforniaWebCheckout, "A non-object additionalPaywallFields must fail closed")
+    }
 }

--- a/Tests/helium-swiftTests/PaddleCheckoutPrefetchCoordinatorTests.swift
+++ b/Tests/helium-swiftTests/PaddleCheckoutPrefetchCoordinatorTests.swift
@@ -135,6 +135,223 @@ final class PaddleCheckoutPrefetchCoordinatorTests: XCTestCase {
         XCTAssertGreaterThan(paddle.rawBody.count, 0)
     }
 
+    // MARK: - California consent gate (AB 2863)
+
+    /// BFF success body whose IP-geo resolves to a US California ZIP. The same
+    /// `ip_geo_postal_code` field the web bundle reads to drive its consent modal.
+    private func bffCaliforniaBody(
+        checkoutId: String,
+        transactionId: String,
+        postalCode: String = "94102"
+    ) -> String {
+        return """
+        {
+            "data": {
+                "id": "\(checkoutId)",
+                "transaction_id": "\(transactionId)",
+                "status": "draft",
+                "ip_geo_country_code": "US",
+                "ip_geo_postal_code": "\(postalCode)"
+            }
+        }
+        """
+    }
+
+    private func californiaHandler(
+        transactionId: String = "txn_ca",
+        checkoutId: String = "che_ca",
+        postalCode: String = "94102"
+    ) -> ((URLRequest) throws -> (HTTPURLResponse, Data?)) {
+        return { request in
+            let url = request.url!.absoluteString
+            if url.contains("/paddle/create-transaction-for-paywall") {
+                let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                return (response, self.banditSuccessBody(transactionId: transactionId).data(using: .utf8)!)
+            } else if url.contains("/transaction-checkout") {
+                let response = HTTPURLResponse(url: request.url!, statusCode: 201, httpVersion: nil, headerFields: nil)!
+                return (response, self.bffCaliforniaBody(checkoutId: checkoutId, transactionId: transactionId, postalCode: postalCode).data(using: .utf8)!)
+            }
+            throw NSError(domain: "PaddleCheckoutPrefetchCoordinatorTests", code: 0,
+                          userInfo: [NSLocalizedDescriptionKey: "Unexpected URL: \(url)"])
+        }
+    }
+
+    /// Flag ON: the server-side kill switch is flipped, so a California buyer must
+    /// reach the (consent-aware) web paywall. The prefetch resolves `.ready`.
+    func testAwaitOutcome_returnsReady_forCaliforniaZip_whenConsentFlagOn() async throws {
+        MockURLProtocol.requestHandler = californiaHandler()
+
+        coordinator.prefetch(
+            paywallSession: testSession,
+            priceIds: ["pri_ca"],
+            paddleClientToken: "test_xyz",
+            iosBundleId: "com.example.test",
+            allowCaliforniaCheckout: true
+        )
+
+        let outcome = await coordinator.awaitOutcome(sessionId: testSessionId, priceId: "pri_ca")
+
+        guard case .ready = outcome else {
+            XCTFail("With the CA consent flag ON, a California-IP prefetch must resolve .ready so the buyer reaches the consent paywall; got \(outcome)")
+            return
+        }
+    }
+
+    /// Flag OFF (the default): the binary-shipped safety net keeps blocking
+    /// California buyers until the server flips the kill switch. Regression guard
+    /// for the default behavior — there was previously no behavioral test of the
+    /// block, so this pins it.
+    func testAwaitOutcome_returnsCaliforniaBlocked_forCaliforniaZip_whenConsentFlagOff() async throws {
+        MockURLProtocol.requestHandler = californiaHandler(postalCode: "90001")
+
+        // No `allowCaliforniaCheckout` argument — defaults to false (block).
+        coordinator.prefetch(
+            paywallSession: testSession,
+            priceIds: ["pri_ca"],
+            paddleClientToken: "test_xyz",
+            iosBundleId: "com.example.test"
+        )
+
+        let outcome = await coordinator.awaitOutcome(sessionId: testSessionId, priceId: "pri_ca")
+
+        guard case .failed(let error) = outcome, let blocked = error as? PaddleCaliforniaBlocked else {
+            XCTFail("With the consent flag OFF (default), a California-IP prefetch must stay blocked; got \(outcome)")
+            return
+        }
+        XCTAssertEqual(blocked.postalCode, "90001")
+    }
+
+    /// The gate is California-specific, not all-of-US. A US ZIP outside the
+    /// 90001–96162 range must resolve `.ready` even with the flag off, so the
+    /// block never over-reaches to non-CA buyers.
+    func testAwaitOutcome_returnsReady_forNonCaliforniaUsZip_whenConsentFlagOff() async throws {
+        // 10001 = New York, US — outside the California ZIP range.
+        MockURLProtocol.requestHandler = californiaHandler(postalCode: "10001")
+
+        coordinator.prefetch(
+            paywallSession: testSession,
+            priceIds: ["pri_ny"],
+            paddleClientToken: "test_xyz",
+            iosBundleId: "com.example.test"
+        )
+
+        let outcome = await coordinator.awaitOutcome(sessionId: testSessionId, priceId: "pri_ny")
+
+        guard case .ready = outcome else {
+            XCTFail("A non-California US ZIP must not be blocked even with the flag off; got \(outcome)")
+            return
+        }
+    }
+
+    /// Inclusive upper bound of the CA range (90001–96162) — must stay blocked.
+    func testAwaitOutcome_returnsCaliforniaBlocked_forUpperBoundaryZip96162_whenConsentFlagOff() async throws {
+        MockURLProtocol.requestHandler = californiaHandler(postalCode: "96162")
+
+        coordinator.prefetch(
+            paywallSession: testSession,
+            priceIds: ["pri_ca"],
+            paddleClientToken: "test_xyz",
+            iosBundleId: "com.example.test"
+        )
+
+        let outcome = await coordinator.awaitOutcome(sessionId: testSessionId, priceId: "pri_ca")
+
+        guard case .failed(let error) = outcome, error is PaddleCaliforniaBlocked else {
+            XCTFail("96162 is the inclusive upper bound of the CA range and must stay blocked with the flag off; got \(outcome)")
+            return
+        }
+    }
+
+    /// 96701 = Hawaii (HI ZIPs start at 96701). The block must never reach past
+    /// the CA range into Hawaii — over-block guard for an off-by-one at the bound.
+    func testAwaitOutcome_returnsReady_forHawaiiZip96701_whenConsentFlagOff() async throws {
+        MockURLProtocol.requestHandler = californiaHandler(postalCode: "96701")
+
+        coordinator.prefetch(
+            paywallSession: testSession,
+            priceIds: ["pri_hi"],
+            paddleClientToken: "test_xyz",
+            iosBundleId: "com.example.test"
+        )
+
+        let outcome = await coordinator.awaitOutcome(sessionId: testSessionId, priceId: "pri_hi")
+
+        guard case .ready = outcome else {
+            XCTFail("Hawaii ZIP 96701 must never be blocked (over-block guard); got \(outcome)")
+            return
+        }
+    }
+
+    /// Just above the CA upper bound — must not be blocked.
+    func testAwaitOutcome_returnsReady_forZipJustAboveCaRange96163_whenConsentFlagOff() async throws {
+        MockURLProtocol.requestHandler = californiaHandler(postalCode: "96163")
+
+        coordinator.prefetch(
+            paywallSession: testSession,
+            priceIds: ["pri_above"],
+            paddleClientToken: "test_xyz",
+            iosBundleId: "com.example.test"
+        )
+
+        let outcome = await coordinator.awaitOutcome(sessionId: testSessionId, priceId: "pri_above")
+
+        guard case .ready = outcome else {
+            XCTFail("96163 is just above the CA upper bound (96162) and must not be blocked; got \(outcome)")
+            return
+        }
+    }
+
+    /// End-to-end wiring: `handlePaywallOpen` must read the kill switch off the
+    /// paywall info (`additionalPaywallFields.allowCaliforniaWebCheckout`) and
+    /// forward it into the prefetch. Flag ON => a California buyer reaches the
+    /// (consent-aware) paywall.
+    func testHandlePaywallOpen_forwardsConsentFlag_californiaResolvesReady_whenFlagOn() async throws {
+        var config = makeTestConfig(triggers: [:])
+        config.paddleClientToken = "test_paddle_token"
+        injectConfig(config)
+        addTeardownBlock { HeliumFetchedConfigManager.reset() }
+
+        MockURLProtocol.requestHandler = californiaHandler()
+
+        var info = makeTestPaywallInfo()
+        info.webProductsOfferedPaddle = ["pro_x:pri_ca"]
+        info.additionalPaywallFields = JSON(["allowCaliforniaWebCheckout": true])
+        let session = makeTestSession(paywallInfo: info)
+
+        coordinator.handlePaywallOpen(paywallSession: session)
+
+        let outcome = await coordinator.awaitOutcome(sessionId: session.sessionId, priceId: "pri_ca")
+
+        guard case .ready = outcome else {
+            XCTFail("handlePaywallOpen must forward allowCaliforniaWebCheckout=true so the CA buyer reaches the paywall; got \(outcome)")
+            return
+        }
+    }
+
+    /// Flag absent on the paywall info => default block, end to end.
+    func testHandlePaywallOpen_forwardsConsentFlag_californiaStaysBlocked_whenFlagAbsent() async throws {
+        var config = makeTestConfig(triggers: [:])
+        config.paddleClientToken = "test_paddle_token"
+        injectConfig(config)
+        addTeardownBlock { HeliumFetchedConfigManager.reset() }
+
+        MockURLProtocol.requestHandler = californiaHandler(postalCode: "90001")
+
+        var info = makeTestPaywallInfo()
+        info.webProductsOfferedPaddle = ["pro_x:pri_ca"]
+        // additionalPaywallFields omitted => allowCaliforniaWebCheckout defaults false.
+        let session = makeTestSession(paywallInfo: info)
+
+        coordinator.handlePaywallOpen(paywallSession: session)
+
+        let outcome = await coordinator.awaitOutcome(sessionId: session.sessionId, priceId: "pri_ca")
+
+        guard case .failed(let error) = outcome, error is PaddleCaliforniaBlocked else {
+            XCTFail("handlePaywallOpen must keep CA blocked when the flag is absent; got \(outcome)")
+            return
+        }
+    }
+
     // MARK: - alreadyEntitled
 
     func testAwaitOutcome_returnsAlreadyEntitled_whenBanditReturns409Duplicate_andSkipsBFFCall() async throws {


### PR DESCRIPTION
## Summary

The SDK currently **hard-blocks California buyers** before the Paddle web paywall opens. The bundler-service web paywall now shows an **AB 2863 affirmative-consent modal** to California buyers (detected via Paddle `ip_geo_postal_code`, US ZIP 90001–96162) and lets them complete the purchase *with* consent. This SDK is the upstream layer that does the hard block, so it needs to stop — but only behind a **server-side kill switch**, because the SDK is binary-shipped.

This PR makes the California block flippable via a remote flag that **defaults to the current blocking behavior**.

## What changed

- **New remote flag** `HeliumPaywallInfo.allowCaliforniaWebCheckout` — a computed property reading `additionalPaywallFields["allowCaliforniaWebCheckout"]`, sitting right next to `webPaywallBundleUrl`. Uses SwiftyJSON's strict `.bool` (not coercive `.boolValue`), so **only a literal JSON `true` flips the switch**; absent / null / wrong-typed / string `"true"` / number all default to `false` (block).
- **Threaded** `allowCaliforniaCheckout` through `PaddleCheckoutPrefetchCoordinator.prefetch` → `runPrefetchChain` (default `false`).
- **Gated the block** at `runPrefetchChain`: `if !allowCaliforniaCheckout, let caPostal = californiaPostalCode(...)`. Flag on ⇒ the prefetch resolves `.ready` and the buyer reaches the (consent-aware) paywall.
- `handlePaywallOpen` forwards `info.allowCaliforniaWebCheckout` into the prefetch.

### Intentionally left inert (not deleted)

`PaddleCaliforniaBlocked`, `californiaPostalCode`, `californiaBlockedPostalCode`, `WebCheckoutError.californiaBuyerBlocked`, and the `.caBlocked` telemetry arm are kept. They remain the **active mechanism for the flag-off (default) path**. When the flag is on, the coordinator never produces a `PaddleCaliforniaBlocked` outcome, so the consumer's throw in `ExternalWebCheckoutManager` is simply never reached. Removing them would risk the default-block behavior; they can be retired later when fully flag-on. The `ip_geo` observability and the `paddleResponseFixtureWithCruft` fixture (which proves `ip_geo_postal_code` survives into the bundle ctx) are kept.

## Tests (TDD)

Added behavioral tests (there were previously **no** behavioral tests asserting the block):

**`PaddleCheckoutPrefetchCoordinatorTests`**
- CA-ZIP prefetch resolves `.ready` when the flag is **on**
- CA-ZIP prefetch stays `.failed(PaddleCaliforniaBlocked)` when the flag is **off** (default)
- Non-CA US ZIP (NY 10001) resolves `.ready` even with the flag off (block stays CA-specific)
- End-to-end: `handlePaywallOpen` forwards the flag from paywall-info config → `.ready` when on, blocked when absent

**`OnLaunchResponseDecodingTests`** (JSON contract)
- `allowCaliforniaWebCheckout` decodes `true` from `additionalPaywallFields`
- defaults `false` when absent
- is `false` when explicitly `false`

Full suite: **135 tests, 0 failures** (run via Mac Catalyst locally; CI runs the iOS-simulator suite in helium-demo).

## ⚠️ Compliance & rollout

The SDK is **binary-shipped** — old versions keep blocking for weeks–months as adoption rolls out, and there's no way to retroactively change them. This is exactly why the kill switch defaults to **block**.

**Do not flip `allowCaliforniaWebCheckout` to `true` server-side until the bundler consent modal + bandit changes are confirmed live end-to-end.** Until then, every layer keeps the current safe (blocking) behavior with zero change in production.

## Cross-repo contract

Server sets, per-paywall, in the paywall info's `additionalPaywallFields`:
```json
{ "allowCaliforniaWebCheckout": true }
```
Must be a JSON boolean. Same `ip_geo_postal_code` field is still forwarded into the bundle ctx, so the bundle keeps detecting CA after the SDK stops blocking.

Linear: HEL-5430

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes who can proceed to web checkout for California IP-geo buyers when the server flag is enabled; default-off and strict boolean parsing limit accidental unblock, but incorrect server rollout could affect AB 2863 compliance.
> 
> **Overview**
> Adds a **remote kill switch** so California (AB 2863) buyers are no longer hard-blocked during Paddle prefetch only when the server explicitly allows it; **default stays block** for older SDK builds and missing config.
> 
> **`HeliumPaywallInfo.allowCaliforniaWebCheckout`** reads `additionalPaywallFields["allowCaliforniaWebCheckout"]` with strict JSON boolean semantics (only literal `true` enables; absent/null/wrong types → `false`). **`PaddleCheckoutPrefetchCoordinator`** threads `allowCaliforniaCheckout` from `handlePaywallOpen` through prefetch into **`runPrefetchChain`**, where the existing CA ZIP check runs only when the flag is off; when on, prefetch returns **`.ready`** so buyers reach the consent-aware web paywall.
> 
> Tests lock the JSON contract (fail-closed decoding) and prefetch behavior (flag on/off, ZIP boundaries, non-CA US, end-to-end `handlePaywallOpen` wiring).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fca18c7eb088f9af10f6ffa67f6f0cc4ee8a0e94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration control for California web checkout availability

* **Tests**
  * Added comprehensive test coverage for California checkout scenarios, including edge cases and conditional behavior validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->