### PR TITLE
[SDK-37] | iOS uptake for haptics

### DIFF
--- a/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
@@ -12,7 +12,17 @@ import WebKit
 
 class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
     private weak var delegateWrapper: ActionsDelegateWrapper?
-    
+
+    /// This handler instance is reused across paywall presentations, so haptics resolve their
+    /// enabled actions against the current delegate on each event rather than capturing them once.
+    @MainActor
+    private lazy var haptics: PaywallHaptics = PaywallHapticsImpl(
+        player: UIKitHapticPlayer(),
+        enabledActions: { [weak self] in
+            ProductHapticAction.from(self?.delegateWrapper?.productHapticsEnabled ?? [])
+        }
+    )
+
     func setActionsDelegate(delegateWrapper: ActionsDelegateWrapper) {
         self.delegateWrapper = delegateWrapper
     }
@@ -56,6 +66,7 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
                     break
                 }
                 self.delegateWrapper?.selectProduct(productId: productId)
+                self.haptics.onProductSelected()
                 respond(["status": "success", "selectedProduct": productId])
             case "cta-pressed":
                 guard let componentName = data["componentName"] as? String else {
@@ -66,15 +77,18 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
                 respond(["status": "success"])
                 
             case "subscribe":
+                self.haptics.onPurchasePressed()
                 if let productId = data["product"] as? String {
                     self.delegateWrapper?.selectProduct(productId: productId)
                 }
                 if let result = await self.delegateWrapper?.makePurchase() {
                     switch result {
                     case .purchased:
+                        self.haptics.onPurchaseSucceeded()
                         respond(["status": "purchased"]);
                         self.delegateWrapper?.dismissAll(dispatchEvent: false);
                     case .cancelled:
+                        self.haptics.onPurchaseCancelled()
                         respond(["status": "cancelled"])
                     case .pending:
                         respond(["status": "pending"])
@@ -82,6 +96,7 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
                         respond(["status": "restored"])
                         self.delegateWrapper?.dismissAll(dispatchEvent: false);
                     case .failed:
+                        self.haptics.onPurchaseFailed()
                         respond(["status": "failed"])
                     }
                 } else {
@@ -123,6 +138,7 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
                    let params = data["params"] as? [String: Any] {
                     // Convert Objective-C types to Swift types
                     let swiftParams = convertToSwiftTypes(params) as? [String: Any] ?? params
+                    self.haptics.onCustomHaptic(swiftParams[PaywallHapticsImpl.customHapticParam] as? String)
                     self.delegateWrapper?.onCustomAction(actionName: actionName, params: swiftParams)
                     respond(["status": "success"])
                 } else {

--- a/Sources/Helium/HeliumCore/Haptics/HapticPlayer.swift
+++ b/Sources/Helium/HeliumCore/Haptics/HapticPlayer.swift
@@ -1,0 +1,4 @@
+@MainActor
+protocol HapticPlayer {
+    func play(_ haptic: HeliumHaptic)
+}

--- a/Sources/Helium/HeliumCore/Haptics/HeliumHaptic.swift
+++ b/Sources/Helium/HeliumCore/Haptics/HeliumHaptic.swift
@@ -1,0 +1,6 @@
+enum HeliumHaptic {
+    case selection
+    case success
+    case warning
+    case error
+}

--- a/Sources/Helium/HeliumCore/Haptics/PaywallHaptics.swift
+++ b/Sources/Helium/HeliumCore/Haptics/PaywallHaptics.swift
@@ -1,0 +1,53 @@
+/// Product-flow haptics fire only for events the paywall has enabled; a custom haptic is requested
+/// explicitly per action and bypasses that gating.
+@MainActor
+protocol PaywallHaptics {
+    func onProductSelected()
+    func onPurchasePressed()
+    func onPurchaseSucceeded()
+    func onPurchaseCancelled()
+    func onPurchaseFailed()
+    func onCustomHaptic(_ value: String?)
+}
+
+@MainActor
+final class PaywallHapticsImpl: PaywallHaptics {
+    /// Param key a paywall sets on a custom action to request a haptic by name.
+    static let customHapticParam = "hlm_haptic"
+
+    private let player: HapticPlayer
+    /// Re-read on every event so haptics resolve against whichever paywall is currently presented.
+    private let enabledActions: () -> Set<ProductHapticAction>
+
+    init(player: HapticPlayer, enabledActions: @escaping () -> Set<ProductHapticAction>) {
+        self.player = player
+        self.enabledActions = enabledActions
+    }
+
+    func onProductSelected() { playGated(.select) }
+    func onPurchasePressed() { playGated(.press) }
+    func onPurchaseSucceeded() { playGated(.success) }
+    func onPurchaseCancelled() { playGated(.cancel) }
+    func onPurchaseFailed() { playGated(.fail) }
+
+    func onCustomHaptic(_ value: String?) {
+        guard let value, let haptic = customHaptic(for: value) else { return }
+        player.play(haptic)
+    }
+
+    private func playGated(_ action: ProductHapticAction) {
+        if enabledActions().contains(action) {
+            player.play(action.haptic)
+        }
+    }
+
+    private func customHaptic(for value: String) -> HeliumHaptic? {
+        switch value {
+        case "selection": return .selection
+        case "success": return .success
+        case "cancel": return .warning
+        case "failure": return .error
+        default: return nil
+        }
+    }
+}

--- a/Sources/Helium/HeliumCore/Haptics/ProductHapticAction.swift
+++ b/Sources/Helium/HeliumCore/Haptics/ProductHapticAction.swift
@@ -1,0 +1,35 @@
+/// `configKey` is a server wire value: it must stay in sync with the strings the backend sends to
+/// enable haptics for an event, so these keys are not safe to rename independently.
+enum ProductHapticAction: CaseIterable {
+    case select
+    case press
+    case success
+    case cancel
+    case fail
+
+    var configKey: String {
+        switch self {
+        case .select: return "select"
+        case .press: return "press"
+        case .success: return "success"
+        case .cancel: return "cancel"
+        case .fail: return "fail"
+        }
+    }
+
+    var haptic: HeliumHaptic {
+        switch self {
+        case .select: return .selection
+        case .press: return .success
+        case .success: return .success
+        case .cancel: return .warning
+        case .fail: return .error
+        }
+    }
+
+    /// Unrecognized keys are ignored so the backend can introduce new ones without breaking
+    /// older clients.
+    static func from(_ configKeys: [String]) -> Set<ProductHapticAction> {
+        Set(configKeys.compactMap { key in allCases.first { $0.configKey == key } })
+    }
+}

--- a/Sources/Helium/HeliumCore/Haptics/UIKitHapticPlayer.swift
+++ b/Sources/Helium/HeliumCore/Haptics/UIKitHapticPlayer.swift
@@ -1,0 +1,20 @@
+import UIKit
+
+/// Feedback generators honor the user's system haptic settings and need no permission, so there
+/// is nothing to request or gate here. A fresh generator per call keeps this stateless; at paywall
+/// interaction rates the Taptic Engine warm-up that caching one would save is immaterial.
+@MainActor
+final class UIKitHapticPlayer: HapticPlayer {
+    func play(_ haptic: HeliumHaptic) {
+        switch haptic {
+        case .selection:
+            UISelectionFeedbackGenerator().selectionChanged()
+        case .success:
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+        case .warning:
+            UINotificationFeedbackGenerator().notificationOccurred(.warning)
+        case .error:
+            UINotificationFeedbackGenerator().notificationOccurred(.error)
+        }
+    }
+}

--- a/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
@@ -38,7 +38,11 @@ class ActionsDelegateWrapper: ObservableObject {
     init(delegate: HeliumActionsDelegate) {
         self.delegate = delegate
     }
-    
+
+    var productHapticsEnabled: [String] {
+        delegate.paywallInfo.productHapticsEnabled ?? []
+    }
+
     func dismiss(dispatchEvent: Bool = true) {
         delegate.dismiss(dispatchEvent: dispatchEvent)
     }

--- a/Sources/Helium/HeliumCore/Models.swift
+++ b/Sources/Helium/HeliumCore/Models.swift
@@ -51,6 +51,7 @@ public struct HeliumPaywallInfo: Codable {
     var experimentInfo: JSON?  // New top-level field from server
     var additionalPaywallFields: JSON?
     var presentationStyle: PaywallPresentationStyle?
+    var productHapticsEnabled: [String]? = nil
     
     var productIdsIOS: [String] {
         productsOfferedIOS ?? productsOffered ?? []

--- a/Tests/helium-swiftTests/HeliumPaywallInfoDecodingTests.swift
+++ b/Tests/helium-swiftTests/HeliumPaywallInfoDecodingTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import Helium
+
+/// Locks the JSON contract for the `productHapticsEnabled` paywall field, which the SDK shares
+/// with the Android client and the paywall dashboard.
+final class HeliumPaywallInfoDecodingTests: XCTestCase {
+
+    private func makePaywallInfoJSON(extras: [String: Any] = [:]) throws -> Data {
+        var dict: [String: Any] = [
+            "paywallID": 1,
+            "paywallTemplateName": "test_paywall",
+            "resolvedConfig": [String: Any](),
+        ]
+        for (k, v) in extras { dict[k] = v }
+        return try JSONSerialization.data(withJSONObject: dict, options: [])
+    }
+
+    func test_GIVEN_productHapticsEnabledPresent_WHEN_decoded_THEN_parsesList() throws {
+        let json = try makePaywallInfoJSON(extras: [
+            "productHapticsEnabled": ["select", "press"],
+        ])
+
+        let decoded = try JSONDecoder().decode(HeliumPaywallInfo.self, from: json)
+
+        XCTAssertEqual(decoded.productHapticsEnabled, ["select", "press"])
+    }
+
+    func test_GIVEN_productHapticsEnabledAbsent_WHEN_decoded_THEN_isNil() throws {
+        let json = try makePaywallInfoJSON()
+
+        let decoded = try JSONDecoder().decode(HeliumPaywallInfo.self, from: json)
+
+        XCTAssertNil(decoded.productHapticsEnabled)
+    }
+}

--- a/Tests/helium-swiftTests/PaywallHapticsImplTests.swift
+++ b/Tests/helium-swiftTests/PaywallHapticsImplTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import Helium
+
+@MainActor
+final class PaywallHapticsImplTests: XCTestCase {
+
+    private final class FakeHapticPlayer: HapticPlayer {
+        private(set) var played: [HeliumHaptic] = []
+        func play(_ haptic: HeliumHaptic) { played.append(haptic) }
+    }
+
+    private func makeHaptics(
+        enabled: Set<ProductHapticAction>
+    ) -> (PaywallHapticsImpl, FakeHapticPlayer) {
+        let player = FakeHapticPlayer()
+        let haptics = PaywallHapticsImpl(player: player, enabledActions: { enabled })
+        return (haptics, player)
+    }
+
+    // MARK: - Product events are gated by enabled actions
+
+    func test_GIVEN_actionEnabled_WHEN_productSelected_THEN_playsSelection() {
+        let (haptics, player) = makeHaptics(enabled: [.select])
+        haptics.onProductSelected()
+        XCTAssertEqual(player.played, [.selection])
+    }
+
+    func test_GIVEN_actionDisabled_WHEN_productSelected_THEN_playsNothing() {
+        let (haptics, player) = makeHaptics(enabled: [])
+        haptics.onProductSelected()
+        XCTAssertTrue(player.played.isEmpty)
+    }
+
+    func test_GIVEN_allActionsEnabled_WHEN_purchaseLifecycle_THEN_playsMappedHaptics() {
+        let (haptics, player) = makeHaptics(enabled: Set(ProductHapticAction.allCases))
+        haptics.onPurchasePressed()
+        haptics.onPurchaseSucceeded()
+        haptics.onPurchaseCancelled()
+        haptics.onPurchaseFailed()
+        XCTAssertEqual(player.played, [.success, .success, .warning, .error])
+    }
+
+    func test_GIVEN_onlyPressEnabled_WHEN_pressedThenSucceeded_THEN_playsOnlyPress() {
+        let (haptics, player) = makeHaptics(enabled: [.press])
+        haptics.onPurchasePressed()
+        haptics.onPurchaseSucceeded()
+        XCTAssertEqual(player.played, [.success])
+    }
+
+    // MARK: - Enabled actions are re-read on every event
+
+    func test_GIVEN_enabledActionsChange_WHEN_productSelected_THEN_reflectsLatest() {
+        let player = FakeHapticPlayer()
+        var enabled: Set<ProductHapticAction> = []
+        let haptics = PaywallHapticsImpl(player: player, enabledActions: { enabled })
+
+        haptics.onProductSelected()
+        XCTAssertTrue(player.played.isEmpty)
+
+        enabled = [.select]
+        haptics.onProductSelected()
+        XCTAssertEqual(player.played, [.selection])
+    }
+
+    // MARK: - Custom haptics are ungated and map strings to haptics
+
+    func test_GIVEN_knownCustomValues_WHEN_onCustomHaptic_THEN_playsMappedHaptics() {
+        let (haptics, player) = makeHaptics(enabled: [])
+        haptics.onCustomHaptic("selection")
+        haptics.onCustomHaptic("success")
+        haptics.onCustomHaptic("cancel")
+        haptics.onCustomHaptic("failure")
+        XCTAssertEqual(player.played, [.selection, .success, .warning, .error])
+    }
+
+    func test_GIVEN_nilCustomValue_WHEN_onCustomHaptic_THEN_playsNothing() {
+        let (haptics, player) = makeHaptics(enabled: [])
+        haptics.onCustomHaptic(nil)
+        XCTAssertTrue(player.played.isEmpty)
+    }
+
+    func test_GIVEN_unknownCustomValue_WHEN_onCustomHaptic_THEN_playsNothing() {
+        let (haptics, player) = makeHaptics(enabled: [])
+        haptics.onCustomHaptic("explode")
+        haptics.onCustomHaptic("")
+        XCTAssertTrue(player.played.isEmpty)
+    }
+}

--- a/Tests/helium-swiftTests/ProductHapticActionTests.swift
+++ b/Tests/helium-swiftTests/ProductHapticActionTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import Helium
+
+final class ProductHapticActionTests: XCTestCase {
+
+    func test_GIVEN_knownConfigKeys_WHEN_from_THEN_resolvesMatchingActions() {
+        let actions = ProductHapticAction.from(["select", "press", "success", "cancel", "fail"])
+        XCTAssertEqual(actions, Set(ProductHapticAction.allCases))
+    }
+
+    func test_GIVEN_unknownConfigKeys_WHEN_from_THEN_ignoresThem() {
+        let actions = ProductHapticAction.from(["select", "bogus", "tap"])
+        XCTAssertEqual(actions, [.select])
+    }
+
+    func test_GIVEN_duplicateConfigKeys_WHEN_from_THEN_dedupes() {
+        let actions = ProductHapticAction.from(["press", "press", "press"])
+        XCTAssertEqual(actions, [.press])
+    }
+
+    func test_GIVEN_emptyConfigKeys_WHEN_from_THEN_returnsEmptySet() {
+        XCTAssertTrue(ProductHapticAction.from([]).isEmpty)
+    }
+
+    func test_GIVEN_action_WHEN_readingConfigKey_THEN_matchesWireValue() {
+        XCTAssertEqual(ProductHapticAction.select.configKey, "select")
+        XCTAssertEqual(ProductHapticAction.press.configKey, "press")
+        XCTAssertEqual(ProductHapticAction.success.configKey, "success")
+        XCTAssertEqual(ProductHapticAction.cancel.configKey, "cancel")
+        XCTAssertEqual(ProductHapticAction.fail.configKey, "fail")
+    }
+
+    func test_GIVEN_action_WHEN_readingHaptic_THEN_matchesMapping() {
+        XCTAssertEqual(ProductHapticAction.select.haptic, .selection)
+        XCTAssertEqual(ProductHapticAction.press.haptic, .success)
+        XCTAssertEqual(ProductHapticAction.success.haptic, .success)
+        XCTAssertEqual(ProductHapticAction.cancel.haptic, .warning)
+        XCTAssertEqual(ProductHapticAction.fail.haptic, .error)
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive UX and decoding only; purchase and delegate behavior are unchanged aside from haptic side effects on existing message paths.
> 
> **Overview**
> Adds **config-driven haptics** for web paywall flows on iOS, aligned with Android and the dashboard via the `productHapticsEnabled` paywall field.
> 
> `HeliumPaywallInfo` decodes an optional list of wire keys (`select`, `press`, `success`, `cancel`, `fail`). A new haptics stack (`PaywallHapticsImpl`, `ProductHapticAction`, `UIKitHapticPlayer`) plays UIKit feedback only when the **current** paywall has that event enabled; enabled actions are re-read on each event because `WebViewMessageHandler` is reused across presentations.
> 
> `WebViewMessageHandler` triggers haptics on `select-product`, subscribe press, and purchase outcomes (success / cancelled / failed). **Custom actions** can request a haptic with the `hlm_haptic` param (`selection`, `success`, `cancel`, `failure`), which bypasses product gating. Unit tests cover decoding, action mapping, gating, and custom haptics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80f9c07648440a72a473abb8133f97f157fa134e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Haptic feedback now activates on key paywall interactions: product selection, purchase initiation, and purchase outcomes (success, cancellation, failure)
* Haptic responses adapt based on paywall configuration for enabled actions
* Support for custom haptic feedback via action parameters

## Tests
* Added comprehensive test coverage for haptic triggering, action mapping, and custom haptic behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->