### PR TITLE
Always set resolved userId in baseRequestBody; drop unused productId …

### DIFF
--- a/Sources/Helium/HeliumCore/BuildConstants.swift
+++ b/Sources/Helium/HeliumCore/BuildConstants.swift
@@ -8,5 +8,5 @@
  */
 public struct BuildConstants {
     /// Current SDK version
-    public static let version = "4.5.2"
+    public static let version = "4.5.3"
 }

--- a/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentAPIClient.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentAPIClient.swift
@@ -69,11 +69,9 @@ public class HeliumPaymentAPIClient {
         }
         var body: [String: Any] = [
             "apiKey": apiKey,
-            "heliumPersistentId": HeliumIdentityManager.shared.getHeliumPersistentId()
+            "heliumPersistentId": HeliumIdentityManager.shared.getHeliumPersistentId(),
+            "userId": HeliumIdentityManager.shared.getResolvedUserId()
         ]
-        if let userId = Helium.identify.userId {
-            body["userId"] = userId
-        }
         if let rcUserId = Helium.identify.revenueCatAppUserId {
             body["rcUserId"] = rcUserId
         }

--- a/Sources/Helium/HeliumCore/StripeCheckout/WebCheckoutModels.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/WebCheckoutModels.swift
@@ -79,13 +79,11 @@ enum WebCheckoutRedirect {
 // MARK: - Payment Success Response
 
 public struct PaymentSuccessResponse: Sendable {
-    public let productId: String
     public let priceId: String?
     public let expiresAt: Date?
     public let transactionId: String?
 
-    public init(productId: String, priceId: String?, expiresAt: Date? = nil, transactionId: String? = nil) {
-        self.productId = productId
+    public init(priceId: String? = nil, expiresAt: Date? = nil, transactionId: String? = nil) {
         self.priceId = priceId
         self.expiresAt = expiresAt
         self.transactionId = transactionId
@@ -109,9 +107,8 @@ public struct ExecutePurchaseResponse: Decodable {
         subscriptionItemId ?? subscriptionId ?? paymentIntentId
     }
 
-    public func toPaymentSuccessResponse(backupProductId: String = "") -> PaymentSuccessResponse {
+    public func toPaymentSuccessResponse() -> PaymentSuccessResponse {
         PaymentSuccessResponse(
-            productId: productId ?? backupProductId,
             priceId: priceId,
             expiresAt: parseISODate(expiresAt),
             transactionId: transactionId


### PR DESCRIPTION
…from PaymentSuccessResponse

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Payment payloads always include a userId (including anonymous persistent id), which may change server-side identity handling; removing public `PaymentSuccessResponse.productId` is a breaking API change for integrators.
> 
> **Overview**
> Bumps the SDK to **4.5.3**.
> 
> Payment API request bodies built via `baseRequestBody` now **always** include `userId`, using `HeliumIdentityManager.shared.getResolvedUserId()` (custom identify id or persistent id fallback). The previous behavior only added `userId` when `Helium.identify.userId` was set.
> 
> `PaymentSuccessResponse` no longer exposes `productId`; checkout success mapping via `ExecutePurchaseResponse.toPaymentSuccessResponse()` only returns `priceId`, `expiresAt`, and `transactionId`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 828be22b8b5d206575d8b2f4b927db621ec555a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkout request handling so purchases consistently include the necessary account identifiers.
  * Refined purchase success data to use the latest available checkout details more reliably.

* **Chores**
  * Bumped the app version to **4.5.3**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->