### PR TITLE
Pin CI Xcode to 26.4.1 (WarpBuild default rolled to 26.5, broke UI tests)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,6 +12,12 @@ on:
         default: "core"
   workflow_dispatch:
 
+# Pin Xcode so the WarpBuild image's rolling default can't change the toolchain
+# under us. The macos-26 default moved to 26.5 on 2026-06-08, which broke the UI
+# test suite; 26.4.1 was the prior default. Bump this deliberately, not implicitly.
+env:
+  XCODE_PATH: /Applications/Xcode_26.4.1.app
+
 jobs:
   unit-tests:
     runs-on: warp-macos-26-arm64-6x
@@ -21,6 +27,11 @@ jobs:
       SIMULATOR_NAME: iPhone 17
     steps:
       - uses: actions/checkout@v4
+      - name: Select Xcode
+        run: |
+          ls -d /Applications/Xcode_*.app 2>/dev/null || true
+          sudo xcode-select -s "$XCODE_PATH"
+          xcodebuild -version
       - name: Run SwiftPM tests with Thread Sanitizer
         run: |
           xcodebuild test \
@@ -39,6 +50,12 @@ jobs:
       SIMULATOR_NAME: iPhone 17
     steps:
       - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: |
+          ls -d /Applications/Xcode_*.app 2>/dev/null || true
+          sudo xcode-select -s "$XCODE_PATH"
+          xcodebuild -version
 
       - name: Verify secrets are available
         run: |


### PR DESCRIPTION
## Problem

The UI test suite started failing in CI with simulator/XCUITest-level hangs (`IDELaunchParametersSnapshot ... no debugger version`, 600s "collecting diagnostics from simulator" timeouts) — not assertion failures in test logic. Tests pass locally.

## Root cause

We don't pin an Xcode version anywhere in the workflows — CI uses whatever Xcode is default-selected on the `warp-macos-26-arm64-6x` image. WarpBuild mirrors `actions/runner-images`, whose macos-26 default Xcode rolled to **26.5 on 2026-06-08** ([actions/runner-images#14172](https://github.com/actions/runner-images/issues/14172)). The runner label never changed, so the toolchain moved under us silently. The build log confirms CI was on `/Applications/Xcode_26.5.app`.

## Fix

Pin Xcode via a workflow-level `XCODE_PATH` env var and a `Select Xcode` step in both jobs, set to `26.4.1` (the prior default, before the breaking bump). The step also `ls`es the installed Xcodes so if `26.4.1` isn't present the run fails fast and clearly (vs. a confusing multi-minute test hang) and shows the exact path to use.

## Notes

- This is a deliberate pin — bump `XCODE_PATH` intentionally when we want to move to a newer Xcode, rather than inheriting the image default.
- If `Xcode_26.4.1.app` isn't on the image, update the single `XCODE_PATH` line based on the `ls` output in the Select step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change with no application, auth, or data-path impact; main risk is the pinned Xcode missing on the runner image.
> 
> **Overview**
> Pins the **Run Tests** workflow to **Xcode 26.4.1** so CI no longer follows the WarpBuild/macOS runner’s rolling default (which moved to 26.5 and caused UI test simulator/XCUITest hangs).
> 
> Adds a workflow-level `XCODE_PATH` and a **Select Xcode** step before tests in both **unit-tests** and **ui-tests**: list installed Xcode apps, `xcode-select` to the pinned path, and print `xcodebuild -version` for a fast, visible failure if that bundle is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e95d7c086b508ea611b747b7fb636a1e0e355cb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the test workflow to consistently use the same Xcode version across test jobs.
  * Added version checks before tests run to make build environments easier to verify and diagnose.
  * Improved test-run consistency for both unit and UI test pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->