### PR TITLE
Derive currentLanguage from preferred language, not device region

### DIFF
--- a/Sources/Helium/HeliumCore/UserContext.swift
+++ b/Sources/Helium/HeliumCore/UserContext.swift
@@ -227,8 +227,9 @@ public struct CodableUserContext: Codable {
     // Locale.current, which is constrained to the host app's localizations and
     // can disagree with the language Helium paywalls actually render.
     static func resolveCurrentLanguage() -> String? {
-        if let preferred = Locale.preferredLanguages.first {
-            return Locale(identifier: preferred).languageCode
+        if let preferred = Locale.preferredLanguages.first,
+           let code = Locale(identifier: preferred).languageCode {
+            return code
         }
         return Locale.current.languageCode
     }

--- a/Sources/Helium/HeliumCore/UserContext.swift
+++ b/Sources/Helium/HeliumCore/UserContext.swift
@@ -223,13 +223,23 @@ public struct CodableUserContext: Codable {
         ]
     }
 
+    // Derive the language from the user's top preferred language rather than
+    // Locale.current, which is constrained to the host app's localizations and
+    // can disagree with the language Helium paywalls actually render.
+    static func resolveCurrentLanguage() -> String? {
+        if let preferred = Locale.preferredLanguages.first {
+            return Locale(identifier: preferred).languageCode
+        }
+        return Locale.current.languageCode
+    }
+
     static func create(userTraits: HeliumUserTraits?) -> CodableUserContext {
-        
+
         let locale = CodableLocale(
             currentCountry: Locale.current.regionCode,
             currentCurrency: Locale.current.currencyCode,
             currentCurrencySymbol: Locale.current.currencySymbol,
-            currentLanguage: Locale.current.languageCode,
+            currentLanguage: resolveCurrentLanguage(),
             preferredLanguages: Locale.preferredLanguages,
             currentTimeZone: TimeZone.current,
             currentTimeZoneName: TimeZone.current.identifier,


### PR DESCRIPTION
## What

`currentLanguage` in the uploaded user context now derives from `Locale.preferredLanguages.first` instead of `Locale.current.languageCode`.

## Why

`Locale.current.languageCode` is constrained to the host app's localizations (`CFBundleLocalizations`). If the host app ships only English but a user's top preferred language is Spanish, `Locale.current.languageCode` resolves to `"en"` while `Locale.preferredLanguages.first` is still `"es-…"`.

Helium paywalls render remotely and aren't bound by the host app's localizations — they key off the preferred language. So targeting rules built on `currentLanguage` disagreed with the language the paywall actually rendered. This aligns the two.

Resolves HEL-5947.

## Details

- Format is unchanged: bare language subtag (`"es-MX"` → `"es"`), so rules matching `"en"`/`"es"` keep working — just sourced correctly.
- Safety net back to `Locale.current.languageCode` if `preferredLanguages` is somehow empty.
- `preferredLanguages` continues to be sent as before.

## ⚠️ Before landing: check existing targeting rules

This changes the reported `currentLanguage` value for users whose **device region and preferred language diverge** — exactly the population this ticket is about. Any existing dashboard targeting rules relying (perhaps unknowingly) on the old region-influenced value could behave differently for those users. Review existing `currentLanguage` targeting rules before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reported `currentLanguage` for users where preferred language and app localizations diverge, which can shift existing dashboard targeting rules without a code bug in the SDK itself.
> 
> **Overview**
> **`currentLanguage`** in the uploaded user context now comes from the user’s top **preferred language** instead of **`Locale.current.languageCode`**, which can be limited to the host app’s localizations and disagree with what Helium paywalls render.
> 
> Adds **`resolveCurrentLanguage()`** to take the language subtag from **`Locale.preferredLanguages.first`** (same bare code shape as before) and fall back to **`Locale.current.languageCode`** if needed. **`CodableUserContext.create`** uses this helper when building **`CodableLocale`**.
> 
> Users whose preferred language and app-localization-derived locale differ may see a different **`currentLanguage`** in payloads, so dashboard rules keyed on that field could behave differently for that group.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 742ef0be96558878a2387313aeca26dde2357b19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language detection so the app now uses the user’s preferred locale language more accurately when setting the current language.
  * Added a fallback to the device’s current language if no preferred language is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->