### PR TITLE
Fix CFBoolean encoding as integer in AnyEncodable

### DIFF
--- a/Sources/Helium/HeliumCore/AnyCodable/AnyEncodable.swift
+++ b/Sources/Helium/HeliumCore/AnyCodable/AnyEncodable.swift
@@ -68,14 +68,28 @@ extension _AnyEncodable {
         #endif
         case is Void:
             try container.encodeNil()
-        // HELIUM MODIFICATION: Added `where type(of: value) == Bool.self` guard to prevent
-        // NSNumber from incorrectly matching as Bool. Without this guard, NSNumber(0.0) and
-        // NSNumber(1.0) from Expo/Flutter bridges match this case and encode as false/true
-        // instead of numeric values. The guard ensures only native Swift Bool matches here,
-        // while NSNumber values fall through to numeric cases (Int, Float, etc.) and encode
-        // as numbers.
+        // HELIUM MODIFICATION: Boolean handling for a type-erased `Any` is ambiguous because
+        // Swift's `NSNumber` bridging is lenient in BOTH directions: a numeric `NSNumber(1)`
+        // succeeds as `value as? Bool` (== true), AND a boolean `NSNumber`/`CFBoolean`
+        // succeeds as `value as? Int` (== 1). So we must disambiguate by the value's real
+        // type, in this exact order:
+        //
+        //   1. Native Swift `Bool` -> encode as bool.
+        //   2. `CFBoolean` (a.k.a. `__NSCFBoolean`) -> encode as bool. This is how a *genuine*
+        //      boolean arrives from `JSONSerialization`, Objective-C (`@YES`/`@NO`), and
+        //      React Native / Expo / Flutter bridges. Without this case it falls through to
+        //      `case let int as Int` (via lenient `as? Int`) and serializes as 0/1, silently
+        //      corrupting boolean values (e.g. a `showOnlyPremium: true` paywall trait).
+        //   3. Numeric `NSNumber` (e.g. NSNumber(0)/NSNumber(1) from Expo/Flutter) -> the
+        //      `type(of:) == Bool.self` guard keeps these OUT of case 1, and the
+        //      `CFGetTypeID` check keeps them out of case 2, so they fall through to the
+        //      numeric cases below and encode as numbers.
         case let bool as Bool where type(of: value) == Bool.self:
             try container.encode(bool)
+        #if canImport(Foundation)
+        case let number as NSNumber where CFGetTypeID(number) == CFBooleanGetTypeID():
+            try container.encode(number.boolValue)
+        #endif
         case let int as Int:
             try container.encode(int)
         case let int8 as Int8:

--- a/Tests/helium-swiftTests/AnyEncodableBooleanTests.swift
+++ b/Tests/helium-swiftTests/AnyEncodableBooleanTests.swift
@@ -1,0 +1,169 @@
+import XCTest
+@testable import Helium
+
+/// Tests for boolean encoding through the type-erased `AnyCodable`/`AnyEncodable` path.
+///
+/// Background: encoding a boolean from a type-erased `Any` is ambiguous because Swift's
+/// `NSNumber` bridging is lenient in both directions — a numeric `NSNumber(1)` casts to
+/// `Bool` (== true), and a boolean `NSNumber`/`CFBoolean` casts to `Int` (== 1). Booleans
+/// that originate outside pure Swift (JSONSerialization, Objective-C `@YES`/`@NO`, and
+/// React Native / Expo / Flutter bridges) arrive as `CFBoolean` (`__NSCFBoolean`), and
+/// must serialize as `true`/`false` — NOT `1`/`0`. Numeric `NSNumber`s must stay numeric.
+///
+/// This is the exact path used to inject `customPaywallTraits` into the paywall webview
+/// (`HeliumUserTraits` → `JSONEncoder`), so a regression here silently corrupts boolean
+/// traits such as `showOnlyPremium`.
+final class AnyEncodableBooleanTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.outputFormatting = [.sortedKeys]
+        return e
+    }()
+
+    /// Encodes a single value (wrapped in a one-key object) and returns the JSON string.
+    private func json(_ value: Any?) throws -> String {
+        let data = try encoder.encode(["v": AnyCodable(value)])
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    /// Returns a genuine `CFBoolean` (`__NSCFBoolean`) — exactly what `JSONSerialization`,
+    /// Objective-C, and cross-platform bridges produce for a boolean.
+    private func cfBoolean(_ b: Bool) -> Any {
+        let source = b ? #"{"v":true}"# : #"{"v":false}"#
+        let obj = try! JSONSerialization.jsonObject(with: Data(source.utf8)) as! [String: Any]
+        return obj["v"]!
+    }
+
+    /// True iff the reparsed JSON value is a JSON boolean (CFBoolean) rather than a number.
+    /// `JSONSerialization` maps JSON `true` → CFBoolean and JSON `1` → numeric NSNumber,
+    /// so this faithfully reflects which token was actually written.
+    private func isJSONBoolean(_ value: Any?) -> Bool {
+        guard let n = value as? NSNumber else { return false }
+        return CFGetTypeID(n) == CFBooleanGetTypeID()
+    }
+
+    /// Encodes via the real trait path (`HeliumUserTraits` → `JSONEncoder`) and reparses.
+    private func encodeTraitAndReparse(_ dict: [String: Any], key: String) throws -> Any? {
+        let data = try encoder.encode(HeliumUserTraits(dict))
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        return obj?[key]
+    }
+
+    // MARK: - Native Swift Bool
+
+    func testNativeSwiftBoolEncodesAsBoolean() throws {
+        XCTAssertEqual(try json(true), #"{"v":true}"#)
+        XCTAssertEqual(try json(false), #"{"v":false}"#)
+    }
+
+    // MARK: - CFBoolean (JSONSerialization / bridges) — the regression under test
+
+    func testCFBooleanEncodesAsBooleanNotInteger() throws {
+        // This is the exact case that regressed: a boolean parsed by JSONSerialization
+        // (an __NSCFBoolean) must serialize as true/false, not 1/0.
+        XCTAssertEqual(try json(cfBoolean(true)), #"{"v":true}"#)
+        XCTAssertEqual(try json(cfBoolean(false)), #"{"v":false}"#)
+    }
+
+    func testObjCNSNumberBoolEncodesAsBoolean() throws {
+        // Objective-C `@YES` / `@NO` and `NSNumber(value: Bool)` are CFBoolean-backed.
+        XCTAssertEqual(try json(NSNumber(value: true)), #"{"v":true}"#)
+        XCTAssertEqual(try json(NSNumber(value: false)), #"{"v":false}"#)
+    }
+
+    // MARK: - Numeric NSNumber must NOT become boolean (preserves the original fix)
+
+    func testNumericNSNumberZeroAndOneStayNumeric() throws {
+        // These come from Expo/Flutter numeric bridging; they must NOT collapse to true/false.
+        XCTAssertEqual(try json(NSNumber(value: 1)), #"{"v":1}"#)
+        XCTAssertEqual(try json(NSNumber(value: 0)), #"{"v":0}"#)
+    }
+
+    func testNumericNSNumberFromJSONStaysNumeric() throws {
+        let obj = try JSONSerialization.jsonObject(with: Data(#"{"v":1}"#.utf8)) as! [String: Any]
+        XCTAssertEqual(try json(obj["v"]!), #"{"v":1}"#)
+    }
+
+    func testNumericNSNumberDoubleStaysNumeric() throws {
+        // A non-integral numeric NSNumber must remain a number.
+        let v = try json(NSNumber(value: 1.5))
+        XCTAssertFalse(v.contains("true"))
+        XCTAssertFalse(v.contains("false"))
+        XCTAssertTrue(v.contains("1.5"))
+    }
+
+    // MARK: - Other scalars unaffected
+
+    func testIntStringDoubleUnaffected() throws {
+        XCTAssertEqual(try json(42), #"{"v":42}"#)
+        XCTAssertEqual(try json(-7), #"{"v":-7}"#)
+        XCTAssertEqual(try json("hello"), #"{"v":"hello"}"#)
+        XCTAssertEqual(try json(Int64(9_000_000_000)), #"{"v":9000000000}"#)
+    }
+
+    // MARK: - HeliumUserTraits round-trip (the real injection path)
+
+    func testTraitBooleanFromJSONSerializesAsBoolean() throws {
+        // Mirrors the demo app / cross-platform bridge: traits built from parsed JSON.
+        let parsed = try JSONSerialization.jsonObject(
+            with: Data(#"{"showOnlyPremium": true}"#.utf8)) as! [String: Any]
+
+        let value = try encodeTraitAndReparse(parsed, key: "showOnlyPremium")
+        XCTAssertTrue(isJSONBoolean(value), "showOnlyPremium must serialize as a JSON boolean, not a number")
+        XCTAssertEqual(value as? Bool, true)
+    }
+
+    func testTraitNativeBooleanSerializesAsBoolean() throws {
+        let value = try encodeTraitAndReparse(["showOnlyPremium": true], key: "showOnlyPremium")
+        XCTAssertTrue(isJSONBoolean(value))
+        XCTAssertEqual(value as? Bool, true)
+    }
+
+    func testTraitNumericValueStaysNumeric() throws {
+        let parsed = try JSONSerialization.jsonObject(
+            with: Data(#"{"count": 1}"#.utf8)) as! [String: Any]
+
+        let value = try encodeTraitAndReparse(parsed, key: "count")
+        XCTAssertFalse(isJSONBoolean(value), "numeric trait must not collapse to a boolean")
+        XCTAssertEqual(value as? Int, 1)
+    }
+
+    func testMixedTraitsPreserveTypesTogether() throws {
+        // A single payload mixing genuine booleans and numeric 0/1 — the crux of the
+        // ambiguity. Booleans stay boolean; numbers stay numeric.
+        let parsed = try JSONSerialization.jsonObject(
+            with: Data(#"{"flagOn": true, "flagOff": false, "count": 1, "zero": 0}"#.utf8)) as! [String: Any]
+
+        let flagOn = try encodeTraitAndReparse(parsed, key: "flagOn")
+        let flagOff = try encodeTraitAndReparse(parsed, key: "flagOff")
+        let count = try encodeTraitAndReparse(parsed, key: "count")
+        let zero = try encodeTraitAndReparse(parsed, key: "zero")
+
+        XCTAssertTrue(isJSONBoolean(flagOn));  XCTAssertEqual(flagOn as? Bool, true)
+        XCTAssertTrue(isJSONBoolean(flagOff)); XCTAssertEqual(flagOff as? Bool, false)
+        XCTAssertFalse(isJSONBoolean(count));  XCTAssertEqual(count as? Int, 1)
+        XCTAssertFalse(isJSONBoolean(zero));   XCTAssertEqual(zero as? Int, 0)
+    }
+
+    func testNestedBooleanInDictionaryAndArray() throws {
+        // Booleans nested inside container traits must also survive.
+        let parsed = try JSONSerialization.jsonObject(
+            with: Data(#"{"nested": {"on": true}, "list": [true, false, 1]}"#.utf8)) as! [String: Any]
+
+        let data = try encoder.encode(HeliumUserTraits(parsed))
+        let obj = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        let nested = obj["nested"] as? [String: Any]
+        XCTAssertTrue(isJSONBoolean(nested?["on"]))
+        XCTAssertEqual(nested?["on"] as? Bool, true)
+
+        let list = obj["list"] as? [Any]
+        XCTAssertEqual(list?.count, 3)
+        XCTAssertTrue(isJSONBoolean(list?[0]));  XCTAssertEqual(list?[0] as? Bool, true)
+        XCTAssertTrue(isJSONBoolean(list?[1]));  XCTAssertEqual(list?[1] as? Bool, false)
+        XCTAssertFalse(isJSONBoolean(list?[2])); XCTAssertEqual(list?[2] as? Int, 1)
+    }
+}

--- a/Tests/helium-swiftTests/AnyEncodableBooleanTests.swift
+++ b/Tests/helium-swiftTests/AnyEncodableBooleanTests.swift
@@ -166,4 +166,42 @@ final class AnyEncodableBooleanTests: XCTestCase {
         XCTAssertTrue(isJSONBoolean(list?[1]));  XCTAssertEqual(list?[1] as? Bool, false)
         XCTAssertFalse(isJSONBoolean(list?[2])); XCTAssertEqual(list?[2] as? Int, 1)
     }
+
+    // MARK: - SwiftyJSON round-trip (the ACTUAL webview injection path)
+
+    /// Encodes via the trait path, then runs the encoded data through SwiftyJSON's
+    /// `JSON(data:)` → `rawString()` — the exact serialization the paywall webview is
+    /// injected with (see `DynamicWebView`). The other tests stop at `JSONEncoder`; this
+    /// one guards the additional SwiftyJSON round-trip, where a boolean could still be
+    /// collapsed back to 1/0 even though the encoder produced it correctly.
+    private func encodeTraitThroughSwiftyJSONAndReparse(_ dict: [String: Any], key: String) throws -> Any? {
+        let data = try encoder.encode(HeliumUserTraits(dict))
+        let rawString = try JSON(data: data).rawString() ?? ""
+        let obj = try JSONSerialization.jsonObject(with: Data(rawString.utf8)) as? [String: Any]
+        return obj?[key]
+    }
+
+    func testBooleanSurvivesSwiftyJSONRoundTrip() throws {
+        // The tokens actually injected into the webview come from SwiftyJSON's rawString(),
+        // not JSONEncoder. Booleans must stay boolean and numbers must stay numeric through
+        // that round-trip — otherwise a `showOnlyPremium: true` trait ships as 1.
+        let parsed = try JSONSerialization.jsonObject(
+            with: Data(#"{"showOnlyPremium": true, "isTrial": false, "count": 1, "zero": 0}"#.utf8)) as! [String: Any]
+
+        let showOnlyPremium = try encodeTraitThroughSwiftyJSONAndReparse(parsed, key: "showOnlyPremium")
+        XCTAssertTrue(isJSONBoolean(showOnlyPremium), "boolean must survive the SwiftyJSON round-trip as a JSON boolean")
+        XCTAssertEqual(showOnlyPremium as? Bool, true)
+
+        let isTrial = try encodeTraitThroughSwiftyJSONAndReparse(parsed, key: "isTrial")
+        XCTAssertTrue(isJSONBoolean(isTrial))
+        XCTAssertEqual(isTrial as? Bool, false)
+
+        let count = try encodeTraitThroughSwiftyJSONAndReparse(parsed, key: "count")
+        XCTAssertFalse(isJSONBoolean(count), "numeric trait must not collapse to a boolean through the round-trip")
+        XCTAssertEqual(count as? Int, 1)
+
+        let zero = try encodeTraitThroughSwiftyJSONAndReparse(parsed, key: "zero")
+        XCTAssertFalse(isJSONBoolean(zero))
+        XCTAssertEqual(zero as? Int, 0)
+    }
 }


### PR DESCRIPTION
## Problem

Booleans that arrive as an `NSNumber`/`CFBoolean` — rather than a native Swift `Bool` — were serialized as `1`/`0` instead of `true`/`false`.

`CFBoolean` (`__NSCFBoolean`) is how a genuine boolean is represented when it comes from:
- `JSONSerialization` (JSON-sourced config, remote values, the demo app's paste-JSON path)
- Objective-C (`@YES` / `@NO`, `NSDictionary`)
- React Native / Expo / Flutter bridges

The existing `case let bool as Bool where type(of: value) == Bool.self` guard was added (correctly) to stop *numeric* `NSNumber`s (`NSNumber(0)`/`NSNumber(1)` from Expo/Flutter) from encoding as booleans. But that guard also excludes real `CFBoolean`s, which then fall through to `case let int as Int` via lenient `as? Int` bridging and encode as `1`/`0`.

### Impact
Any boolean value passed through `HeliumUserTraits` from a non-Swift-literal source was silently corrupted on injection into the paywall webview. For example a `showOnlyPremium: true` paywall trait arrived in JS as `1`, which a strict `=== true` check reads as `false`.

## Fix

Add an explicit `CFBoolean` case (`CFGetTypeID(number) == CFBooleanGetTypeID()`) **before** the numeric cases. All three cases now route correctly:

| Input | Encodes as |
|-------|-----------|
| native Swift `Bool` | `true` / `false` |
| `CFBoolean` (JSON / Obj-C / bridge) | `true` / `false` |
| numeric `NSNumber` (`0`/`1`, doubles) | number |

The original numeric-`NSNumber` fix is preserved.

## Tests

New `AnyEncodableBooleanTests` (12 cases): native `Bool`, `CFBoolean` from `JSONSerialization`, `@YES`/`@NO`, numeric `0`/`1`, doubles, other scalars, and the full `HeliumUserTraits` → `JSONEncoder` round-trip including mixed and nested payloads. The `CFBoolean`/JSON-trait cases fail without the fix and pass with it.

Verified locally: `xcodebuild test -scheme helium-swift -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:helium-swiftTests/AnyEncodableBooleanTests` → 12 passed, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared type-erased JSON encoding used for paywall trait injection; wrong branching could still mis-type booleans vs numbers, but scope is narrow and heavily tested.
> 
> **Overview**
> Fixes **boolean paywall traits** (e.g. `showOnlyPremium`) being serialized as **`1`/`0`** instead of **`true`/`false`** when values come from `JSONSerialization`, Obj-C, or RN/Expo/Flutter bridges as **`CFBoolean`** (`__NSCFBoolean`).
> 
> `AnyEncodable` now adds a dedicated **`CFGetTypeID` == `CFBooleanGetTypeID()`** branch after native Swift `Bool` and before integer cases, while keeping the existing guard so numeric **`NSNumber(0)`/`NSNumber(1)`** still encode as numbers. Comments document the disambiguation order.
> 
> Adds **`AnyEncodableBooleanTests`** covering native `Bool`, `CFBoolean`, Obj-C booleans, numeric `NSNumber`s, **`HeliumUserTraits` → `JSONEncoder`**, nested structures, and the **SwiftyJSON `rawString()`** path used in **`DynamicWebView`** injection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31c0ada3022b49babea05b124d26205d6ba5e58a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON encoding so boolean values remain JSON booleans when originating from Foundation/Objective-C bridging.
  * Ensured numeric `NSNumber` values (including `0/1`) are not misidentified as booleans during encoding.
  * Preserved boolean vs numeric types across mixed and nested dictionaries/arrays.
* **Tests**
  * Added coverage to verify correct boolean and numeric behavior across type-erased encoders and trait serialization, including JSON round-trip validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->