### PR TITLE
Inject latest customPaywallTraits at display time for embedded paywalls

### DIFF
--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -39,6 +39,7 @@ struct DynamicWebView: View {
     @State private var processingVisible = false
     @Environment(\.paywallPresentationState) var presentationState: HeliumPaywallPresentationState
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.heliumDynamicPaywallTraits) private var dynamicPaywallTraits: HeliumUserTraits?
     
     private var effectiveColorScheme: ColorScheme {
         switch Helium.config.lightDarkModeOverride {
@@ -209,7 +210,10 @@ struct DynamicWebView: View {
             // customPaywallTraits are key/values that Helium customer can direct paywall editor to read.
             var combinedTraits = HeliumUserTraits(["trigger": triggerName ?? ""])
             combinedTraits.merge(HeliumIdentityManager.shared.getUserTraits())
-            if let paywallTraits = paywallSession?.presentationContext.customPaywallTraits {
+            // Prefer the live environment traits so a paywall constructed off-screen still injects the latest
+            // traits at display time; the frozen session value is the safety net (and covers the presented path,
+            // which does not set the environment).
+            if let paywallTraits = dynamicPaywallTraits ?? paywallSession?.presentationContext.customPaywallTraits {
                 combinedTraits.merge(paywallTraits)
             }
             let combinedTraitsData = try JSONEncoder().encode(combinedTraits)

--- a/Sources/Helium/HeliumCore/HeliumPaywall.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywall.swift
@@ -103,6 +103,7 @@ public struct HeliumPaywall<PaywallNotShownView: View>: View {
             case .ready(let paywallViewAndSession):
                 paywallViewAndSession.view
                     .environment(\.heliumLoadTimeTakenMS, resolvedLoadTimeTakenMS)
+                    .environment(\.heliumDynamicPaywallTraits, config.customPaywallTraits)
             case .noShow(let reason):
                 paywallNotShownView(reason)
                     .onAppear {
@@ -297,5 +298,20 @@ extension EnvironmentValues {
     var heliumLoadTimeTakenMS: UInt64? {
         get { self[HeliumLoadTimeTakenMSKey.self] }
         set { self[HeliumLoadTimeTakenMSKey.self] = newValue }
+    }
+}
+
+// Carries the presentation's customPaywallTraits down to the webview through the environment (resolved at
+// render time) rather than only via the frozen PaywallSession captured when state first resolved to .ready.
+// This lets an embedded paywall that was constructed while off-screen (e.g. a non-selected TabView tab, or an
+// eagerly-built navigation destination) inject the latest traits when it finally displays.
+private struct HeliumDynamicPaywallTraitsKey: EnvironmentKey {
+    static let defaultValue: HeliumUserTraits? = nil
+}
+
+extension EnvironmentValues {
+    var heliumDynamicPaywallTraits: HeliumUserTraits? {
+        get { self[HeliumDynamicPaywallTraitsKey.self] }
+        set { self[HeliumDynamicPaywallTraitsKey.self] = newValue }
     }
 }


### PR DESCRIPTION
## Problem

An embedded `HeliumPaywall` freezes its `PaywallSession` — including `config.customPaywallTraits` — the first time its `@State` resolves to `.ready`. For most embeddings that's fine because construction coincides with display. But when the view is **constructed while off-screen** (e.g. a non-selected `TabView` tab, or an eagerly-built `NavigationLink` destination), the session can freeze *before* the paywall is ever shown. If the host updates the traits between that point and display, the paywall injects the **stale** traits captured at resolution time.

This is intermittent by nature: it only bites when Helium config is already downloaded at the moment the state resolves (warm launch / cached config), so it reproduces inconsistently across launches and embedding styles — which makes it hard to attribute to the SDK vs. host integration.

## Fix

Route the presentation's `customPaywallTraits` down to the webview through a new `heliumDynamicPaywallTraits` **environment** value. Environment resolves at render time, so it flows the *current* traits into the cached `.ready` subtree without rebuilding it (no webview reload). `DynamicWebView.loadWebView` — which runs at `.onAppear`, i.e. display time — now prefers that value over the frozen session traits when building the injected `customPaywallTraits`.

This also aligns `customPaywallTraits` with user traits, which were *already* read live at injection via `getUserTraits()`.

## Scope / safety

- **TabView / eager navigation destination / constructed-while-hidden with deferred `onAppear`** → now injects the latest traits at display. ✅
- **Conditional / `.sheet` / `.fullScreenCover` / lazy containers** → env equals the session value, pure no-op. ✅
- **Presented / UIKit path** → never sets the environment; the `?? session` safety net keeps behavior identical. ✅

## Known boundary (not covered)

A paywall whose `onAppear` already fired *while hidden* (e.g. `.opacity(0)` in a `ZStack`) and is later revealed without a fresh `onAppear` — injection already happened and `loadWebView` early-returns on `webView != nil`. Covering that would require a reload or a live JS-push hook; deliberately left out as over-engineering for a niche embedding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to trait sourcing at webview injection; embedded path gains fresher traits while presented flows fall back to unchanged session behavior.
> 
> **Overview**
> Fixes **stale `customPaywallTraits`** when an embedded `HeliumPaywall` becomes `.ready` while still off-screen (e.g. unselected `TabView` tab, eager navigation destination) and the host updates traits before the paywall appears.
> 
> `HeliumPaywall` now passes `config.customPaywallTraits` through a new **`heliumDynamicPaywallTraits` environment** value on the ready paywall subtree. In `DynamicWebView.loadWebView` (runs on `.onAppear`), trait merging **prefers that environment value** over `paywallSession?.presentationContext.customPaywallTraits`, so injection uses traits resolved at display/render time without rebuilding the cached `.ready` view or reloading the webview.
> 
> Presented/UIKit paths that do not set the environment keep the previous behavior via the session fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4257eda612615b669a7dae4daee0c9bafb01af6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Paywalls now use the latest configured custom traits when rendering and loading web content.
  * Updated trait values are reflected without relying on previously captured session data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->