### PR TITLE
HEL-6133 Add getPaddleCustomerId(), deprecate createPaddlePortalSession()

### DIFF
--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -627,14 +627,9 @@ public class ExternalWebCheckoutManager: NSObject {
 
     // MARK: - API Calls
 
-    /// Syncs Stripe customer metadata with the current user identity.
+    /// Syncs customer metadata with the current user identity.
     @discardableResult
-    func updateCustomerMetadata(
-        name: String? = nil,
-        email: String? = nil,
-        phone: String? = nil,
-        description: String? = nil
-    ) async throws -> Bool {
+    func updateCustomerMetadata() async throws -> Bool {
         var body = try HeliumPaymentAPIClient.shared.baseRequestBody(provider: provider)
         body["metadata"] = [
             "userId": body["userId"] as? String ?? "",
@@ -642,11 +637,6 @@ public class ExternalWebCheckoutManager: NSObject {
             "heliumPersistentId": body["heliumPersistentId"] as? String ?? "",
             "appTransactionId": body["appTransactionId"] as? String ?? ""
         ]
-
-        if let name { body["name"] = name }
-        if let email { body["email"] = email }
-        if let phone { body["phone"] = phone }
-        if let description { body["description"] = description }
 
         let response: UpdateCustomerMetadataResponse = try await HeliumPaymentAPIClient.shared.post(provider.updateCustomerMetadataPath, body: body)
         if let customerId = response.customerId, provider.getCustomerId() == nil {

--- a/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
@@ -69,11 +69,6 @@ open class HeliumPaymentEntitlementsSource: ThirdPartyEntitlementsSource, @unche
         await fetchFromServer(forceNew: true)
     }
 
-    /// Refreshes only if the cache is stale, respecting the cache TTL.
-    func refreshEntitlementsIfNeeded() async {
-        await refreshIfNeeded()
-    }
-
     /// Latest server-reported intro-offer eligibility for this customer, or nil
     /// if unknown (no fetch yet, or server omitted the field on partial failure).
     open func introOfferEligible() async -> Bool? {
@@ -131,8 +126,6 @@ open class HeliumPaymentEntitlementsSource: ThirdPartyEntitlementsSource, @unche
         }
     }
 
-    // MARK: - Private
-
     private var currentHeliumProductIds: Set<String> {
         if let cached {
             return cached.activeHeliumProductIds
@@ -147,7 +140,7 @@ open class HeliumPaymentEntitlementsSource: ThirdPartyEntitlementsSource, @unche
         return Set(persisted.filter { $0.subscriptionExpiresAt != nil && $0.isActive }.map { $0.heliumProductId })
     }
 
-    private func refreshIfNeeded() async {
+    func refreshIfNeeded() async {
         let needsRefresh: Bool = lock.withLock {
             guard let cached else { return true }
             return cached.needsRefresh

--- a/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/HeliumPaymentEntitlementsSource.swift
@@ -69,6 +69,11 @@ open class HeliumPaymentEntitlementsSource: ThirdPartyEntitlementsSource, @unche
         await fetchFromServer(forceNew: true)
     }
 
+    /// Refreshes only if the cache is stale, respecting the cache TTL.
+    func refreshEntitlementsIfNeeded() async {
+        await refreshIfNeeded()
+    }
+
     /// Latest server-reported intro-offer eligibility for this customer, or nil
     /// if unknown (no fetch yet, or server omitted the field on partial failure).
     open func introOfferEligible() async -> Bool? {

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -384,9 +384,8 @@ public class Helium {
         if let customerId = HeliumIdentityManager.shared.getPaddleCustomerId() {
             return customerId
         }
-        let paddleSource = HeliumEntitlementsManager.shared.paddleEntitlementsSource
-        guard paddleSource.isConfigured else { return nil }
-        await paddleSource.refreshIfNeeded()
+        guard HeliumIdentityManager.shared.isPaddleCheckoutEligible() else { return nil }
+        await HeliumEntitlementsManager.shared.paddleEntitlementsSource.refreshIfNeeded()
         return HeliumIdentityManager.shared.getPaddleCustomerId()
     }
     

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -384,7 +384,7 @@ public class Helium {
         if let customerId = HeliumIdentityManager.shared.getPaddleCustomerId() {
             return customerId
         }
-        guard HeliumIdentityManager.shared.isPaddleCheckoutEligible() else { return nil }
+        guard Helium.config.webCheckoutProcessors.contains(.paddle) else { return nil }
         await HeliumEntitlementsManager.shared.paddleEntitlementsSource.refreshIfNeeded()
         return HeliumIdentityManager.shared.getPaddleCustomerId()
     }

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -386,7 +386,7 @@ public class Helium {
         }
         let paddleSource = HeliumEntitlementsManager.shared.paddleEntitlementsSource
         guard paddleSource.isConfigured else { return nil }
-        await paddleSource.refreshEntitlementsIfNeeded()
+        await paddleSource.refreshIfNeeded()
         return HeliumIdentityManager.shared.getPaddleCustomerId()
     }
     

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -369,8 +369,25 @@ public class Helium {
     /// the user manage their subscriptions.
     ///
     /// - Returns: The portal session URL.
+    @available(*, deprecated, message: "Use getPaddleCustomerId() and pass the ID to your server to generate a Paddle customer portal session instead.")
     public func createPaddlePortalSession() async throws -> URL {
         return try await PaddleCheckoutManager.shared.createPortalSession()
+    }
+
+    /// Returns the Paddle customer ID for the current user, if one exists.
+    ///
+    /// Pass this ID to your server to generate a Paddle customer portal session,
+    /// allowing the user to manage their subscriptions.
+    ///
+    /// - Returns: The Paddle customer ID, or `nil` if none has been assigned.
+    public func getPaddleCustomerId() async -> String? {
+        if let customerId = HeliumIdentityManager.shared.getPaddleCustomerId() {
+            return customerId
+        }
+        let paddleSource = HeliumEntitlementsManager.shared.paddleEntitlementsSource
+        guard paddleSource.isConfigured else { return nil }
+        await paddleSource.refreshEntitlementsIfNeeded()
+        return HeliumIdentityManager.shared.getPaddleCustomerId()
     }
     
     /// Resets Paddle entitlements and clears the user ID.


### PR DESCRIPTION
## Summary

- Adds `Helium.shared.getPaddleCustomerId() async -> String?`, exposing the current user's Paddle customer ID so host apps can generate a Paddle customer portal session on their own server.
- Deprecates `createPaddlePortalSession()`, pointing callers to the new getter.

## Behavior

`getPaddleCustomerId()` returns the cached ID immediately when available (the common case for existing subscribers — no network). If no ID is cached and Paddle is configured, it triggers a TTL-respecting entitlements refresh and returns whatever ID the server reports. Apps not using Paddle return `nil` with no network call.

Adds an internal `refreshEntitlementsIfNeeded()` on `HeliumPaymentEntitlementsSource` — a thin wrapper over the private, TTL-respecting `refreshIfNeeded()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Public API adds a getter and deprecates portal creation; metadata sync drops optional PII fields—callers relying on those fields would need another path.
> 
> **Overview**
> Adds **`Helium.shared.getPaddleCustomerId()`** so host apps can read the current Paddle customer ID (cached when available, otherwise a TTL-respecting Paddle entitlements refresh when Paddle web checkout is enabled) and create customer portal sessions on their own server. **`createPaddlePortalSession()`** is **deprecated** with guidance to use the new getter instead.
> 
> **`HeliumPaymentEntitlementsSource.refreshIfNeeded()`** is widened from `private` to module-internal so the public getter can trigger a refresh without a forced network fetch when the cache is still valid.
> 
> **`updateCustomerMetadata()`** on the shared web checkout manager no longer accepts optional `name` / `email` / `phone` / `description`; it only posts identity **metadata** derived from the standard payment API request body (affects Stripe and Paddle metadata sync on `userId` changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9a590740859f37f6e5b323fffc79e77d8187a30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an API to retrieve the current Paddle customer ID, including refreshing entitlements when needed.
  - Stripe customer metadata now synchronizes current identity information automatically.

- **Deprecations**
  - Deprecated direct Paddle customer-portal session creation. Applications should retrieve the customer ID and use it to create portal sessions through their server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->