### PR TITLE
Document and harden customPaywallTraits trait-staleness behavior

### DIFF
--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -52,6 +52,14 @@ struct DynamicWebView: View {
     private var paywallSession: PaywallSession? {
         return actionsDelegate.delegate.paywallSession
     }
+
+    /// The `customPaywallTraits` to inject into the webview, resolved at display time. This is
+    /// normally the presentation's snapshot carried on the session (the case for the presented path).
+    /// An environment override, when set, takes precedence — it lets an embedded `HeliumPaywall` that
+    /// was constructed before it displayed still inject current traits.
+    private var resolvedInjectedPaywallTraits: HeliumUserTraits? {
+        return dynamicPaywallTraits ?? paywallSession?.presentationContext.customPaywallTraits
+    }
     
     init(filePath: String, backupFilePath: String?, json: JSON, actionsDelegate: ActionsDelegateWrapper, triggerName: String?) {
         self.filePath = filePath
@@ -210,10 +218,7 @@ struct DynamicWebView: View {
             // customPaywallTraits are key/values that Helium customer can direct paywall editor to read.
             var combinedTraits = HeliumUserTraits(["trigger": triggerName ?? ""])
             combinedTraits.merge(HeliumIdentityManager.shared.getUserTraits())
-            // Prefer the live environment traits so a paywall constructed off-screen still injects the latest
-            // traits at display time; the frozen session value is the safety net (and covers the presented path,
-            // which does not set the environment).
-            if let paywallTraits = dynamicPaywallTraits ?? paywallSession?.presentationContext.customPaywallTraits {
+            if let paywallTraits = resolvedInjectedPaywallTraits {
                 combinedTraits.merge(paywallTraits)
             }
             let combinedTraitsData = try JSONEncoder().encode(combinedTraits)

--- a/Sources/Helium/HeliumCore/HeliumPaywall.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywall.swift
@@ -28,7 +28,7 @@ import SwiftUI
 ///   UIKit via `UIHostingController`, update the controller's `rootView` (or drive it from an
 ///   `ObservableObject`) so the config is current before display — otherwise the paywall may show
 ///   trait values captured when the controller was first created. See
-///   https://docs.tryhelium.com/sdk/quickstart-ios for a UIKit example.
+///   https://docs.tryhelium.com/guides/ways-to-show-paywall#embedded-view for a UIKit example.
 public struct HeliumPaywall<PaywallNotShownView: View>: View {
     
     let trigger: String

--- a/Sources/Helium/HeliumCore/HeliumPaywall.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywall.swift
@@ -22,6 +22,13 @@ import SwiftUI
 ///     Text("Paywall not shown: \(reason.rawValue)")
 /// }
 /// ```
+///
+/// - Note: `customPaywallTraits` are captured when the paywall displays and then fixed for that
+///   presentation. In SwiftUI the config stays current automatically. When hosting this view in
+///   UIKit via `UIHostingController`, update the controller's `rootView` (or drive it from an
+///   `ObservableObject`) so the config is current before display — otherwise the paywall may show
+///   trait values captured when the controller was first created. See
+///   https://docs.tryhelium.com/sdk/quickstart-ios for a UIKit example.
 public struct HeliumPaywall<PaywallNotShownView: View>: View {
     
     let trigger: String

--- a/Sources/Helium/HeliumCore/HeliumPaywall.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywall.swift
@@ -24,7 +24,8 @@ import SwiftUI
 /// ```
 ///
 /// - Note: `customPaywallTraits` are captured when the paywall displays and then fixed for that
-///   presentation. In SwiftUI the config stays current automatically. When hosting this view in
+///   presentation. In SwiftUI this happens automatically as long as the traits come from state that
+///   re-renders the view (the normal case). When hosting this view in
 ///   UIKit via `UIHostingController`, update the controller's `rootView` (or drive it from an
 ///   `ObservableObject`) so the config is current before display — otherwise the paywall may show
 ///   trait values captured when the controller was first created. See

--- a/Sources/Helium/HeliumCore/PaywallSession.swift
+++ b/Sources/Helium/HeliumCore/PaywallSession.swift
@@ -20,6 +20,11 @@ struct PaywallPresentationContext {
     let onEntitled: (() -> Void)?
     let onPaywallNotShown: ((PaywallNotShownReason) -> Void)?
     
+    /// The `customPaywallTraits` supplied for this presentation. On the presented path this is also
+    /// exactly what the webview receives. If a paywall is instead constructed before it is displayed
+    /// (e.g. an embedded `HeliumPaywall`), the injected value is resolved at display time (see
+    /// `DynamicWebView.resolvedInjectedPaywallTraits`)
+    /// and can be more current than this snapshot — so read this only for the as-supplied input.
     var customPaywallTraits: HeliumUserTraits? {
         return config.customPaywallTraits
     }


### PR DESCRIPTION
## Summary

Documentation and safety follow-ups to PR #293 (which fixed stale `customPaywallTraits` for embedded paywalls constructed off-screen). **No runtime behavior change** — all edits are docs and internal structure.

## Changes

- **`HeliumPaywall` docstring** — Adds a note on the trait snapshot contract (captured at display, fixed for the presentation) and how to keep traits current when hosting the SwiftUI view in UIKit via `UIHostingController` (re-drive `rootView` / back it with an `ObservableObject`). Links to the embedded-view guide.
- **Centralized injection resolution** — Extracts the inline `env ?? session` trait resolution in `DynamicWebView` into a single named `resolvedInjectedPaywallTraits`, so "the traits the paywall receives" has one definition.
- **Documented the session accessor** — Clarifies `PaywallPresentationContext.customPaywallTraits` is the as-supplied input; on the presented path it's exactly what's injected, and it can differ from the injected value only when a paywall is constructed before display (e.g. an embedded `HeliumPaywall`). Prevents a future reader from mistaking the resolution-time snapshot for what the webview actually received.

## Why not more

The heavier "finalize the session snapshot at display" refactor was deliberately **not** done: the session is a `let` on a shared `ObservableObject` threaded through the event/purchase system, so making it authoritative would mean mutating that shared object on the display hot path — more risk than the (currently zero-instance) footgun warrants.

## Testing

Docs/structure only; `resolvedInjectedPaywallTraits` is the exact expression that was previously inline. No behavior change from shipped 4.5.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comments and a pure extraction of existing logic; no changes to paywall injection or session mutation.
> 
> **Overview**
> Follow-up to embedded paywall trait fixes: **no runtime behavior change** — docs and a small refactor only.
> 
> **`DynamicWebView`** pulls the existing `dynamicPaywallTraits ?? session` logic into **`resolvedInjectedPaywallTraits`**, with comments describing display-time injection (environment override vs session snapshot).
> 
> **`HeliumPaywall`** docstring explains that `customPaywallTraits` are fixed per presentation at display, and how to avoid stale traits when embedding via **`UIHostingController`** (refresh `rootView` / `ObservableObject`), with a link to the embedded-view guide.
> 
> **`PaywallPresentationContext.customPaywallTraits`** is documented as the as-supplied config input, which may differ from what the webview actually receives when traits are resolved at display time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8799c9c50b03015b6a3d2de0acb303225fcc3927. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved paywall trait resolution when loading web content, ensuring the most current available traits are injected.
* **Documentation**
  * Added guidance explaining when custom paywall traits are captured and how to keep configuration and traits current before display.
  * Documented how traits are passed to the webview for presented paywalls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->