### PR TITLE
[HEL-6105] | Fallback paywall status + disclaimer in control panel

### DIFF
--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -20,6 +20,10 @@ struct DynamicWebView: View {
     @State private var fileLoadAttempt: FileLoadAttempt = .initialLoad
     
     let triggerName: String?
+    /// Describes `filePath` when it is a fallback paywall; nil when it is the live remote paywall.
+    let fallbackStatus: FallbackStatusContext?
+    /// Describes the fallback paywall `backupFilePath` serves if the primary content fails to render.
+    let backupFallbackStatus: FallbackStatusContext?
     let actionConfig: JSON
     let templateConfig: JSON
     var actionsDelegate: ActionsDelegateWrapper
@@ -52,11 +56,18 @@ struct DynamicWebView: View {
     private var paywallSession: PaywallSession? {
         return actionsDelegate.delegate.paywallSession
     }
+
+    /// The status of the fallback paywall currently on screen, or nil when the live remote paywall is.
+    private var displayedFallbackStatus: FallbackStatusContext? {
+        fileLoadAttempt == .backupLoad ? backupFallbackStatus : fallbackStatus
+    }
     
-    init(filePath: String, backupFilePath: String?, json: JSON, actionsDelegate: ActionsDelegateWrapper, triggerName: String?) {
+    init(filePath: String, backupFilePath: String?, json: JSON, actionsDelegate: ActionsDelegateWrapper, triggerName: String?, fallbackStatus: FallbackStatusContext? = nil, backupFallbackStatus: FallbackStatusContext? = nil) {
         self.filePath = filePath
         self.backupFilePath = backupFilePath
-        
+        self.fallbackStatus = fallbackStatus
+        self.backupFallbackStatus = backupFallbackStatus
+
         bundleId = HeliumAssetManager.shared.getBundleIdFromURL(filePath)
         if let backupFilePath {
             backupBundleId = HeliumAssetManager.shared.getBundleIdFromURL(backupFilePath)
@@ -144,11 +155,11 @@ struct DynamicWebView: View {
        .edgesIgnoringSafeArea(.all)
        .sheet(isPresented: $showControlPanel) {
            if #available(iOS 16.0, *) {
-               HeliumControlPanelView()
+               HeliumControlPanelView(fallbackStatus: displayedFallbackStatus)
                    .presentationDetents([.large])
                    .presentationDragIndicator(.visible)
            } else {
-               HeliumControlPanelView()
+               HeliumControlPanelView(fallbackStatus: displayedFallbackStatus)
            }
        }
        .onAppear {

--- a/Sources/Helium/HeliumCore/ControlPanel/FallbackStatusCard.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/FallbackStatusCard.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// Amber card telling a developer that the paywall behind the control panel is a fallback and
+/// which bundle entry served it.
+struct FallbackStatusCard: View {
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    let status: FallbackStatusContext
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(FallbackStatusContext.disclaimer)
+                .font(.subheadline.weight(.bold))
+                .padding(.bottom, 4)
+
+            Text(status.reasonLine)
+            Text(status.requestedTriggerLine)
+            Text(status.resolvedEntryLine)
+            Text(status.servingPaywallLine)
+            Text(status.configuredBundleLine)
+        }
+        .font(.footnote)
+        .foregroundColor(FallbackWarningPalette.text(colorScheme))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(FallbackWarningPalette.background(colorScheme))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .strokeBorder(FallbackWarningPalette.stroke(colorScheme), lineWidth: 1)
+        )
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/Sources/Helium/HeliumCore/ControlPanel/FallbackStatusContext.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/FallbackStatusContext.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Raw facts about the fallback paywall a triple tap was performed on, captured at the presentation
+/// that received the gesture and handed to the control panel.
+///
+/// A presentation is the only place that unambiguously knows which paywall was tapped — an app can
+/// host several at once — so the panel never re-derives this from global SDK state. The bundle
+/// status is the resolution that selected the rendered paywall, captured when it was made, so it
+/// still describes the tapped presentation even if the bundle reloads while the panel is open.
+struct FallbackStatusContext: Equatable {
+    let requestedTrigger: String
+    /// Why a fallback paywall rendered in place of the live remote paywall.
+    let reason: PaywallUnavailableReason
+    let bundleStatus: FallbackBundleStatus
+}
+
+extension FallbackStatusContext {
+
+    static let disclaimer = "You're viewing a fallback paywall"
+
+    /// Shows the raw reason key on purpose: this is a developer surface, and the raw key is what
+    /// appears in logs and paywall events.
+    var reasonLine: String {
+        "Reason: \(reason.rawValue)"
+    }
+
+    var requestedTriggerLine: String {
+        "Requested trigger: \(requestedTrigger)"
+    }
+
+    /// Shows the raw default-entry key on purpose: this is a developer surface, and the raw key is
+    /// what appears in logs and in the bundle JSON.
+    var resolvedEntryLine: String {
+        switch bundleStatus.resolvedEntry {
+        case .triggerOwnEntry:
+            return "Resolved from this trigger's own fallback entry"
+        case .defaultEntry:
+            return "Resolved from the default fallback entry (\(bundleStatus.resolvedTrigger))"
+        }
+    }
+
+    var servingPaywallLine: String {
+        "Serving paywall: \(bundleStatus.paywallTemplateName ?? "Unknown paywall")"
+    }
+
+    var configuredBundleLine: String {
+        bundleStatus.configuredTriggerCount == 1
+            ? "Fallback bundle configured with 1 trigger"
+            : "Fallback bundle configured with \(bundleStatus.configuredTriggerCount) triggers"
+    }
+}

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
@@ -9,6 +9,13 @@ struct HeliumControlPanelView: View {
     @State private var searchText: String = ""
     @State private var paywallLoadError: String? = nil
 
+    /// Set only when the paywall behind this panel is a fallback.
+    private let fallbackStatus: FallbackStatusContext?
+
+    init(fallbackStatus: FallbackStatusContext? = nil) {
+        self.fallbackStatus = fallbackStatus
+    }
+
     var body: some View {
         NavigationView {
             ZStack {
@@ -17,53 +24,7 @@ struct HeliumControlPanelView: View {
                 })
                 .ignoresSafeArea()
 
-                switch state {
-                case .loading:
-                    ProgressView("Loading paywalls...")
-                case .loaded(let response):
-                    ScrollView {
-                        VStack(spacing: 16) {
-                            descriptionHeader
-
-                            if response.paywalls.isEmpty {
-                                Text("No paywalls found.")
-                                    .foregroundColor(.secondary)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .padding(.top, 20)
-                            } else {
-                                let filtered = response.paywalls.filter {
-                                    searchText.isEmpty || $0.paywallName.localizedCaseInsensitiveContains(searchText)
-                                }
-                                if filtered.isEmpty {
-                                    Text("No paywalls match \"\(searchText)\".")
-                                        .foregroundColor(.secondary)
-                                        .multilineTextAlignment(.leading)
-                                        .frame(maxWidth: .infinity, alignment: .leading)
-                                        .padding(.top, 20)
-                                } else {
-                                    LazyVStack(spacing: 16) {
-                                        ForEach(filtered) { paywall in
-                                            paywallCard(paywall)
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        .padding()
-                    }
-                case .error(let message):
-                    VStack(spacing: 16) {
-                        Text(message)
-                            .foregroundColor(.secondary)
-                            .multilineTextAlignment(.center)
-                            .padding(.horizontal)
-                        Button("Retry") {
-                            state = .loading
-                            fetchTask?.cancel()
-                            fetchTask = Task { await fetchPaywalls() }
-                        }
-                    }
-                }
+                remoteListContent
             }
             .navigationTitle("Paywall Previews")
             .searchable(text: $searchText, prompt: "Search paywalls")
@@ -98,6 +59,78 @@ struct HeliumControlPanelView: View {
         .onDisappear {
             fetchTask?.cancel()
             previewTask?.cancel()
+        }
+    }
+
+    /// Shown in every list state so a developer always sees why they're looking at a fallback,
+    /// and above the paywall list so it is never filtered by search.
+    @ViewBuilder
+    private var fallbackStatusSection: some View {
+        if let fallbackStatus {
+            FallbackStatusCard(status: fallbackStatus)
+        }
+    }
+
+    @ViewBuilder
+    private var remoteListContent: some View {
+        switch state {
+        case .loading:
+            VStack(spacing: 0) {
+                fallbackStatusSection
+                    .padding([.horizontal, .top])
+                ProgressView("Loading paywalls...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        case .loaded(let response):
+            ScrollView {
+                VStack(spacing: 16) {
+                    fallbackStatusSection
+
+                    descriptionHeader
+
+                    if response.paywalls.isEmpty {
+                        Text("No paywalls found.")
+                            .foregroundColor(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.top, 20)
+                    } else {
+                        let filtered = response.paywalls.filter {
+                            searchText.isEmpty || $0.paywallName.localizedCaseInsensitiveContains(searchText)
+                        }
+                        if filtered.isEmpty {
+                            Text("No paywalls match \"\(searchText)\".")
+                                .foregroundColor(.secondary)
+                                .multilineTextAlignment(.leading)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.top, 20)
+                        } else {
+                            LazyVStack(spacing: 16) {
+                                ForEach(filtered) { paywall in
+                                    paywallCard(paywall)
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding()
+            }
+        case .error(let message):
+            VStack(spacing: 0) {
+                fallbackStatusSection
+                    .padding([.horizontal, .top])
+                VStack(spacing: 16) {
+                    Text(message)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal)
+                    Button("Retry") {
+                        state = .loading
+                        fetchTask?.cancel()
+                        fetchTask = Task { await fetchPaywalls() }
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
         }
     }
 

--- a/Sources/Helium/HeliumCore/FallbackWarningPalette.swift
+++ b/Sources/Helium/HeliumCore/FallbackWarningPalette.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+/// The amber palette every fallback-warning surface is drawn with, so that each surface telling a
+/// developer a fallback paywall is on screen reads as one signal rather than several unrelated ones.
+enum FallbackWarningPalette {
+
+    static func background(_ colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark
+            ? Color(red: 122/255, green: 79/255, blue: 1/255)
+            : Color(red: 255/255, green: 202/255, blue: 40/255)
+    }
+
+    static func text(_ colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark
+            ? Color(red: 255/255, green: 231/255, blue: 166/255)
+            : Color(red: 74/255, green: 47/255, blue: 0/255)
+    }
+
+    /// Derived from the text color so the border stays visible against both scheme backgrounds.
+    static func stroke(_ colorScheme: ColorScheme) -> Color {
+        text(colorScheme).opacity(strokeOpacity)
+    }
+
+    private static let strokeOpacity: Double = 0.2
+}

--- a/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
+++ b/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
@@ -16,9 +16,12 @@ public struct DynamicBaseTemplateView: View {
     let backupFilePath: String?
     var componentPropsJSON: JSON
     var triggerName: String?
-    let fallbackReason: PaywallUnavailableReason?
-    
-    init(paywallSession: PaywallSession, fallbackReason: PaywallUnavailableReason?, filePath: String, backupFilePath: String?, resolvedConfig: JSON?) throws {
+    /// Describes `filePath` when it is a fallback paywall; nil when it is the live remote paywall.
+    let fallbackStatus: FallbackStatusContext?
+    /// Describes the fallback paywall `backupFilePath` serves if the primary content fails to render.
+    let backupFallbackStatus: FallbackStatusContext?
+
+    init(paywallSession: PaywallSession, fallbackStatus: FallbackStatusContext?, filePath: String, backupFilePath: String?, backupFallbackStatus: FallbackStatusContext?, resolvedConfig: JSON?) throws {
         let trigger = paywallSession.trigger
         guard let paywallInfo = paywallSession.paywallInfoWithBackups else {
             throw TemplateError.missingRequiredFields("Missing paywallInfo")
@@ -40,7 +43,8 @@ public struct DynamicBaseTemplateView: View {
         
         self.componentPropsJSON = templateValues["baseStack"]["componentProps"]
         self.triggerName = trigger;
-        self.fallbackReason = fallbackReason
+        self.fallbackStatus = fallbackStatus
+        self.backupFallbackStatus = backupFallbackStatus
     }
     
     public var body: some View {
@@ -50,7 +54,9 @@ public struct DynamicBaseTemplateView: View {
             backupFilePath: backupFilePath,
             json: componentPropsJSON,
             actionsDelegate: actionsDelegateWrapper,
-            triggerName: triggerName
+            triggerName: triggerName,
+            fallbackStatus: fallbackStatus,
+            backupFallbackStatus: backupFallbackStatus
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .edgesIgnoringSafeArea(.all)
@@ -64,7 +70,7 @@ public struct DynamicBaseTemplateView: View {
                 }
                 if !presentationState.isOpen {
                     presentationState.isOpen = true
-                    actionsDelegateWrapper.logImpression(viewType: presentationState.viewType, fallbackReason: fallbackReason, loadTimeTakenMS: loadTimeTakenMS)
+                    actionsDelegateWrapper.logImpression(viewType: presentationState.viewType, fallbackReason: fallbackStatus?.reason, loadTimeTakenMS: loadTimeTakenMS)
                 }
             }
         }

--- a/Sources/Helium/HeliumCore/HeliumFallbackViewManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumFallbackViewManager.swift
@@ -7,21 +7,67 @@
 import SwiftUI
 import Foundation
 
+/// Which entry of the fallback bundle a resolution picked: the requested trigger's own entry, or
+/// the bundle's default entry that stands in for triggers without a usable one.
+enum ResolvedFallbackEntry {
+    case triggerOwnEntry
+    case defaultEntry
+}
+
+/// What the loaded fallback bundle served for one requested trigger.
+struct FallbackBundleStatus: Equatable {
+    let resolvedTrigger: String
+    let resolvedEntry: ResolvedFallbackEntry
+    let paywallTemplateName: String?
+    /// Number of triggers with their own bundle entry; the default entry is not one of them.
+    let configuredTriggerCount: Int
+}
+
+/// One resolution of a trigger against the loaded fallback bundle, captured in a single read of
+/// the bundle state so the paywall that renders and the diagnostics describing it cannot disagree.
+struct ResolvedFallback {
+    let paywallInfo: HeliumPaywallInfo?
+    let resolvedConfigJSON: JSON?
+    let status: FallbackBundleStatus
+}
+
 public class HeliumFallbackViewManager {
     // **MARK: - Singleton**
     public static let shared = HeliumFallbackViewManager()
     static func reset() {
-        shared.loadedConfig = nil
-        shared.loadedConfigJSON = nil
+        shared.setLoadedState(config: nil, json: nil)
     }
-    
+
     // **MARK: - Properties**
     private let defaultFallbacksName = "helium-fallbacks"
-    private let defaultFallbackTrigger = "hlm_ios_default_flbk"
-    
+
+    /// The bundle entry that stands in for any trigger without one of its own.
+    static let defaultFallbackTrigger = "hlm_ios_default_flbk"
+
+    /// Guards `loadedConfig`/`loadedConfigJSON`, which are written from `setUpFallbackBundle`'s
+    /// background task while presentation code paths read them from other threads.
+    private let stateLock = NSLock()
     private var loadedConfig: HeliumFetchedConfig?
     private var loadedConfigJSON: JSON?
-    
+
+    private var loadedState: (config: HeliumFetchedConfig?, json: JSON?) {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return (loadedConfig, loadedConfigJSON)
+    }
+
+    private func setLoadedState(config: HeliumFetchedConfig?, json: JSON?) {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        loadedConfig = config
+        loadedConfigJSON = json
+    }
+
+    /// Inject a fallback bundle for testing purposes only. Accessible via @testable import.
+    func injectConfigForTesting(_ config: HeliumFetchedConfig?, json: JSON? = nil) {
+        setLoadedState(config: config, json: json)
+    }
+
     func setUpFallbackBundle() {
         var fallbackBundleURL: URL? = Bundle.main.url(forResource: defaultFallbacksName, withExtension: "json")
         if let customURL = Helium.config.customFallbacksURL {
@@ -44,12 +90,9 @@ public class HeliumFallbackViewManager {
                 let data = try Data(contentsOf: fallbackBundleURL)
                 let decodedConfig = try JSONDecoder().decode(HeliumFetchedConfig.self, from: data)
 
-                loadedConfig = decodedConfig
-                if let json = try? JSON(data: data) {
-                    loadedConfigJSON = json
-                }
+                setLoadedState(config: decodedConfig, json: try? JSON(data: data))
 
-                if let bundles = loadedConfig?.bundles, !bundles.isEmpty {
+                if let bundles = decodedConfig.bundles, !bundles.isEmpty {
                     HeliumAssetManager.shared.writeBundles(bundles: bundles)
                     let generatedAtDisplay = formatDateForDisplay(decodedConfig.generatedAt)
                     HeliumLogger.log(.info, category: .fallback, "👷 Successfully loaded paywalls from fallbacks file! 🎉", metadata: ["name": fallbackBundleURL.lastPathComponent, "generated at": generatedAtDisplay])
@@ -65,46 +108,63 @@ public class HeliumFallbackViewManager {
                     HeliumLogger.log(.error, category: .fallback, "👷 No bundles found in fallbacks file ‼️⚠️‼️")
                 }
                 
-                let triggersMissingProducts = loadedConfig?.getTriggersWithMissingProducts() ?? []
+                let triggersMissingProducts = decodedConfig.getTriggersWithMissingProducts()
                 if !triggersMissingProducts.isEmpty {
                     HeliumLogger.log(.error, category: .fallback, "👷 Some triggers in your fallbacks file have missing iOS products ‼️⚠️‼️", metadata: ["triggers": triggersMissingProducts.joined(separator: ", ")])
                 }
-                
-                if let config = loadedConfig {
-                    HeliumAnalyticsManager.shared.setUpAnalytics(
-                        writeKey: config.segmentBrowserWriteKey,
-                        endpoint: config.segmentAnalyticsEndpoint
-                    )
-                }
-                
-                await HeliumFetchedConfigManager.shared.buildLocalizedPriceMap(config: loadedConfig)
+
+                HeliumAnalyticsManager.shared.setUpAnalytics(
+                    writeKey: decodedConfig.segmentBrowserWriteKey,
+                    endpoint: decodedConfig.segmentAnalyticsEndpoint
+                )
+
+                await HeliumFetchedConfigManager.shared.buildLocalizedPriceMap(config: decodedConfig)
             } catch {
                 HeliumLogger.log(.error, category: .fallback, "👷 Failed to load fallbacks file ‼️⚠️‼️", metadata: ["error": error.localizedDescription])
             }
         }
     }
     
-    /// Returns the trigger to use - uses default if trigger doesn't exist or has invalid resolvedConfig
-    private func resolvedTrigger(for trigger: String) -> String {
-        let fallbackPaywallInfo = loadedConfig?.triggerToPaywalls[trigger]
-        let resolvedConfigJson = loadedConfigJSON?["triggerToPaywalls"][trigger]["resolvedConfig"]
+    /// Picks the bundle entry serving `trigger`: the trigger's own entry when it is usable (has
+    /// products and a resolved config), otherwise the bundle's default entry.
+    private static func resolveEntry(for trigger: String, config: HeliumFetchedConfig, json: JSON?) -> (key: String, entry: ResolvedFallbackEntry) {
+        let fallbackPaywallInfo = config.triggerToPaywalls[trigger]
+        let resolvedConfigJson = json?["triggerToPaywalls"][trigger]["resolvedConfig"]
         let hasResolvedConfig = resolvedConfigJson?.exists() == true && resolvedConfigJson?.type != .null
         if fallbackPaywallInfo?.hasProducts == true && hasResolvedConfig {
-            return trigger
+            return (trigger, .triggerOwnEntry)
         }
-        return defaultFallbackTrigger
+        return (Self.defaultFallbackTrigger, .defaultEntry)
     }
-    
+
+    /// Resolves `trigger` against the loaded bundle, or nil when no bundle is loaded.
+    func resolveFallback(for trigger: String) -> ResolvedFallback? {
+        let state = loadedState
+        guard let config = state.config else { return nil }
+
+        let resolved = Self.resolveEntry(for: trigger, config: config, json: state.json)
+        return ResolvedFallback(
+            paywallInfo: config.triggerToPaywalls[resolved.key],
+            resolvedConfigJSON: state.json?["triggerToPaywalls"][resolved.key]["resolvedConfig"],
+            status: FallbackBundleStatus(
+                resolvedTrigger: resolved.key,
+                resolvedEntry: resolved.entry,
+                paywallTemplateName: config.triggerToPaywalls[resolved.key]?.paywallTemplateName,
+                configuredTriggerCount: config.triggerToPaywalls.keys.filter { $0 != Self.defaultFallbackTrigger }.count
+            )
+        )
+    }
+
     func getFallbackInfo(trigger: String) -> HeliumPaywallInfo? {
-        return loadedConfig?.triggerToPaywalls[resolvedTrigger(for: trigger)]
+        return resolveFallback(for: trigger)?.paywallInfo
     }
-    
+
     func getResolvedConfigJSONForTrigger(_ trigger: String) -> JSON? {
-        return loadedConfigJSON?["triggerToPaywalls"][resolvedTrigger(for: trigger)]["resolvedConfig"]
+        return resolveFallback(for: trigger)?.resolvedConfigJSON
     }
-    
+
     public func getConfig() -> HeliumFetchedConfig? {
-        return loadedConfig
+        return loadedState.config
     }
     
     public func getBackgroundConfigForTrigger(_ trigger: String) -> BackgroundConfig? {

--- a/Sources/Helium/HeliumCore/Models.swift
+++ b/Sources/Helium/HeliumCore/Models.swift
@@ -805,7 +805,7 @@ public enum PaywallOpenViewType : String {
     case embedded = "embedded"
 }
 
-public enum PaywallUnavailableReason: String, Codable {
+public enum PaywallUnavailableReason: String, Codable, CaseIterable {
     case notInitialized
     case triggerHasNoPaywall
     case forceShowFallback

--- a/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
+++ b/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
@@ -570,15 +570,28 @@ extension HeliumPaywallPresenter {
                     HeliumLogger.log(.warn, category: .ui, "No local bundle path for trigger", metadata: ["trigger": trigger])
                     return fallbackViewFor(trigger: trigger, paywallInfo: templatePaywallInfo, fallbackReason: .couldNotFindBundleUrl, presentationContext: presentationContext)
                 }
-                let backupFilePath = HeliumFallbackViewManager.shared.getFallbackInfo(trigger: trigger)?.localBundlePath
-                
+                // The backup only ever renders after the primary content fails in the webview,
+                // so webviewRenderFail is the only reason it can carry.
+                var backupFilePath: String?
+                var backupFallbackStatus: FallbackStatusContext?
+                if let resolvedFallback = HeliumFallbackViewManager.shared.resolveFallback(for: trigger),
+                   let backupPath = resolvedFallback.paywallInfo?.localBundlePath {
+                    backupFilePath = backupPath
+                    backupFallbackStatus = FallbackStatusContext(
+                        requestedTrigger: trigger,
+                        reason: .webviewRenderFail,
+                        bundleStatus: resolvedFallback.status
+                    )
+                }
+
                 let paywallSession = PaywallSession(trigger: trigger, paywallInfo: templatePaywallInfo, fallbackType: .notFallback, presentationContext: presentationContext)
-                
+
                 let paywallView = try AnyView(DynamicBaseTemplateView(
                     paywallSession: paywallSession,
-                    fallbackReason: nil,
+                    fallbackStatus: nil,
                     filePath: filePath,
                     backupFilePath: backupFilePath,
+                    backupFallbackStatus: backupFallbackStatus,
                     resolvedConfig: HeliumFetchedConfigManager.shared.getResolvedConfigJSONForTrigger(trigger)
                 ))
                 HeliumLogger.log(.debug, category: .ui, "Created paywall view for trigger", metadata: ["trigger": trigger])
@@ -619,17 +632,23 @@ extension HeliumPaywallPresenter {
         }
         
         // Check existing fallback mechanisms
-        if let fallbackPaywallInfo = HeliumFallbackViewManager.shared.getFallbackInfo(trigger: trigger),
+        if let resolvedFallback = HeliumFallbackViewManager.shared.resolveFallback(for: trigger),
+           let fallbackPaywallInfo = resolvedFallback.paywallInfo,
            let filePath = fallbackPaywallInfo.localBundlePath {
             do {
                 let fallbackBundlePaywallSession = PaywallSession(trigger: trigger, paywallInfo: fallbackPaywallInfo, fallbackType: .fallbackBundle, presentationContext: presentationContext)
                 let fallbackBundleView = try AnyView(
                     DynamicBaseTemplateView(
                         paywallSession: fallbackBundlePaywallSession,
-                        fallbackReason: fallbackReason,
+                        fallbackStatus: FallbackStatusContext(
+                            requestedTrigger: trigger,
+                            reason: fallbackReason,
+                            bundleStatus: resolvedFallback.status
+                        ),
                         filePath: filePath,
                         backupFilePath: nil,
-                        resolvedConfig: HeliumFallbackViewManager.shared.getResolvedConfigJSONForTrigger(trigger)
+                        backupFallbackStatus: nil,
+                        resolvedConfig: resolvedFallback.resolvedConfigJSON
                     )
                 )
                 return PaywallViewResult(viewAndSession: PaywallViewAndSession(view: fallbackBundleView, paywallSession: fallbackBundlePaywallSession), fallbackReason: fallbackReason)

--- a/Tests/helium-swiftTests/FallbackBundleStatusTests.swift
+++ b/Tests/helium-swiftTests/FallbackBundleStatusTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+@testable import Helium
+
+final class FallbackBundleStatusTests: XCTestCase {
+
+    private let defaultTrigger = HeliumFallbackViewManager.defaultFallbackTrigger
+
+    override func setUp() {
+        super.setUp()
+        HeliumAnalyticsManager.shared.disableAnalyticsForTesting()
+        Helium.resetHelium()
+    }
+
+    override func tearDown() {
+        Helium.resetHelium()
+        super.tearDown()
+    }
+
+    func testResolutionIsNilWhenNoBundleIsLoaded() {
+        XCTAssertNil(HeliumFallbackViewManager.shared.resolveFallback(for: "onboarding_end"))
+    }
+
+    func testTriggerWithItsOwnUsableEntryResolvesToThatEntry() {
+        loadFallbackBundle(triggers: ["onboarding_end", defaultTrigger])
+
+        let resolved = HeliumFallbackViewManager.shared.resolveFallback(for: "onboarding_end")
+
+        XCTAssertEqual(resolved?.status.resolvedTrigger, "onboarding_end")
+        XCTAssertEqual(resolved?.status.resolvedEntry, .triggerOwnEntry)
+    }
+
+    func testTriggerWithoutItsOwnEntryResolvesToTheDefaultEntry() {
+        loadFallbackBundle(triggers: [defaultTrigger])
+
+        let resolved = HeliumFallbackViewManager.shared.resolveFallback(for: "onboarding_end")
+
+        XCTAssertEqual(resolved?.status.resolvedTrigger, defaultTrigger)
+        XCTAssertEqual(resolved?.status.resolvedEntry, .defaultEntry)
+    }
+
+    func testTriggerWhoseEntryHasNoProductsResolvesToTheDefaultEntry() {
+        loadFallbackBundle(
+            triggers: ["onboarding_end", defaultTrigger],
+            triggersWithoutProducts: ["onboarding_end"]
+        )
+
+        let resolved = HeliumFallbackViewManager.shared.resolveFallback(for: "onboarding_end")
+
+        XCTAssertEqual(resolved?.status.resolvedTrigger, defaultTrigger)
+        XCTAssertEqual(resolved?.status.resolvedEntry, .defaultEntry)
+    }
+
+    func testTriggerWhoseEntryLacksAResolvedConfigResolvesToTheDefaultEntry() {
+        loadFallbackBundle(
+            triggers: ["onboarding_end", defaultTrigger],
+            triggersWithoutResolvedConfig: ["onboarding_end"]
+        )
+
+        let resolved = HeliumFallbackViewManager.shared.resolveFallback(for: "onboarding_end")
+
+        XCTAssertEqual(resolved?.status.resolvedTrigger, defaultTrigger)
+        XCTAssertEqual(resolved?.status.resolvedEntry, .defaultEntry)
+    }
+
+    func testTriggerNamedLikeTheDefaultKeyWithAUsableEntryResolvesAsItsOwnEntry() {
+        loadFallbackBundle(triggers: [defaultTrigger])
+
+        let resolved = HeliumFallbackViewManager.shared.resolveFallback(for: defaultTrigger)
+
+        XCTAssertEqual(resolved?.status.resolvedTrigger, defaultTrigger)
+        XCTAssertEqual(resolved?.status.resolvedEntry, .triggerOwnEntry)
+    }
+
+    func testTemplateNameIsPassedThroughFromTheResolvedEntry() {
+        loadFallbackBundle(triggers: ["onboarding_end"], paywallNames: ["onboarding_end": "Spring Sale v3"])
+
+        let resolved = HeliumFallbackViewManager.shared.resolveFallback(for: "onboarding_end")
+
+        XCTAssertEqual(resolved?.status.paywallTemplateName, "Spring Sale v3")
+    }
+
+    func testTemplateNameAndPaywallInfoAreNilWhenTheResolvedEntryIsAbsentFromTheBundle() {
+        // A bundle with no default entry: an unmapped trigger resolves to a key that is not there.
+        loadFallbackBundle(triggers: ["some_other_trigger"])
+
+        let resolved = HeliumFallbackViewManager.shared.resolveFallback(for: "onboarding_end")
+
+        XCTAssertEqual(resolved?.status.resolvedTrigger, defaultTrigger)
+        XCTAssertNil(resolved?.status.paywallTemplateName)
+        XCTAssertNil(resolved?.paywallInfo)
+    }
+
+    func testPaywallInfoAndStatusDescribeTheSameEntry() {
+        loadFallbackBundle(triggers: ["onboarding_end"], paywallNames: ["onboarding_end": "Spring Sale v3"])
+
+        let resolved = HeliumFallbackViewManager.shared.resolveFallback(for: "onboarding_end")
+
+        XCTAssertEqual(resolved?.paywallInfo?.paywallTemplateName, resolved?.status.paywallTemplateName)
+    }
+
+    func testConfiguredTriggerCountExcludesTheDefaultEntry() {
+        loadFallbackBundle(triggers: ["onboarding_end", "paywall_open", defaultTrigger])
+
+        let resolved = HeliumFallbackViewManager.shared.resolveFallback(for: "onboarding_end")
+
+        XCTAssertEqual(resolved?.status.configuredTriggerCount, 2)
+    }
+}

--- a/Tests/helium-swiftTests/FallbackStatusContextTests.swift
+++ b/Tests/helium-swiftTests/FallbackStatusContextTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import Helium
+
+final class FallbackStatusContextTests: XCTestCase {
+
+    private let defaultTrigger = HeliumFallbackViewManager.defaultFallbackTrigger
+
+    func testDisclaimerCopy() {
+        XCTAssertEqual(FallbackStatusContext.disclaimer, "You're viewing a fallback paywall")
+    }
+
+    func testReasonCopyShowsTheRawKeyForEveryReason() {
+        for reason in PaywallUnavailableReason.allCases {
+            XCTAssertEqual(context(reason: reason).reasonLine, "Reason: \(reason.rawValue)")
+        }
+    }
+
+    func testRequestedTriggerCopy() {
+        XCTAssertEqual(
+            context(requestedTrigger: "onboarding_end").requestedTriggerLine,
+            "Requested trigger: onboarding_end"
+        )
+    }
+
+    func testOwnEntryCopy() {
+        XCTAssertEqual(
+            context(resolvedEntry: .triggerOwnEntry).resolvedEntryLine,
+            "Resolved from this trigger's own fallback entry"
+        )
+    }
+
+    func testDefaultEntryCopyShowsTheRawDefaultKey() {
+        XCTAssertEqual(
+            context(resolvedTrigger: defaultTrigger, resolvedEntry: .defaultEntry).resolvedEntryLine,
+            "Resolved from the default fallback entry (hlm_ios_default_flbk)"
+        )
+    }
+
+    func testOwnEntryCopyForATriggerNamedLikeTheDefaultKey() {
+        // The entry classification comes from the resolution, not the trigger's name, so a trigger
+        // that happens to share the default key still reads as its own entry.
+        XCTAssertEqual(
+            context(resolvedTrigger: defaultTrigger, resolvedEntry: .triggerOwnEntry).resolvedEntryLine,
+            "Resolved from this trigger's own fallback entry"
+        )
+    }
+
+    func testServingPaywallCopy() {
+        XCTAssertEqual(
+            context(paywallName: "Spring Sale v3").servingPaywallLine,
+            "Serving paywall: Spring Sale v3"
+        )
+    }
+
+    func testServingPaywallCopyWhenTheNameIsUnresolvable() {
+        XCTAssertEqual(context(paywallName: nil).servingPaywallLine, "Serving paywall: Unknown paywall")
+    }
+
+    func testConfiguredBundleCopyIsSingularForOneTrigger() {
+        XCTAssertEqual(
+            context(configuredTriggerCount: 1).configuredBundleLine,
+            "Fallback bundle configured with 1 trigger"
+        )
+    }
+
+    func testConfiguredBundleCopyIsPluralForOtherCounts() {
+        XCTAssertEqual(
+            context(configuredTriggerCount: 3).configuredBundleLine,
+            "Fallback bundle configured with 3 triggers"
+        )
+        XCTAssertEqual(
+            context(configuredTriggerCount: 0).configuredBundleLine,
+            "Fallback bundle configured with 0 triggers"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func context(
+        requestedTrigger: String = "onboarding_end",
+        reason: PaywallUnavailableReason = .paywallsDownloadFail,
+        resolvedTrigger: String = "onboarding_end",
+        resolvedEntry: ResolvedFallbackEntry = .triggerOwnEntry,
+        paywallName: String? = "Spring Sale v3",
+        configuredTriggerCount: Int = 2
+    ) -> FallbackStatusContext {
+        FallbackStatusContext(
+            requestedTrigger: requestedTrigger,
+            reason: reason,
+            bundleStatus: FallbackBundleStatus(
+                resolvedTrigger: resolvedTrigger,
+                resolvedEntry: resolvedEntry,
+                paywallTemplateName: paywallName,
+                configuredTriggerCount: configuredTriggerCount
+            )
+        )
+    }
+}

--- a/Tests/helium-swiftTests/Helpers/TestHelpers.swift
+++ b/Tests/helium-swiftTests/Helpers/TestHelpers.swift
@@ -212,6 +212,35 @@ func injectConfig(_ config: HeliumFetchedConfig) {
     HeliumFetchedConfigManager.shared.injectConfigForTesting(config)
 }
 
+/// Loads a fallback bundle into `HeliumFallbackViewManager`. Resolution only treats an entry as
+/// usable when it has products and the bundle's raw JSON carries a `resolvedConfig` for it, so
+/// both the decoded config and its JSON have to be injected.
+func loadFallbackBundle(
+    triggers: [String],
+    paywallNames: [String: String] = [:],
+    triggersWithoutProducts: Set<String> = [],
+    triggersWithoutResolvedConfig: Set<String> = []
+) {
+    var triggerToPaywalls: [String: HeliumPaywallInfo] = [:]
+    var rawTriggers: [String: Any] = [:]
+
+    for trigger in triggers {
+        triggerToPaywalls[trigger] = makeTestPaywallInfo(
+            trigger: trigger,
+            paywallName: paywallNames[trigger] ?? "paywall_\(trigger)",
+            products: triggersWithoutProducts.contains(trigger) ? [] : ["com.test.product"]
+        )
+        rawTriggers[trigger] = triggersWithoutResolvedConfig.contains(trigger)
+            ? [:]
+            : ["resolvedConfig": ["baseStack": ["componentProps": [:]]]]
+    }
+
+    HeliumFallbackViewManager.shared.injectConfigForTesting(
+        makeTestConfig(triggers: triggerToPaywalls),
+        json: JSON(["triggerToPaywalls": rawTriggers])
+    )
+}
+
 func makeTestSession(
     trigger: String = "test_trigger",
     eventHandlers: PaywallEventHandlers? = nil,


### PR DESCRIPTION
- Introduce the Fallback status on the Control Panel 
- Fixed race condition on the shared `HeliumFallbackViewManager's` state

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fallback resolution and thread-safe reads on the paywall presentation path, though behavior is mostly additive (dev UI) with solid test coverage.
> 
> **Overview**
> Adds **developer-facing fallback diagnostics** when opening the paywall control panel (triple-tap) on a fallback paywall. Context is captured at presentation time and passed through `DynamicWebView` → `HeliumControlPanelView`, including separate status for **backup** webview loads after primary render failure.
> 
> Introduces `FallbackStatusContext` (requested trigger, `PaywallUnavailableReason`, bundle resolution details) and an amber `FallbackStatusCard` pinned **above** the preview list so it is visible in loading/error states and is not affected by search.
> 
> Refactors `HeliumFallbackViewManager` with `resolveFallback(for:)` returning paywall info, resolved config, and `FallbackBundleStatus` in one locked read, plus **`NSLock`** around loaded bundle state to fix a race between background bundle load and presentation reads. `HeliumPaywallPresenter` wires this into live paywalls (backup path with `webviewRenderFail`) and full fallback presentations.
> 
> Adds unit tests for bundle resolution and disclaimer copy; `PaywallUnavailableReason` is now `CaseIterable` for test coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c19ce14546f20ee3be8cd793e93b3bb0148dc4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Control panels now show detailed fallback paywall status, including the reason, requested trigger, resolved entry, and serving paywall.
  * Added clear amber warning styling for fallback messages, with support for light and dark modes.
  * Fallback paywalls now provide more accurate status information when primary or backup content is used.

* **Bug Fixes**
  * Improved fallback selection when trigger-specific content is unavailable or incomplete.
  * Enhanced thread safety and consistency while loading fallback configuration.

* **Tests**
  * Added coverage for fallback resolution and user-facing status messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->