### PR TITLE
[HEL-6111] | Diagnostic modal refinement

### DIFF
--- a/Sources/Helium/HeliumCore/AppReceiptsHelper.swift
+++ b/Sources/Helium/HeliumCore/AppReceiptsHelper.swift
@@ -17,7 +17,9 @@ class AppReceiptsHelper {
     
     static let shared = AppReceiptsHelper()
     
-    private var appTransactionEnvironment: Environment? = nil
+    /// Written by the AppTransaction task in `setUp()` and read from arbitrary threads via
+    /// `environment`, so access must be atomic.
+    @HeliumAtomic private var appTransactionEnvironment: Environment? = nil
     private var setupCompleted: Bool = false
     
     private var appFirstInstallTime: Date? = nil

--- a/Sources/Helium/HeliumCore/AppReceiptsHelper.swift
+++ b/Sources/Helium/HeliumCore/AppReceiptsHelper.swift
@@ -33,7 +33,7 @@ class AppReceiptsHelper {
             // AppTransaction.shared can trigger Apple account sign-in dialog in debug/sandbox
             // if not signed into a sandbox account, which is annoying for sdk integrators. So avoid
             // that call if can determine sandbox from receipt.
-            if getEnvironment() == Environment.sandbox.rawValue {
+            if environment == .sandbox {
                 return
             }
         }
@@ -80,19 +80,23 @@ class AppReceiptsHelper {
 #endif
     }
     
-    func getEnvironment() -> String {
+    var environment: Environment {
 #if DEBUG || targetEnvironment(simulator)
-        return Environment.debug.rawValue
+        return .debug
 #else
         if let appTransactionEnvironment {
-            return appTransactionEnvironment.rawValue
+            return appTransactionEnvironment
         }
 
         // Note, if supporting mac catalyst, watch os, etc in the future consider looking at RevenueCat sdk for how they handle these special cases.
 
         let isTestFlight = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
-        return isTestFlight ? Environment.sandbox.rawValue : Environment.production.rawValue
+        return isTestFlight ? .sandbox : .production
 #endif
+    }
+
+    func getEnvironment() -> String {
+        environment.rawValue
     }
     
     func getFirstInstallTime() -> Date? {

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelService.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelService.swift
@@ -11,9 +11,8 @@ class HeliumControlPanelService {
         guard Helium.config.paywallPreviewsAutoEnabledInDevBuilds else {
             return false
         }
-        let env = AppReceiptsHelper.shared.getEnvironment()
-        return env == AppReceiptsHelper.Environment.debug.rawValue
-            || env == AppReceiptsHelper.Environment.sandbox.rawValue
+        let environment = AppReceiptsHelper.shared.environment
+        return environment == .debug || environment == .sandbox
     }
 
     private var heliumBaseURL: String { HeliumAPIEndpoint.baseURL }

--- a/Sources/Helium/HeliumCore/Diagnostic/HeliumDiagnosticGate.swift
+++ b/Sources/Helium/HeliumCore/Diagnostic/HeliumDiagnosticGate.swift
@@ -1,0 +1,71 @@
+//
+//  HeliumDiagnosticGate.swift
+//  Helium
+//
+
+import Foundation
+
+/// Decides whether the paywall diagnostic modal may be presented for a given reason.
+///
+/// Pure by design — every input is passed in, so the full visibility matrix is unit-testable
+/// without a live SDK. The caller owns the singleton presentation guard, which has to be a claim
+/// rather than a predicate.
+enum HeliumDiagnosticGate {
+
+    /// UserDefaults key for the per-device "do not show again" preference the gate evaluates.
+    /// The modal's toggle writes it; `shouldShow` callers read it.
+    static let doNotShowAgainKey = "heliumDiagnosticDoNotShowAgain"
+
+    /// Reasons that are logged but never surfaced as a modal.
+    ///
+    /// Only `.alreadyPresented` qualifies: a Helium paywall is literally on screen, so a modal would
+    /// cover the very thing the developer asked to see, and there is nothing to act on. Every other
+    /// reason means the developer is owed an explanation — including a failed second try, which fires
+    /// while a paywall is on screen but leaves a dead button behind it.
+    static let suppressedReasons: Set<PaywallUnavailableReason> = [.alreadyPresented]
+
+    /// - Parameters:
+    ///   - unavailableReason: the reason a paywall was unavailable, or `nil` for a skip (a skip is
+    ///     never suppressed).
+    ///   - fallbackShown: whether a fallback rendered. A rendered fallback is the badge's territory,
+    ///     not the modal's — the two are mutually exclusive, and that is what makes the modal's "no
+    ///     fallback was available, so this user saw nothing" copy truthful.
+    ///   - isPreviewTrigger: dashboard paywall previews bypass the flag, environment and
+    ///     do-not-show gates, but not suppression.
+    ///   - environment: debug always shows; sandbox (TestFlight, and Xcode-installed release
+    ///     builds) requires the opt-in; an App Store build structurally cannot show the modal.
+    ///   - displayEnabled: the public master flag.
+    ///   - enabledInTestFlight: the public TestFlight opt-in.
+    ///   - serverFlagEnabled: the server-side kill switch.
+    ///   - doNotShowAgain: the per-device developer preference. Evaluated last and only if every
+    ///     other gate opens, so builds that can never show the modal do not pay to read it.
+    static func shouldShow(
+        unavailableReason: PaywallUnavailableReason?,
+        fallbackShown: Bool,
+        isPreviewTrigger: Bool,
+        environment: AppReceiptsHelper.Environment,
+        displayEnabled: Bool,
+        enabledInTestFlight: Bool,
+        serverFlagEnabled: Bool,
+        doNotShowAgain: () -> Bool
+    ) -> Bool {
+        if fallbackShown { return false }
+        if let unavailableReason, suppressedReasons.contains(unavailableReason) { return false }
+        if isPreviewTrigger { return true }
+        guard displayEnabled else { return false }
+        guard isVisible(in: environment, enabledInTestFlight: enabledInTestFlight) else { return false }
+        guard serverFlagEnabled else { return false }
+        return !doNotShowAgain()
+    }
+
+    private static func isVisible(
+        in environment: AppReceiptsHelper.Environment,
+        enabledInTestFlight: Bool
+    ) -> Bool {
+        switch environment {
+        case .debug: return true
+        case .sandbox: return enabledInTestFlight
+        case .production: return false
+        }
+    }
+}

--- a/Sources/Helium/HeliumCore/Diagnostic/HeliumDiagnosticGate.swift
+++ b/Sources/Helium/HeliumCore/Diagnostic/HeliumDiagnosticGate.swift
@@ -30,10 +30,14 @@ enum HeliumDiagnosticGate {
     ///   - fallbackShown: whether a fallback rendered. A rendered fallback is the badge's territory,
     ///     not the modal's — the two are mutually exclusive, and that is what makes the modal's "no
     ///     fallback was available, so this user saw nothing" copy truthful.
-    ///   - isPreviewTrigger: dashboard paywall previews bypass the flag, environment and
+    ///   - isPreviewTrigger: dashboard paywall previews bypass the flag, build/environment and
     ///     do-not-show gates, but not suppression.
-    ///   - environment: debug always shows; sandbox (TestFlight, and Xcode-installed release
-    ///     builds) requires the opt-in; an App Store build structurally cannot show the modal.
+    ///   - isDebugBuild: whether the SDK was compiled with DEBUG. A debug build always shows;
+    ///     any other build is gated by the receipt environment.
+    ///   - environment: for non-DEBUG builds: sandbox (TestFlight, and Xcode-installed release
+    ///     builds) requires the opt-in; an App Store build structurally cannot show the modal;
+    ///     `.debug` — here a release-configuration simulator run, since a DEBUG build never
+    ///     reaches this gate — requires the opt-in as well.
     ///   - displayEnabled: the public master flag.
     ///   - enabledInTestFlight: the public TestFlight opt-in.
     ///   - serverFlagEnabled: the server-side kill switch.
@@ -43,6 +47,7 @@ enum HeliumDiagnosticGate {
         unavailableReason: PaywallUnavailableReason?,
         fallbackShown: Bool,
         isPreviewTrigger: Bool,
+        isDebugBuild: Bool,
         environment: AppReceiptsHelper.Environment,
         displayEnabled: Bool,
         enabledInTestFlight: Bool,
@@ -53,18 +58,20 @@ enum HeliumDiagnosticGate {
         if let unavailableReason, suppressedReasons.contains(unavailableReason) { return false }
         if isPreviewTrigger { return true }
         guard displayEnabled else { return false }
-        guard isVisible(in: environment, enabledInTestFlight: enabledInTestFlight) else { return false }
+        guard isVisible(isDebugBuild: isDebugBuild, environment: environment, enabledInTestFlight: enabledInTestFlight) else { return false }
         guard serverFlagEnabled else { return false }
         return !doNotShowAgain()
     }
 
     private static func isVisible(
-        in environment: AppReceiptsHelper.Environment,
+        isDebugBuild: Bool,
+        environment: AppReceiptsHelper.Environment,
         enabledInTestFlight: Bool
     ) -> Bool {
+        if isDebugBuild { return true }
         switch environment {
-        case .debug: return true
-        case .sandbox: return enabledInTestFlight
+        // In a non-DEBUG build, .debug means a release-configuration simulator run.
+        case .debug, .sandbox: return enabledInTestFlight
         case .production: return false
         }
     }

--- a/Sources/Helium/HeliumCore/Diagnostic/Mapper/DiagnosticCategoryStyleMapper.swift
+++ b/Sources/Helium/HeliumCore/Diagnostic/Mapper/DiagnosticCategoryStyleMapper.swift
@@ -1,0 +1,68 @@
+//
+//  DiagnosticCategoryStyleMapper.swift
+//  Helium
+//
+
+import Foundation
+
+/// Maps a diagnostic category onto the banner resources that render it.
+///
+/// Icons are per category, but tints are per severity: `.setup` and `.network` deliberately share
+/// the amber pair, which is also the fallback debug badge's palette, so a Helium developer warning
+/// reads as one signal wherever it surfaces.
+struct DiagnosticCategoryStyleMapper {
+
+    private enum Palette {
+        static let infoBackgroundLight = RGB(r: 220, g: 235, b: 255)
+        static let infoTextLight = RGB(r: 10, g: 61, b: 122)
+        static let infoBackgroundDark = RGB(r: 18, g: 58, b: 102)
+        static let infoTextDark = RGB(r: 207, g: 227, b: 255)
+
+        static let warningBackgroundLight = RGB(r: 255, g: 202, b: 40)
+        static let warningTextLight = RGB(r: 74, g: 47, b: 0)
+        static let warningBackgroundDark = RGB(r: 122, g: 79, b: 1)
+        static let warningTextDark = RGB(r: 255, g: 231, b: 166)
+
+        static let errorBackgroundLight = RGB(r: 255, g: 217, b: 214)
+        static let errorTextLight = RGB(r: 122, g: 20, b: 20)
+        static let errorBackgroundDark = RGB(r: 102, g: 20, b: 20)
+        static let errorTextDark = RGB(r: 255, g: 208, b: 204)
+    }
+
+    func map(_ category: DiagnosticCategory) -> DiagnosticCategoryStyle {
+        switch category {
+        case .expected:
+            return DiagnosticCategoryStyle(
+                systemImageName: "info.circle.fill",
+                light: Palette.infoBackgroundLight,
+                dark: Palette.infoBackgroundDark,
+                lightText: Palette.infoTextLight,
+                darkText: Palette.infoTextDark
+            )
+        case .setup:
+            return DiagnosticCategoryStyle(
+                systemImageName: "exclamationmark.triangle.fill",
+                light: Palette.warningBackgroundLight,
+                dark: Palette.warningBackgroundDark,
+                lightText: Palette.warningTextLight,
+                darkText: Palette.warningTextDark
+            )
+        case .network:
+            return DiagnosticCategoryStyle(
+                systemImageName: "wifi.exclamationmark",
+                light: Palette.warningBackgroundLight,
+                dark: Palette.warningBackgroundDark,
+                lightText: Palette.warningTextLight,
+                darkText: Palette.warningTextDark
+            )
+        case .integrationError:
+            return DiagnosticCategoryStyle(
+                systemImageName: "xmark.octagon.fill",
+                light: Palette.errorBackgroundLight,
+                dark: Palette.errorBackgroundDark,
+                lightText: Palette.errorTextLight,
+                darkText: Palette.errorTextDark
+            )
+        }
+    }
+}

--- a/Sources/Helium/HeliumCore/Diagnostic/Mapper/DiagnosticCategoryStyleMapper.swift
+++ b/Sources/Helium/HeliumCore/Diagnostic/Mapper/DiagnosticCategoryStyleMapper.swift
@@ -7,9 +7,9 @@ import Foundation
 
 /// Maps a diagnostic category onto the banner resources that render it.
 ///
-/// Icons are per category, but tints are per severity: `.setup` and `.network` deliberately share
-/// the amber pair, which is also the fallback debug badge's palette, so a Helium developer warning
-/// reads as one signal wherever it surfaces.
+/// Icons are per category, but tints are per severity: `.setup` and `.network` are different
+/// categories at the same (warning) severity, so they share the amber pair while keeping distinct
+/// icons.
 struct DiagnosticCategoryStyleMapper {
 
     private enum Palette {

--- a/Sources/Helium/HeliumCore/Diagnostic/Mapper/DiagnosticContentMapper.swift
+++ b/Sources/Helium/HeliumCore/Diagnostic/Mapper/DiagnosticContentMapper.swift
@@ -9,7 +9,8 @@ import Foundation
 ///
 /// Two invariants hold across the whole matrix:
 ///  - **No URLs in `DiagnosticContent.body`.** The CTA owns the URL, so nothing downstream has to
-///    detect one inside prose.
+///    detect one inside prose. `DiagnosticContent.usersWillSee` is the one exception — it may end
+///    with the fallback-guide URL, because the modal is the only surface that renders it.
 ///  - **No raw reason codes as prose.** An unrecognised code maps to generic copy and surfaces its
 ///    code only as `DiagnosticContent.reasonCode`.
 ///
@@ -28,6 +29,19 @@ struct DiagnosticContentMapper {
         static let entitlements = "\(quickstart)#checking-subscription-status-%26-entitlements"
         static let workflows = "https://app.tryhelium.com/workflows"
         static let paywalls = "https://app.tryhelium.com/paywalls"
+        static let fallbackGuide = "https://docs.tryhelium.com/guides/fallback-bundle"
+    }
+
+    private enum UsersWillSee {
+        /// Shared outcome for reasons a bundled fallback would have covered.
+        static let seesNothingConsiderFallback =
+            "Users hitting this trigger see nothing. Consider adding a fallback paywall: "
+            + Url.fallbackGuide
+
+        /// Outcome for failures that stop the SDK before any paywall — fallback included — can load.
+        static let seesNothingNoFallbackPossible =
+            "Users hitting this trigger see nothing — no paywall and no fallback can load until "
+            + "this is fixed."
     }
 
     /// Stands in for the reason code when the SDK reported no reason at all.
@@ -115,7 +129,7 @@ struct DiagnosticContentMapper {
                 + "paywall. To show paywalls to entitled users anyway, set dontShowIfAlreadyEntitled "
                 + "to false.",
             usersWillSee: "Subscribed users see no paywall; users without the entitlement see it "
-                + "normally. Testing? Use an account without an active purchase.",
+                + "normally.",
             cta: .openUrl(label: "Entitlement Docs", url: Url.entitlements),
             reasonCode: PaywallSkippedReason.alreadyEntitled.rawValue
         )
@@ -154,10 +168,9 @@ struct DiagnosticContentMapper {
         DiagnosticContent(
             category: .setup,
             title: "Helium isn't initialized",
-            body: "A paywall was requested before Helium.initialize() completed, or it was never "
-                + "called. Initialize Helium at app launch, before any trigger can fire.",
-            usersWillSee: "Nothing was shown to this user — no paywall and no fallback. No paywall "
-                + "can load until the SDK initializes.",
+            body: "Helium.initialize() was never called. Initialize Helium at app launch, before "
+                + "any trigger can fire.",
+            usersWillSee: UsersWillSee.seesNothingNoFallbackPossible,
             cta: .openUrl(label: "View Setup Docs", url: Url.quickstart),
             reasonCode: code
         )
@@ -169,7 +182,7 @@ struct DiagnosticContentMapper {
             title: "No screen to present the paywall on",
             body: "Helium could not find a root view controller to present from. Trigger the paywall "
                 + "after your window and root view controller exist — not during app or scene startup.",
-            usersWillSee: "Nothing was shown to this user — no paywall and no fallback.",
+            usersWillSee: UsersWillSee.seesNothingNoFallbackPossible,
             cta: .openUrl(label: "View Setup Docs", url: Url.quickstart),
             reasonCode: code
         )
@@ -181,7 +194,7 @@ struct DiagnosticContentMapper {
             title: "No paywall is connected to this trigger",
             body: "Could not find a paywall for the trigger \"\(context.trigger)\". Verify the trigger "
                 + "is in a workflow. Changes to a workflow can take a few minutes to be reflected here.",
-            usersWillSee: "Users hitting this trigger see nothing, unless you bundle a fallback paywall.",
+            usersWillSee: UsersWillSee.seesNothingConsiderFallback,
             cta: .openUrl(label: "Open Workflows", url: Url.workflows),
             reasonCode: code
         )
@@ -193,8 +206,7 @@ struct DiagnosticContentMapper {
             title: "This paywall has no iOS products",
             body: "The paywall for \"\(context.trigger)\" does not include any iOS products. Sync your "
                 + "App Store in-app products and subscriptions, then select them on this paywall.",
-            usersWillSee: "Users see nothing for this trigger, unless a fallback with valid products "
-                + "is bundled.",
+            usersWillSee: UsersWillSee.seesNothingConsiderFallback,
             cta: .openUrl(label: "Open Paywall Editor", url: paywallEditorUrl(context)),
             reasonCode: code
         )
@@ -206,7 +218,7 @@ struct DiagnosticContentMapper {
             title: "Web checkout needs a custom user ID",
             body: "External web checkout requires a custom user ID so purchases can be linked to this "
                 + "user. Set one via Helium.identify.userId before showing the paywall.",
-            usersWillSee: "Users see nothing for this trigger until a custom user ID is set.",
+            usersWillSee: UsersWillSee.seesNothingConsiderFallback,
             cta: .openUrl(label: "View Docs", url: Url.quickstart),
             reasonCode: code
         )
@@ -222,7 +234,7 @@ struct DiagnosticContentMapper {
             category: .setup,
             title: "Web checkout isn't enabled",
             body: body,
-            usersWillSee: "Users see nothing for this trigger until web checkout is enabled.",
+            usersWillSee: UsersWillSee.seesNothingConsiderFallback,
             cta: .openUrl(label: "View Docs", url: Url.quickstart),
             reasonCode: code
         )
@@ -236,9 +248,8 @@ struct DiagnosticContentMapper {
             title: "Paywalls are still downloading",
             body: "Paywalls had not completed downloading when this trigger fired. Check your "
                 + "connection, and consider raising the loading budget or initializing Helium sooner.",
-            usersWillSee: "Real users on slow connections hit this too. They would see your bundled "
-                + "fallback — none was available here, so this user saw nothing. Ship a fallback to "
-                + "guarantee coverage.",
+            usersWillSee: "Real users see a loading indication followed by no paywall. Consider "
+                + "adding a fallback paywall: \(Url.fallbackGuide)",
             cta: .openUrl(label: "View Docs", url: Url.quickstart),
             reasonCode: code
         )
@@ -249,8 +260,7 @@ struct DiagnosticContentMapper {
             category: .network,
             title: "Paywalls failed to download",
             body: "Paywalls failed to download. Check this device's connection and your Helium API key.",
-            usersWillSee: "No fallback was available, so this user saw nothing. With a bundled "
-                + "fallback, users would see that instead.",
+            usersWillSee: UsersWillSee.seesNothingConsiderFallback,
             cta: .openUrl(label: "View Docs", url: Url.quickstart),
             reasonCode: code
         )
@@ -264,7 +274,7 @@ struct DiagnosticContentMapper {
             title: "The paywall couldn't be retrieved",
             body: "Helium could not fetch or read this paywall's bundle. Copy the diagnostic report "
                 + "and contact Helium if this continues to be an issue.",
-            usersWillSee: "No fallback was available, so this user saw nothing.",
+            usersWillSee: UsersWillSee.seesNothingConsiderFallback,
             cta: .copyReport,
             reasonCode: code
         )
@@ -276,7 +286,7 @@ struct DiagnosticContentMapper {
             title: "The paywall failed to render",
             body: "The paywall's web view failed to render, or could not communicate with the SDK. "
                 + "Retry once; if it reproduces, copy the diagnostic report and contact Helium.",
-            usersWillSee: "No fallback was available, so this user saw nothing.",
+            usersWillSee: UsersWillSee.seesNothingConsiderFallback,
             cta: .copyReport,
             reasonCode: code
         )
@@ -304,7 +314,7 @@ struct DiagnosticContentMapper {
             title: "Paywall configuration is invalid",
             body: "The resolved configuration for this trigger failed validation. Copy the diagnostic "
                 + "report and contact Helium support.",
-            usersWillSee: "No fallback was available, so this user saw nothing.",
+            usersWillSee: UsersWillSee.seesNothingConsiderFallback,
             cta: .copyReport,
             reasonCode: code
         )
@@ -315,7 +325,7 @@ struct DiagnosticContentMapper {
             category: .integrationError,
             title: "The paywall couldn't be shown",
             body: "Helium hit an unexpected state. Copy the diagnostic report and contact Helium support.",
-            usersWillSee: "No fallback was available, so this user saw nothing.",
+            usersWillSee: UsersWillSee.seesNothingConsiderFallback,
             cta: .copyReport,
             reasonCode: code
         )

--- a/Sources/Helium/HeliumCore/Diagnostic/Mapper/DiagnosticContentMapper.swift
+++ b/Sources/Helium/HeliumCore/Diagnostic/Mapper/DiagnosticContentMapper.swift
@@ -1,0 +1,332 @@
+//
+//  DiagnosticContentMapper.swift
+//  Helium
+//
+
+import Foundation
+
+/// Maps a paywall-not-shown reason onto the authored copy that describes it.
+///
+/// Two invariants hold across the whole matrix:
+///  - **No URLs in `DiagnosticContent.body`.** The CTA owns the URL, so nothing downstream has to
+///    detect one inside prose.
+///  - **No raw reason codes as prose.** An unrecognised code maps to generic copy and surfaces its
+///    code only as `DiagnosticContent.reasonCode`.
+///
+/// One content record serves two contexts: the modal (nothing rendered) and the fallback-shown log
+/// (a fallback rendered). The fields divide along that seam — `body` states the *cause*, which is
+/// true in both contexts, while `usersWillSee` states what this user actually got and is rendered
+/// only by the modal. That is what lets a row like `forceShowFallback` read correctly in a log line
+/// saying a fallback was shown and in a modal that only appears when one wasn't.
+///
+/// Helium sells digital in-app products and subscriptions, so product copy names the store's
+/// vocabulary (in-app products, subscriptions, the App Store) and never generic commerce language.
+struct DiagnosticContentMapper {
+
+    private enum Url {
+        static let quickstart = "https://docs.tryhelium.com/sdk/quickstart-ios"
+        static let entitlements = "\(quickstart)#checking-subscription-status-%26-entitlements"
+        static let workflows = "https://app.tryhelium.com/workflows"
+        static let paywalls = "https://app.tryhelium.com/paywalls"
+    }
+
+    /// Stands in for the reason code when the SDK reported no reason at all.
+    private static let unknownReasonCode = "unknown"
+
+    // MARK: - Entry points
+
+    /// Maps a skip — a paywall Helium deliberately chose not to show. Skip copy needs no runtime
+    /// context beyond the reason itself.
+    func mapSkip(_ reason: PaywallSkippedReason) -> DiagnosticContent {
+        switch reason {
+        case .targetingHoldout: return targetingHoldout()
+        case .alreadyEntitled: return alreadyEntitled()
+        }
+    }
+
+    /// Maps the reason a paywall was unavailable, whether or not a fallback then rendered.
+    func mapUnavailable(_ reason: PaywallUnavailableReason?, context: DiagnosticContext) -> DiagnosticContent {
+        guard let reason else { return unknown(Self.unknownReasonCode) }
+        let code = reason.rawValue
+
+        // Deliberately exhaustive with no `default:` — a new PaywallUnavailableReason case becomes a
+        // compile error here rather than silently leaking its raw code into the UI.
+        switch reason {
+        case .notInitialized:
+            return notInitialized(code)
+        case .noRootController:
+            return noRootController(code)
+        case .triggerHasNoPaywall:
+            return triggerHasNoPaywall(code, context)
+        case .noProductsIOS:
+            return noProducts(code, context)
+        case .webCheckoutNoCustomUserId:
+            return webCheckoutNoCustomUserId(code)
+        case .webCheckoutNotEnabled:
+            return webCheckoutNotEnabled(code, context)
+
+        case .paywallsNotDownloaded, .configFetchInProgress, .bundlesFetchInProgress, .productsFetchInProgress:
+            return paywallsNotDownloaded(code)
+        case .paywallsDownloadFail:
+            return paywallsDownloadFail(code)
+
+        case .couldNotFindBundleUrl,
+             .bundleFetchInvalidUrlDetected,
+             .bundleFetchInvalidUrl,
+             .bundleFetch403,
+             .bundleFetch404,
+             .bundleFetch410,
+             .bundleFetchCannotDecodeContent:
+            return bundleRetrieval(code)
+        case .webviewRenderFail, .bridgingError:
+            return renderFailure(code)
+        case .secondTryNoMatch:
+            return secondTryNoMatch(code, context)
+        case .invalidResolvedConfig:
+            return invalidResolvedConfig(code)
+
+        case .alreadyPresented:
+            return alreadyPresented(code)
+        case .forceShowFallback:
+            return forceShowFallback(code)
+        }
+    }
+
+    // MARK: - EXPECTED
+
+    private func targetingHoldout() -> DiagnosticContent {
+        DiagnosticContent(
+            category: .expected,
+            title: "Paywall skipped",
+            body: "Helium did not show this paywall due to your workflow's targeting configuration. "
+                + "Check your workflow configuration if this is not expected.",
+            usersWillSee: "Users matched by this targeting rule see no paywall and the app simply "
+                + "continues. Other users see the paywall normally.",
+            cta: .openUrl(label: "Open Workflows", url: Url.workflows),
+            reasonCode: PaywallSkippedReason.targetingHoldout.rawValue
+        )
+    }
+
+    private func alreadyEntitled() -> DiagnosticContent {
+        DiagnosticContent(
+            category: .expected,
+            title: "Already subscribed",
+            body: "Paywall not shown because this user is already entitled to a product in this "
+                + "paywall. To show paywalls to entitled users anyway, set dontShowIfAlreadyEntitled "
+                + "to false.",
+            usersWillSee: "Subscribed users see no paywall; users without the entitlement see it "
+                + "normally. Testing? Use an account without an active purchase.",
+            cta: .openUrl(label: "Entitlement Docs", url: Url.entitlements),
+            reasonCode: PaywallSkippedReason.alreadyEntitled.rawValue
+        )
+    }
+
+    /// Suppressed from the modal, so only `body` is ever surfaced — in the log.
+    private func alreadyPresented(_ code: String) -> DiagnosticContent {
+        DiagnosticContent(
+            category: .expected,
+            title: "A Helium paywall is already being presented",
+            body: "Another Helium paywall is already on screen, so this request was ignored. "
+                + "Dismiss the current paywall before presenting another.",
+            usersWillSee: "Users see the paywall that is already on screen.",
+            cta: .openUrl(label: "View Docs", url: Url.quickstart),
+            reasonCode: code
+        )
+    }
+
+    private func forceShowFallback(_ code: String) -> DiagnosticContent {
+        DiagnosticContent(
+            category: .expected,
+            title: "Fallback paywall forced for this trigger",
+            body: "This trigger's paywall is configured to force the bundled fallback, so Helium "
+                + "attempted your fallback instead of the remote paywall.",
+            // The modal only appears when nothing rendered, so reaching it means the forced fallback
+            // itself failed. The log path, where the fallback did render, never reads this field.
+            usersWillSee: "The bundled fallback could not be rendered, so this user saw nothing.",
+            cta: .openUrl(label: "View Docs", url: Url.quickstart),
+            reasonCode: code
+        )
+    }
+
+    // MARK: - SETUP
+
+    private func notInitialized(_ code: String) -> DiagnosticContent {
+        DiagnosticContent(
+            category: .setup,
+            title: "Helium isn't initialized",
+            body: "A paywall was requested before Helium.initialize() completed, or it was never "
+                + "called. Initialize Helium at app launch, before any trigger can fire.",
+            usersWillSee: "Nothing was shown to this user — no paywall and no fallback. No paywall "
+                + "can load until the SDK initializes.",
+            cta: .openUrl(label: "View Setup Docs", url: Url.quickstart),
+            reasonCode: code
+        )
+    }
+
+    private func noRootController(_ code: String) -> DiagnosticContent {
+        DiagnosticContent(
+            category: .setup,
+            title: "No screen to present the paywall on",
+            body: "Helium could not find a root view controller to present from. Trigger the paywall "
+                + "after your window and root view controller exist — not during app or scene startup.",
+            usersWillSee: "Nothing was shown to this user — no paywall and no fallback.",
+            cta: .openUrl(label: "View Setup Docs", url: Url.quickstart),
+            reasonCode: code
+        )
+    }
+
+    private func triggerHasNoPaywall(_ code: String, _ context: DiagnosticContext) -> DiagnosticContent {
+        DiagnosticContent(
+            category: .setup,
+            title: "No paywall is connected to this trigger",
+            body: "Could not find a paywall for the trigger \"\(context.trigger)\". Verify the trigger "
+                + "is in a workflow. Changes to a workflow can take a few minutes to be reflected here.",
+            usersWillSee: "Users hitting this trigger see nothing, unless you bundle a fallback paywall.",
+            cta: .openUrl(label: "Open Workflows", url: Url.workflows),
+            reasonCode: code
+        )
+    }
+
+    private func noProducts(_ code: String, _ context: DiagnosticContext) -> DiagnosticContent {
+        DiagnosticContent(
+            category: .setup,
+            title: "This paywall has no iOS products",
+            body: "The paywall for \"\(context.trigger)\" does not include any iOS products. Sync your "
+                + "App Store in-app products and subscriptions, then select them on this paywall.",
+            usersWillSee: "Users see nothing for this trigger, unless a fallback with valid products "
+                + "is bundled.",
+            cta: .openUrl(label: "Open Paywall Editor", url: paywallEditorUrl(context)),
+            reasonCode: code
+        )
+    }
+
+    private func webCheckoutNoCustomUserId(_ code: String) -> DiagnosticContent {
+        DiagnosticContent(
+            category: .setup,
+            title: "Web checkout needs a custom user ID",
+            body: "External web checkout requires a custom user ID so purchases can be linked to this "
+                + "user. Set one via Helium.identify.userId before showing the paywall.",
+            usersWillSee: "Users see nothing for this trigger until a custom user ID is set.",
+            cta: .openUrl(label: "View Docs", url: Url.quickstart),
+            reasonCode: code
+        )
+    }
+
+    private func webCheckoutNotEnabled(_ code: String, _ context: DiagnosticContext) -> DiagnosticContent {
+        var body = "This paywall has Stripe/Paddle products, but external web checkout is not enabled "
+            + "for those processors. Call Helium.config.enableExternalWebCheckout(...) to enable."
+        if !context.webCheckoutProcessors.isEmpty {
+            body += " Currently enabled: \(context.webCheckoutProcessors)."
+        }
+        return DiagnosticContent(
+            category: .setup,
+            title: "Web checkout isn't enabled",
+            body: body,
+            usersWillSee: "Users see nothing for this trigger until web checkout is enabled.",
+            cta: .openUrl(label: "View Docs", url: Url.quickstart),
+            reasonCode: code
+        )
+    }
+
+    // MARK: - NETWORK
+
+    private func paywallsNotDownloaded(_ code: String) -> DiagnosticContent {
+        DiagnosticContent(
+            category: .network,
+            title: "Paywalls are still downloading",
+            body: "Paywalls had not completed downloading when this trigger fired. Check your "
+                + "connection, and consider raising the loading budget or initializing Helium sooner.",
+            usersWillSee: "Real users on slow connections hit this too. They would see your bundled "
+                + "fallback — none was available here, so this user saw nothing. Ship a fallback to "
+                + "guarantee coverage.",
+            cta: .openUrl(label: "View Docs", url: Url.quickstart),
+            reasonCode: code
+        )
+    }
+
+    private func paywallsDownloadFail(_ code: String) -> DiagnosticContent {
+        DiagnosticContent(
+            category: .network,
+            title: "Paywalls failed to download",
+            body: "Paywalls failed to download. Check this device's connection and your Helium API key.",
+            usersWillSee: "No fallback was available, so this user saw nothing. With a bundled "
+                + "fallback, users would see that instead.",
+            cta: .openUrl(label: "View Docs", url: Url.quickstart),
+            reasonCode: code
+        )
+    }
+
+    // MARK: - INTEGRATION ERROR
+
+    private func bundleRetrieval(_ code: String) -> DiagnosticContent {
+        DiagnosticContent(
+            category: .integrationError,
+            title: "The paywall couldn't be retrieved",
+            body: "Helium could not fetch or read this paywall's bundle. Copy the diagnostic report "
+                + "and contact Helium if this continues to be an issue.",
+            usersWillSee: "No fallback was available, so this user saw nothing.",
+            cta: .copyReport,
+            reasonCode: code
+        )
+    }
+
+    private func renderFailure(_ code: String) -> DiagnosticContent {
+        DiagnosticContent(
+            category: .integrationError,
+            title: "The paywall failed to render",
+            body: "The paywall's web view failed to render, or could not communicate with the SDK. "
+                + "Retry once; if it reproduces, copy the diagnostic report and contact Helium.",
+            usersWillSee: "No fallback was available, so this user saw nothing.",
+            cta: .copyReport,
+            reasonCode: code
+        )
+    }
+
+    /// Fires when a presented paywall asks Helium to open a second try paywall and neither the
+    /// requested paywall uuid nor the `<trigger>_second_try` trigger resolves. The context trigger
+    /// is the second-try trigger, not the paywall the user is looking at.
+    private func secondTryNoMatch(_ code: String, _ context: DiagnosticContext) -> DiagnosticContent {
+        DiagnosticContent(
+            category: .integrationError,
+            title: "No second try paywall found",
+            body: "This paywall asked Helium to open a second try paywall, but no paywall matched "
+                + "\"\(context.trigger)\". Confirm the second try paywall exists and is connected.",
+            usersWillSee: "Users who reach this step see no second try paywall — the paywall they are "
+                + "on stays on screen.",
+            cta: .openUrl(label: "Open Paywall Editor", url: paywallEditorUrl(context)),
+            reasonCode: code
+        )
+    }
+
+    private func invalidResolvedConfig(_ code: String) -> DiagnosticContent {
+        DiagnosticContent(
+            category: .integrationError,
+            title: "Paywall configuration is invalid",
+            body: "The resolved configuration for this trigger failed validation. Copy the diagnostic "
+                + "report and contact Helium support.",
+            usersWillSee: "No fallback was available, so this user saw nothing.",
+            cta: .copyReport,
+            reasonCode: code
+        )
+    }
+
+    private func unknown(_ code: String) -> DiagnosticContent {
+        DiagnosticContent(
+            category: .integrationError,
+            title: "The paywall couldn't be shown",
+            body: "Helium hit an unexpected state. Copy the diagnostic report and contact Helium support.",
+            usersWillSee: "No fallback was available, so this user saw nothing.",
+            cta: .copyReport,
+            reasonCode: code
+        )
+    }
+
+    // MARK: - URLs
+
+    /// Deep-links straight to the offending paywall when the id resolved; otherwise the editor's
+    /// paywall list, which is still the right place to go.
+    private func paywallEditorUrl(_ context: DiagnosticContext) -> String {
+        guard let paywallId = context.paywallId else { return Url.paywalls }
+        return "\(Url.paywalls)/\(paywallId)"
+    }
+}

--- a/Sources/Helium/HeliumCore/Diagnostic/Mapper/DiagnosticLogLineMapper.swift
+++ b/Sources/Helium/HeliumCore/Diagnostic/Mapper/DiagnosticLogLineMapper.swift
@@ -1,0 +1,21 @@
+//
+//  DiagnosticLogLineMapper.swift
+//  Helium
+//
+
+import Foundation
+
+/// Projects diagnostic content onto the single log line the SDK emits for it.
+///
+/// The line re-appends the CTA's URL so log output stays as actionable as the modal, and leads with
+/// the bracketed reason code so it remains greppable.
+struct DiagnosticLogLineMapper {
+
+    func map(_ content: DiagnosticContent) -> String {
+        var line = "[\(content.reasonCode)] \(content.title). \(content.body)"
+        if case let .openUrl(_, url) = content.cta {
+            line += " \(url)"
+        }
+        return line
+    }
+}

--- a/Sources/Helium/HeliumCore/Diagnostic/Mapper/DiagnosticReportMapper.swift
+++ b/Sources/Helium/HeliumCore/Diagnostic/Mapper/DiagnosticReportMapper.swift
@@ -1,0 +1,23 @@
+//
+//  DiagnosticReportMapper.swift
+//  Helium
+//
+
+import Foundation
+
+/// Projects diagnostic content onto the plain-text report a developer copies to the clipboard and
+/// sends to Helium support.
+///
+/// The format is shared verbatim with the Android SDK, so support tooling can parse either.
+struct DiagnosticReportMapper {
+
+    func map(_ content: DiagnosticContent, trigger: String, sdkVersion: String) -> String {
+        """
+        Helium paywall diagnostic
+        trigger: \(trigger)
+        reason: \(content.reasonCode) (\(content.category.reportName))
+        sdk: helium-swift \(sdkVersion)
+        \(content.title) — \(content.body)
+        """
+    }
+}

--- a/Sources/Helium/HeliumCore/Diagnostic/Model/DiagnosticCategory.swift
+++ b/Sources/Helium/HeliumCore/Diagnostic/Model/DiagnosticCategory.swift
@@ -1,0 +1,36 @@
+//
+//  DiagnosticCategory.swift
+//  Helium
+//
+
+import Foundation
+
+/// Severity grouping for a paywall-unavailable reason, keyed by *who fixes it* rather than by
+/// where the failure occurred.
+///
+/// `bannerLabel` is displayed copy; `reportName` is the stable token written into the diagnostic
+/// report, and is shared verbatim with the Android SDK.
+enum DiagnosticCategory {
+    case expected
+    case setup
+    case network
+    case integrationError
+
+    var bannerLabel: String {
+        switch self {
+        case .expected: return "WORKING AS CONFIGURED"
+        case .setup: return "SETUP NEEDED"
+        case .network: return "NETWORK / TIMING"
+        case .integrationError: return "INTEGRATION ERROR"
+        }
+    }
+
+    var reportName: String {
+        switch self {
+        case .expected: return "expected"
+        case .setup: return "setup"
+        case .network: return "network"
+        case .integrationError: return "integrationError"
+        }
+    }
+}

--- a/Sources/Helium/HeliumCore/Diagnostic/Model/DiagnosticCategoryStyle.swift
+++ b/Sources/Helium/HeliumCore/Diagnostic/Model/DiagnosticCategoryStyle.swift
@@ -1,0 +1,41 @@
+//
+//  DiagnosticCategoryStyle.swift
+//  Helium
+//
+
+import SwiftUI
+import UIKit
+
+/// Presentation resources for a `DiagnosticCategory`'s banner strip.
+///
+/// The colors are dynamic: each resolves its light or dark variant from the trait collection at
+/// render time, so no view has to branch on `colorScheme`.
+struct DiagnosticCategoryStyle {
+    let systemImageName: String
+    let background: Color
+    let foreground: Color
+
+    init(systemImageName: String, light: RGB, dark: RGB, lightText: RGB, darkText: RGB) {
+        self.systemImageName = systemImageName
+        self.background = RGB.dynamicColor(light: light, dark: dark)
+        self.foreground = RGB.dynamicColor(light: lightText, dark: darkText)
+    }
+}
+
+/// A literal 8-bit color, so the palette in `DiagnosticCategoryStyleMapper` reads as the hex values
+/// the cross-platform spec defines.
+struct RGB {
+    let r: Int
+    let g: Int
+    let b: Int
+
+    var uiColor: UIColor {
+        UIColor(red: CGFloat(r) / 255, green: CGFloat(g) / 255, blue: CGFloat(b) / 255, alpha: 1)
+    }
+
+    /// Resolves a light/dark pair from the trait collection at render time, so no view has to
+    /// branch on `colorScheme`.
+    static func dynamicColor(light: RGB, dark: RGB) -> Color {
+        Color(UIColor { $0.userInterfaceStyle == .dark ? dark.uiColor : light.uiColor })
+    }
+}

--- a/Sources/Helium/HeliumCore/Diagnostic/Model/DiagnosticContent.swift
+++ b/Sources/Helium/HeliumCore/Diagnostic/Model/DiagnosticContent.swift
@@ -1,0 +1,23 @@
+//
+//  DiagnosticContent.swift
+//  Helium
+//
+
+import Foundation
+
+/// The authored copy describing one reason a paywall was not shown.
+///
+/// A pure model: rendering it as a log line or as a support report belongs to the corresponding
+/// mappers, so the same content can be projected into either without this type knowing about them.
+///
+/// `usersWillSee` is a required field rather than a sentence buried in `body` so that every reason
+/// is forced to answer the question a tester actually has: did real customers get a broken
+/// experience?
+struct DiagnosticContent: Equatable {
+    let category: DiagnosticCategory
+    let title: String
+    let body: String
+    let usersWillSee: String
+    let cta: DiagnosticCta
+    let reasonCode: String
+}

--- a/Sources/Helium/HeliumCore/Diagnostic/Model/DiagnosticContext.swift
+++ b/Sources/Helium/HeliumCore/Diagnostic/Model/DiagnosticContext.swift
@@ -1,0 +1,37 @@
+//
+//  DiagnosticContext.swift
+//  Helium
+//
+
+import Foundation
+
+/// The runtime facts the copy matrix needs beyond the reason itself.
+///
+/// Passed in rather than read from global state inside the mapper, so the whole copy matrix stays
+/// a pure function and is unit-testable without a fetched config.
+struct DiagnosticContext {
+    let trigger: String
+
+    /// Deep-links the paywall editor CTA straight to the offending paywall when it resolves.
+    let paywallId: String?
+
+    /// The web checkout processors currently enabled, so the web-checkout copy can name them.
+    /// Carried as the typed set; how (and whether) to render it is the mapper's decision.
+    let webCheckoutProcessors: WebCheckoutProcessors
+
+    init(trigger: String, paywallId: String? = nil, webCheckoutProcessors: WebCheckoutProcessors = []) {
+        self.trigger = trigger
+        self.paywallId = paywallId
+        self.webCheckoutProcessors = webCheckoutProcessors
+    }
+
+    /// Resolves the context from live SDK state. The paywall id is best-effort: an unresolvable
+    /// trigger simply leaves the CTA pointing at the paywall list.
+    static func live(trigger: String) -> DiagnosticContext {
+        DiagnosticContext(
+            trigger: trigger,
+            paywallId: HeliumFetchedConfigManager.shared.getPaywallInfoForTrigger(trigger)?.paywallUUID,
+            webCheckoutProcessors: Helium.config.webCheckoutProcessors
+        )
+    }
+}

--- a/Sources/Helium/HeliumCore/Diagnostic/Model/DiagnosticCta.swift
+++ b/Sources/Helium/HeliumCore/Diagnostic/Model/DiagnosticCta.swift
@@ -1,0 +1,21 @@
+//
+//  DiagnosticCta.swift
+//  Helium
+//
+
+import Foundation
+
+/// The diagnostic modal's single primary action.
+///
+/// Authored per reason rather than inferred from body text, which is what allows body copy to stay
+/// free of URLs — and what removes the need to detect a URL inside prose.
+///
+/// The URL is carried as a `String` so the copy matrix never has to parse one, and so no code path
+/// force-unwraps a `URL`. The presentation layer converts it once and ignores an unopenable link.
+enum DiagnosticCta: Equatable {
+    /// Opens `url`; the modal offers a copy-URL affordance alongside it.
+    case openUrl(label: String, url: String)
+
+    /// Copies the diagnostic report. Used where no useful destination URL exists.
+    case copyReport
+}

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -231,7 +231,9 @@ public class HeliumFetchedConfigManager {
     static let MAX_NUM_CONFIG_ATTEMPTS: Int = 6 // roughly 36 seconds of delays in between attempts
     static let MAX_NUM_BUNDLE_ATTEMPTS: Int = 4 // roughly 7 seconds of delays in between attempts
     
-    private(set) var fetchedConfig: HeliumFetchedConfig?
+    /// Written by the background fetch task and read from arbitrary threads (paywall presentation,
+    /// diagnostics), so access must be atomic.
+    @HeliumAtomic private(set) var fetchedConfig: HeliumFetchedConfig?
     private(set) var fetchedConfigJSON: JSON?
     private(set) var triggersWithSkippedBundleAndReason: [(trigger: String, reason: PaywallUnavailableReason)] = []
     @HeliumAtomic private var localizedPriceMap: [String: LocalizedPrice] = [:]

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -234,8 +234,8 @@ public class HeliumFetchedConfigManager {
     /// Written by the background fetch task and read from arbitrary threads (paywall presentation,
     /// diagnostics), so access must be atomic.
     @HeliumAtomic private(set) var fetchedConfig: HeliumFetchedConfig?
-    private(set) var fetchedConfigJSON: JSON?
-    private(set) var triggersWithSkippedBundleAndReason: [(trigger: String, reason: PaywallUnavailableReason)] = []
+    @HeliumAtomic private(set) var fetchedConfigJSON: JSON?
+    @HeliumAtomic private(set) var triggersWithSkippedBundleAndReason: [(trigger: String, reason: PaywallUnavailableReason)] = []
     @HeliumAtomic private var localizedPriceMap: [String: LocalizedPrice] = [:]
     
     func fetchConfig(
@@ -1030,7 +1030,7 @@ public class HeliumFetchedConfigManager {
         productIdsStripe: [String],
         productIdsPaddle: [String],
         productIdsPaddleWeb: [String],
-        webPaywallBundleUrl: String? = nil,
+        webPaywallBundleUrl: String? = nil
     ) throws {
         guard var config = fetchedConfig else {
             throw HeliumControlPanelError.noConfigAvailable
@@ -1091,11 +1091,12 @@ public class HeliumFetchedConfigManager {
         fetchedConfig = config
 
         // Also update fetchedConfigJSON so getResolvedConfigJSONForTrigger works
-        if var configJSON = fetchedConfigJSON {
+        _fetchedConfigJSON.withValue { json in
+            guard var configJSON = json else { return }
             var sourceJSON = configJSON["triggerToPaywalls"][sourceTrigger]
             sourceJSON["resolvedConfig"]["baseStack"]["componentProps"]["bundleURL"] = JSON(bundleUrl)
             configJSON["triggerToPaywalls"][Self.HELIUM_PREVIEW_TRIGGER] = sourceJSON
-            fetchedConfigJSON = configJSON
+            json = configJSON
         }
     }
 }

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -51,7 +51,12 @@ public extension HeliumPaywallDelegate {
 class HeliumPaywallDelegateWrapper {
     
     public static let shared = HeliumPaywallDelegateWrapper()
-    
+
+    /// Authored diagnostic copy, shared by the log lines and the diagnostic modal so the two can
+    /// never describe the same reason differently.
+    private static let diagnosticContentMapper = DiagnosticContentMapper()
+    private static let diagnosticLogLineMapper = DiagnosticLogLineMapper()
+
     /// Tracks Transaction.updates observation tasks for pending purchases, keyed by product ID
     @HeliumAtomic private var pendingPurchaseTasks: [String: Task<Void, Never>] = [:]
     
@@ -328,80 +333,73 @@ class HeliumPaywallDelegateWrapper {
         fallbackShown: Bool,
         logMetadata: [String: String]
     ) {
+        let content = Self.diagnosticContentMapper.mapUnavailable(
+            paywallUnavailableReason,
+            context: .live(trigger: trigger)
+        )
         let logPrefix = fallbackShown ? "Fallback paywall shown!" : "Paywall not shown!"
-        var notShownAddendum: String = ""
-        switch paywallUnavailableReason {
-        case .notInitialized:
-            notShownAddendum = "Helium is not initialized"
-        case .triggerHasNoPaywall:
-            notShownAddendum = "Could not find paywall for trigger \"\(trigger)\". Verify your trigger is in a workflow. Note that changes to a workflow may take a few minutes to be reflected here. https://app.tryhelium.com/workflows"
-        case .paywallsNotDownloaded, .configFetchInProgress, .bundlesFetchInProgress, .productsFetchInProgress:
-            notShownAddendum = "Paywalls have not completed downloading. Check your connection and consider adjusting loading budget or initializing Helium sooner before presenting paywall"
-        case .paywallsDownloadFail:
-            notShownAddendum = "Paywalls failed to download. Check your connection and Helium API key"
-        case .alreadyPresented:
-            notShownAddendum = "A Helium paywall is already being presented"
-        case .noProductsIOS:
-            var paywallLink = "https://app.tryhelium.com/paywalls"
-            let paywallInfo = HeliumFetchedConfigManager.shared.getPaywallInfoForTrigger(trigger)
-            if let paywallId = paywallInfo?.paywallUUID {
-                paywallLink += "/\(paywallId)"
-            }
-            notShownAddendum = "Your paywall does not include any iOS products. Ensure you have synced your iOS products and selected products for your paywall \(paywallLink)"
-        case .webCheckoutNoCustomUserId:
-            notShownAddendum = "External Web Checkout requires a custom user ID to be set"
-        case .webCheckoutNotEnabled:
-            notShownAddendum = "External Web Checkout is not enabled for a payment processor this paywall requires. See Helium.config.enableExternalWebCheckout. Enabled processors: \(Helium.config.webCheckoutProcessors)"
-        case .bundleFetchCannotDecodeContent:
-            notShownAddendum = "Paywall html could not be read. Ensure the paywall is not corrupted and contact Helium if this continues to be an issue."
-        case .bundleFetchInvalidUrl, .bundleFetchInvalidUrlDetected, .bundleFetch403, .bundleFetch404, .bundleFetch410:
-            notShownAddendum = "Could not retrieve paywall. Contact Helium if this continues to be an issue."
-        case .couldNotFindBundleUrl:
-            notShownAddendum = "Could not extract paywall url. Contact Helium if this continues to be an issue."
-        default:
-            notShownAddendum = paywallUnavailableReason?.rawValue ?? ""
-        }
-        HeliumLogger.log(.error, category: .fallback, "\(logPrefix) \(notShownAddendum)", metadata: logMetadata)
-        
-#if DEBUG
-        let canShowDiagnosticView = true
-#else
-        let canShowDiagnosticView = trigger == HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER
-#endif
-        if canShowDiagnosticView {
-            if !fallbackShown && paywallUnavailableReason != .alreadyPresented {
-                Task { @MainActor in
-                    HeliumPaywallDiagnosticView.presentIfNeeded(
-                        trigger: trigger,
-                        message: notShownAddendum
-                    )
-                }
-            }
-        }
+        HeliumLogger.log(
+            .error,
+            category: .fallback,
+            "\(logPrefix) \(Self.diagnosticLogLineMapper.map(content))",
+            metadata: logMetadata
+        )
+
+        presentDiagnosticIfNeeded(
+            trigger: trigger,
+            content: content,
+            unavailableReason: paywallUnavailableReason,
+            fallbackShown: fallbackShown
+        )
     }
-    
+
     private func logPaywallSkip(
         trigger: String,
         skipReason: PaywallSkippedReason,
         logMetadata: [String: String]
     ) {
-        var skipMessage: String = ""
-        switch skipReason {
-        case .targetingHoldout:
-            skipMessage = "Paywall skipped due to targeting holdout. Check your workflow configuration if this is not expected https://app.tryhelium.com/workflows"
-        case .alreadyEntitled:
-            skipMessage = "Paywall not shown because user is already entitled to a product in the paywall. To disable this, ensure dontShowIfAlreadyEntitled is false. https://docs.tryhelium.com/sdk/quickstart-ios#checking-subscription-status-%26-entitlements"
-        }
-        HeliumLogger.log(.warn, category: .ui, skipMessage, metadata: logMetadata)
-        
-#if DEBUG
+        let content = Self.diagnosticContentMapper.mapSkip(skipReason)
+        HeliumLogger.log(
+            .warn,
+            category: .ui,
+            Self.diagnosticLogLineMapper.map(content),
+            metadata: logMetadata
+        )
+
+        // A skip is never a suppressed reason, and nothing rendered.
+        presentDiagnosticIfNeeded(
+            trigger: trigger,
+            content: content,
+            unavailableReason: nil,
+            fallbackShown: false
+        )
+    }
+
+    /// Single gating funnel for both the unavailable and skip paths, so neither can drift from the
+    /// visibility rules.
+    private func presentDiagnosticIfNeeded(
+        trigger: String,
+        content: DiagnosticContent,
+        unavailableReason: PaywallUnavailableReason?,
+        fallbackShown: Bool
+    ) {
+        let allowed = HeliumDiagnosticGate.shouldShow(
+            unavailableReason: unavailableReason,
+            fallbackShown: fallbackShown,
+            isPreviewTrigger: trigger == HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER,
+            environment: AppReceiptsHelper.shared.environment,
+            displayEnabled: Helium.config.paywallNotShownDiagnosticDisplayEnabled,
+            enabledInTestFlight: Helium.config.paywallNotShownDiagnosticEnabledInTestFlight,
+            serverFlagEnabled: HeliumFetchedConfigManager.shared.fetchedConfig?.diagnosticModalEnabled ?? true,
+            doNotShowAgain: {
+                UserDefaults.standard.bool(forKey: HeliumDiagnosticGate.doNotShowAgainKey)
+            }
+        )
+        guard allowed else { return }
+
         Task { @MainActor in
-            HeliumPaywallDiagnosticView.presentIfNeeded(
-                trigger: trigger,
-                message: skipMessage
-            )
+            HeliumPaywallDiagnosticView.presentIfNeeded(trigger: trigger, content: content)
         }
-#endif
     }
     
     // MARK: - Pending Purchase Observation

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -383,10 +383,16 @@ class HeliumPaywallDelegateWrapper {
         unavailableReason: PaywallUnavailableReason?,
         fallbackShown: Bool
     ) {
+#if DEBUG
+        let isDebugBuild = true
+#else
+        let isDebugBuild = false
+#endif
         let allowed = HeliumDiagnosticGate.shouldShow(
             unavailableReason: unavailableReason,
             fallbackShown: fallbackShown,
             isPreviewTrigger: trigger == HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER,
+            isDebugBuild: isDebugBuild,
             environment: AppReceiptsHelper.shared.environment,
             displayEnabled: Helium.config.paywallNotShownDiagnosticDisplayEnabled,
             enabledInTestFlight: Helium.config.paywallNotShownDiagnosticEnabledInTestFlight,

--- a/Sources/Helium/HeliumCore/HeliumPaywallDiagnosticView.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDiagnosticView.swift
@@ -77,6 +77,7 @@ struct HeliumPaywallDiagnosticView: View {
                 Image(systemName: "xmark")
                     .font(.body.weight(.semibold))
             }
+            .accessibilityLabel("Dismiss")
         }
         .foregroundColor(style.foreground)
         .padding(.horizontal, 20)
@@ -168,6 +169,7 @@ struct HeliumPaywallDiagnosticView: View {
                         .background(Color(.systemGray5))
                         .cornerRadius(12)
                 }
+                .accessibilityLabel("Copy URL")
             }
             .padding(.top, 24)
 

--- a/Sources/Helium/HeliumCore/HeliumPaywallDiagnosticView.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDiagnosticView.swift
@@ -4,44 +4,12 @@
 //
 //  Diagnostic modal shown when a paywall fails to display or is skipped.
 //
+//  All displayed copy arrives as an authored `DiagnosticContent`, so nothing here has to infer
+//  meaning — or a CTA destination — from message text.
+//
 
 import SwiftUI
 import UIKit
-
-// MARK: - Data Model
-
-struct DiagnosticContent {
-    let bodyText: String
-    let ctaTitle: String
-    let ctaURL: URL
-
-    private static let defaultURL = URL(string: "https://docs.tryhelium.com/sdk/quickstart-ios")!
-
-    /// Extracts the first URL found in the given text and returns it along with the text stripped of that URL.
-    private static func extractAndStripURL(from text: String) -> (url: URL, strippedText: String) {
-        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue),
-              let match = detector.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
-              let range = Range(match.range, in: text),
-              let url = URL(string: String(text[range])) else {
-            return (defaultURL, text)
-        }
-        let stripped = text.replacingCharacters(in: range, with: "").trimmingCharacters(in: .whitespaces)
-        return (url, stripped)
-    }
-
-    static func from(bodyText: String) -> DiagnosticContent {
-        let (url, strippedText) = extractAndStripURL(from: bodyText)
-        let ctaTitle: String
-        if url == defaultURL {
-            ctaTitle = "View Docs"
-        } else if url.host?.contains("app.tryhelium.com") == true {
-            ctaTitle = "Open Dashboard"
-        } else {
-            ctaTitle = "View Docs"
-        }
-        return DiagnosticContent(bodyText: strippedText, ctaTitle: ctaTitle, ctaURL: url)
-    }
-}
 
 // MARK: - SwiftUI View
 
@@ -50,129 +18,241 @@ struct HeliumPaywallDiagnosticView: View {
     let triggerName: String
     let onDismiss: () -> Void
 
-    @Environment(\.colorScheme) private var colorScheme
-    @State private var doNotShowAgain: Bool = UserDefaults.standard.bool(forKey: "heliumDiagnosticDoNotShowAgain")
+    @State private var doNotShowAgain: Bool = UserDefaults.standard.bool(forKey: HeliumDiagnosticGate.doNotShowAgainKey)
 
-    private var triggerTextColor: Color {
-        colorScheme == .dark
-            ? Color(red: 241/255, green: 233/255, blue: 253/255)
-            : Color(red: 44/255, green: 112/255, blue: 106/255)
+    private let styleMapper = DiagnosticCategoryStyleMapper()
+    private let reportMapper = DiagnosticReportMapper()
+
+    private var style: DiagnosticCategoryStyle {
+        styleMapper.map(content.category)
     }
 
-    private var triggerBackgroundColor: Color {
-        colorScheme == .dark
-            ? Color(red: 118/255, green: 44/255, blue: 200/255)
-            : Color(red: 213/255, green: 248/255, blue: 239/255)
+    private var report: String {
+        reportMapper.map(content, trigger: triggerName, sdkVersion: BuildConstants.version)
     }
-    
+
     private var isForPreview: Bool {
-        return triggerName == HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER
+        triggerName == HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER
     }
 
     var body: some View {
         ScrollView {
             VStack(spacing: 0) {
-                // Dismiss button
-                HStack {
-                    Spacer()
-                    Button(action: {
-                        onDismiss()
-                    }) {
-                        Image(systemName: "xmark.circle.fill")
-                            .font(.title2)
-                            .foregroundColor(.secondary)
+                bannerStrip
+
+                VStack(alignment: .leading, spacing: 0) {
+                    overline
+                    title
+                    if !isForPreview {
+                        triggerPill
                     }
+                    bodyText
+                    usersCallout
+                    primaryAction
+                    secondaryAction
+                    if !isForPreview {
+                        doNotShowAgainToggle
+                    }
+                    footer
                 }
-                .padding(.top, 8)
+                .padding(.horizontal, 28)
+                .padding(.top, 24)
+                .padding(.bottom, 30)
+            }
+        }
+    }
 
-                // Logo + Trigger group
-                Image("heliumlogo", bundle: .heliumResources)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(maxWidth: 200)
-                    .padding(.horizontal, 20)
-                    .padding(.top, 12)
+    // MARK: - Elements
 
-                if !isForPreview {
-                    Button(action: {
-                        UIPasteboard.general.string = triggerName
-                    }) {
-                        HStack(spacing: 10) {
-                            VStack(spacing: 5) {
-                                Text("Trigger")
-                                    .font(.subheadline)
-                                    .foregroundColor(triggerTextColor)
-                                Text(triggerName)
-                                    .font(.title3)
-                                    .fontWeight(.semibold)
-                                    .foregroundColor(triggerTextColor)
-                            }
-                            Image(systemName: "doc.on.doc")
-                                .font(.caption)
-                                .foregroundColor(triggerTextColor)
-                        }
-                        .padding(.horizontal, 18)
-                        .padding(.vertical, 10)
-                        .background(triggerBackgroundColor)
+    /// Full-width tinted row. The modal is classifiable before a single word of prose is read.
+    private var bannerStrip: some View {
+        HStack(spacing: 10) {
+            Image(systemName: style.systemImageName)
+                .font(.body)
+            Text(content.category.bannerLabel)
+                .font(.subheadline.weight(.bold))
+                .kerning(0.8)
+            Spacer()
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.body.weight(.semibold))
+            }
+        }
+        .foregroundColor(style.foreground)
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+        .frame(maxWidth: .infinity)
+        .background(style.background)
+    }
+
+    /// Branding demotes so the diagnosis can promote.
+    private var overline: some View {
+        Text("HELIUM PAYWALL DIAGNOSTIC")
+            .font(.caption2.weight(.bold))
+            .kerning(1)
+            .foregroundColor(.secondary)
+    }
+
+    private var title: some View {
+        Text(content.title)
+            .font(.title.weight(.bold))
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.top, 10)
+    }
+
+    private var triggerPill: some View {
+        Button(action: { UIPasteboard.general.string = triggerName }) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Trigger")
+                    .font(.subheadline)
+                Text(triggerName)
+                    .font(.title3.weight(.semibold))
+                Text("(tap to copy)")
+                    .font(.caption2)
+                    .opacity(0.7)
+            }
+            .foregroundColor(triggerTextColor)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 18)
+            .padding(.vertical, 10)
+            .background(triggerBackgroundColor)
+            .cornerRadius(12)
+        }
+        .padding(.top, 20)
+    }
+
+    private var bodyText: some View {
+        Text(content.body)
+            .font(.body)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.top, 20)
+    }
+
+    /// A distinct element rather than body prose: it answers the tester's actual question — did real
+    /// customers get a broken experience?
+    private var usersCallout: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("WHAT REAL USERS SEE")
+                .font(.caption2.weight(.bold))
+                .kerning(0.8)
+                .foregroundColor(.secondary)
+            Text(content.usersWillSee)
+                .font(.subheadline)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color(.secondarySystemBackground))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color(.separator), lineWidth: 1)
+        )
+        .padding(.top, 20)
+    }
+
+    @ViewBuilder
+    private var primaryAction: some View {
+        switch content.cta {
+        case let .openUrl(label, urlString):
+            HStack(spacing: 12) {
+                filledCtaButton(label) { open(urlString) }
+                Button(action: { UIPasteboard.general.string = urlString }) {
+                    Image(systemName: "doc.on.doc")
+                        .font(.body)
+                        .padding(14)
+                        .background(Color(.systemGray5))
                         .cornerRadius(12)
-                    }
-                    .padding(.top, 40)
-                }
-
-                // Body text
-                Text(content.bodyText)
-                    .font(.body)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.top, 32)
-
-                // CTA button + copy
-                HStack(spacing: 12) {
-                    Button(action: {
-                        UIApplication.shared.open(content.ctaURL)
-                    }) {
-                        Text(content.ctaTitle)
-                            .fontWeight(.semibold)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 14)
-                            .background(Color.blue)
-                            .foregroundColor(.white)
-                            .cornerRadius(12)
-                    }
-
-                    Button(action: {
-                        UIPasteboard.general.string = content.ctaURL.absoluteString
-                    }) {
-                        Image(systemName: "doc.on.doc")
-                            .font(.body)
-                            .padding(14)
-                            .background(Color(.systemGray5))
-                            .cornerRadius(12)
-                    }
-                }
-                .padding(.top, 40)
-
-                if !isForPreview {
-                    // Checkbox + Footer
-                    Toggle(isOn: $doNotShowAgain) {
-                        Text("Do not show again on this device")
-                            .font(.subheadline)
-                    }
-                    .toggleStyle(CheckboxToggleStyle())
-                    .onChange(of: doNotShowAgain) { newValue in
-                        UserDefaults.standard.set(newValue, forKey: "heliumDiagnosticDoNotShowAgain")
-                    }
-                    .padding(.top, 30)
-                    
-                    Text("This diagnostic view is only shown in DEBUG builds.\n\nYou can disable it by setting Helium.config.paywallNotShownDiagnosticDisplayEnabled to false.")
-                        .font(.footnote)
-                        .foregroundColor(.secondary)
-                        .padding(.top, 38)
                 }
             }
-            .padding(.horizontal, 28)
-            .padding(.bottom, 30)
+            .padding(.top, 24)
+
+        // The report is the only action worth offering — no support URL is invented for it.
+        case .copyReport:
+            filledCtaButton("Copy Diagnostic Report", action: copyReport)
+                .padding(.top, 24)
         }
+    }
+
+    /// Hidden when copying the report is already the primary CTA.
+    @ViewBuilder
+    private var secondaryAction: some View {
+        if case .openUrl = content.cta {
+            Button(action: copyReport) {
+                Text("Copy Diagnostic Report")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+            }
+            .padding(.top, 4)
+        }
+    }
+
+    private func filledCtaButton(_ label: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(label)
+                .fontWeight(.semibold)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 14)
+                .background(Color.blue)
+                .foregroundColor(.white)
+                .cornerRadius(12)
+        }
+    }
+
+    private func copyReport() {
+        UIPasteboard.general.string = report
+    }
+
+    private var doNotShowAgainToggle: some View {
+        Toggle(isOn: $doNotShowAgain) {
+            Text("Do not show again on this device")
+                .font(.subheadline)
+        }
+        .toggleStyle(CheckboxToggleStyle())
+        .onChange(of: doNotShowAgain) { newValue in
+            UserDefaults.standard.set(newValue, forKey: HeliumDiagnosticGate.doNotShowAgainKey)
+        }
+        .padding(.top, 20)
+    }
+
+    /// The visibility disclaimer is only true on the non-preview path: dashboard previews bypass
+    /// the environment gate and the display flag, so neither claim may render there.
+    private var footer: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if !isForPreview {
+                Text("Visible in debug builds, and in TestFlight builds only if opted in — App Store users never see this.\n\nDisable with Helium.config.paywallNotShownDiagnosticDisplayEnabled = false.")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+            Text("Reason code: \(content.reasonCode)")
+                .font(.caption2.monospaced())
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.top, 28)
+    }
+
+    // MARK: - Colors
+
+    private var triggerTextColor: Color {
+        RGB.dynamicColor(light: RGB(r: 44, g: 112, b: 106), dark: RGB(r: 127, g: 216, b: 201))
+    }
+
+    private var triggerBackgroundColor: Color {
+        RGB.dynamicColor(light: RGB(r: 213, g: 248, b: 239), dark: RGB(r: 18, g: 59, b: 53))
+    }
+
+    /// An unopenable link is not worth crashing or trapping over — the copy-URL affordance beside
+    /// the CTA still gets the developer where they are going.
+    private func open(_ urlString: String) {
+        guard let url = URL(string: urlString) else { return }
+        UIApplication.shared.open(url)
     }
 }
 
@@ -215,26 +295,12 @@ extension HeliumPaywallDiagnosticView {
         diagnosticWindow = nil
     }
 
+    /// Visibility has already been decided by `HeliumDiagnosticGate`; this owns only the singleton
+    /// claim, which has to be a claim rather than a predicate.
     @MainActor
-    static func presentIfNeeded(
-        trigger: String,
-        message: String
-    ) {
-        guard shouldPresent(trigger: trigger) else { return }
-
-        let content = DiagnosticContent.from(bodyText: message)
+    static func presentIfNeeded(trigger: String, content: DiagnosticContent) {
+        guard !isCurrentlyPresented else { return }
         present(content: content, triggerName: trigger)
-    }
-
-    @MainActor
-    private static func shouldPresent(trigger: String) -> Bool {
-        guard !isCurrentlyPresented else { return false }
-        if trigger == HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER {
-            return true
-        }
-        guard Helium.config.paywallNotShownDiagnosticDisplayEnabled else { return false }
-        guard !UserDefaults.standard.bool(forKey: "heliumDiagnosticDoNotShowAgain") else { return false }
-        return true
     }
 
     @MainActor

--- a/Sources/Helium/HeliumCore/Models.swift
+++ b/Sources/Helium/HeliumCore/Models.swift
@@ -126,6 +126,10 @@ public struct HeliumFetchedConfig: Codable {
     var stripeProducts: [String: ServerProductPrice]?
     var stripeCustomerId: String?
     var enableProductionPaywallPreviews: Bool?
+
+    /// Kill switch for the paywall-not-shown diagnostic modal. Reasons that fire before the
+    /// on-launch response arrives cannot consult it, so this is best effort by design.
+    var diagnosticModalEnabled: Bool?
     
     var paddleProducts: [String: ServerProductPrice]?
     var paddleCustomerId: String?
@@ -805,7 +809,7 @@ public enum PaywallOpenViewType : String {
     case embedded = "embedded"
 }
 
-public enum PaywallUnavailableReason: String, Codable {
+public enum PaywallUnavailableReason: String, Codable, CaseIterable {
     case notInitialized
     case triggerHasNoPaywall
     case forceShowFallback

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -665,11 +665,25 @@ public class HeliumConfig {
     /// Adjust the text copy for the dialog that shows when a user attempts to restore purchases but does not have any to restore. You can also disable the dialog from showing.
     public let restorePurchasesDialog = RestorePurchaseConfig()
     
-    /// Controls whether a debug diagnostic view is shown when a paywall fails to display or is skipped.
-    /// Only applies in DEBUG builds. Defaults to `true`.
-    /// The debug view also contains a "Do not show again" checkbox that persists per-device via UserDefaults (resets on app delete).
-    /// Set this to `false` to disable the diagnostic view for all users in DEBUG builds.
+    /// Controls whether a diagnostic view is shown when a paywall fails to display or is skipped.
+    /// Defaults to `true`.
+    ///
+    /// Applies in DEBUG builds, and in TestFlight builds when
+    /// ``paywallNotShownDiagnosticEnabledInTestFlight`` is also set to `true`. App Store users
+    /// never see it.
+    /// The diagnostic view also contains a "Do not show again" checkbox that persists per-device via UserDefaults (resets on app delete).
+    /// Set this to `false` to disable the diagnostic view entirely.
     public var paywallNotShownDiagnosticDisplayEnabled: Bool = true
+
+    /// Controls whether the paywall diagnostic view is shown to TestFlight testers. Defaults to `false`.
+    ///
+    /// Off by default because TestFlight builds reach real testers, who would otherwise see a
+    /// full-screen developer modal — including for deliberate skips such as targeting rules or
+    /// already-subscribed users. Set it to `true` for internal builds whose testers can act on
+    /// the diagnosis.
+    ///
+    /// This has no effect on App Store builds, which never show the diagnostic view.
+    public var paywallNotShownDiagnosticEnabledInTestFlight: Bool = false
 
     /// Controls whether the triple-tap paywall previews gesture is enabled in DEBUG and TestFlight builds.
     ///

--- a/Tests/helium-swiftTests/DiagnosticContentMapperTests.swift
+++ b/Tests/helium-swiftTests/DiagnosticContentMapperTests.swift
@@ -5,6 +5,7 @@ final class DiagnosticContentMapperTests: XCTestCase {
 
     private let mapper = DiagnosticContentMapper()
     private let trigger = "onboarding_end"
+    private let fallbackGuideUrl = "https://docs.tryhelium.com/guides/fallback-bundle"
 
     private func context(paywallId: String? = nil, processors: WebCheckoutProcessors = []) -> DiagnosticContext {
         DiagnosticContext(trigger: trigger, paywallId: paywallId, webCheckoutProcessors: processors)
@@ -141,6 +142,13 @@ final class DiagnosticContentMapperTests: XCTestCase {
         XCTAssertEqual(mapper.mapSkip(.alreadyEntitled).title, "Already subscribed")
     }
 
+    func testAlreadyEntitledUsersLineStatesOnlyTheSplitOutcome() {
+        XCTAssertEqual(
+            mapper.mapSkip(.alreadyEntitled).usersWillSee,
+            "Subscribed users see no paywall; users without the entitlement see it normally."
+        )
+    }
+
     /// The trigger here is the second-try trigger, not the paywall the user is looking at.
     func testSecondTryMissNamesTheTriggerAndLinksTheEditor() {
         let content = content(for: .secondTryNoMatch)
@@ -243,5 +251,53 @@ final class DiagnosticContentMapperTests: XCTestCase {
             content(for: .alreadyPresented).title,
             "A Helium paywall is already being presented"
         )
+    }
+
+    // MARK: - Users-will-see matrix
+
+    /// A bundled fallback would have covered these users, so the outcome points at the guide.
+    func testFallbackCoverableReasonsSuggestTheFallbackGuide() {
+        let coverable: [PaywallUnavailableReason] = [
+            .triggerHasNoPaywall, .noProductsIOS,
+            .webCheckoutNoCustomUserId, .webCheckoutNotEnabled,
+            .paywallsNotDownloaded, .configFetchInProgress, .bundlesFetchInProgress,
+            .productsFetchInProgress, .paywallsDownloadFail,
+            .couldNotFindBundleUrl, .bundleFetchInvalidUrlDetected, .bundleFetchInvalidUrl,
+            .bundleFetch403, .bundleFetch404, .bundleFetch410, .bundleFetchCannotDecodeContent,
+            .webviewRenderFail, .bridgingError, .invalidResolvedConfig,
+        ]
+
+        for reason in coverable {
+            XCTAssertTrue(
+                content(for: reason).usersWillSee.contains(fallbackGuideUrl),
+                reason.rawValue
+            )
+        }
+    }
+
+    /// These stop the SDK before the loader runs, so no fallback could render either.
+    func testPreLoaderFailuresDoNotAdviseAFallback() {
+        for reason in [PaywallUnavailableReason.notInitialized, .noRootController] {
+            let usersWillSee = content(for: reason).usersWillSee
+            XCTAssertFalse(usersWillSee.contains(fallbackGuideUrl), reason.rawValue)
+            XCTAssertFalse(usersWillSee.contains("Consider adding"), reason.rawValue)
+            XCTAssertTrue(usersWillSee.contains("no fallback can load"), reason.rawValue)
+        }
+    }
+
+    /// Waiting on the download is the one miss real users experience with visible UI.
+    func testPaywallsStillDownloadingNamesTheLoadingState() {
+        XCTAssertTrue(
+            content(for: .paywallsNotDownloaded).usersWillSee.contains("loading indication")
+        )
+    }
+
+    /// notInitialized fires only when initialize() was never called, not while it is in flight —
+    /// `initialized` is set synchronously at the top of initialize().
+    func testNotInitializedBodySaysInitializeWasNeverCalled() {
+        let body = content(for: .notInitialized).body
+
+        XCTAssertTrue(body.contains("never called"))
+        XCTAssertFalse(body.contains("completed"))
     }
 }

--- a/Tests/helium-swiftTests/DiagnosticContentMapperTests.swift
+++ b/Tests/helium-swiftTests/DiagnosticContentMapperTests.swift
@@ -1,0 +1,247 @@
+import XCTest
+@testable import Helium
+
+final class DiagnosticContentMapperTests: XCTestCase {
+
+    private let mapper = DiagnosticContentMapper()
+    private let trigger = "onboarding_end"
+
+    private func context(paywallId: String? = nil, processors: WebCheckoutProcessors = []) -> DiagnosticContext {
+        DiagnosticContext(trigger: trigger, paywallId: paywallId, webCheckoutProcessors: processors)
+    }
+
+    private func content(for reason: PaywallUnavailableReason?) -> DiagnosticContent {
+        mapper.mapUnavailable(reason, context: context())
+    }
+
+    // MARK: - Forward compat: no raw codes leak into displayed prose
+
+    func testNoUnavailableReasonLeaksItsRawCodeIntoProse() {
+        for reason in PaywallUnavailableReason.allCases {
+            let content = content(for: reason)
+            for text in [content.title, content.body, content.usersWillSee] {
+                XCTAssertFalse(
+                    text.contains(reason.rawValue),
+                    "\(reason.rawValue) leaks its raw code into displayed prose: \(text)"
+                )
+            }
+        }
+    }
+
+    func testEveryUnavailableReasonIsFullyAuthored() {
+        for reason in PaywallUnavailableReason.allCases {
+            let content = content(for: reason)
+            XCTAssertFalse(content.title.isEmpty, "\(reason.rawValue) has a blank title")
+            XCTAssertFalse(content.body.isEmpty, "\(reason.rawValue) has a blank body")
+            XCTAssertFalse(content.usersWillSee.isEmpty, "\(reason.rawValue) has no users copy")
+            XCTAssertEqual(content.reasonCode, reason.rawValue)
+        }
+    }
+
+    /// The CTA owns the URL — body prose must never contain one.
+    func testNoBodyContainsAUrl() {
+        for reason in PaywallUnavailableReason.allCases {
+            XCTAssertFalse(
+                content(for: reason).body.contains("http"),
+                "\(reason.rawValue) embeds a URL in its body"
+            )
+        }
+    }
+
+    func testNilReasonRendersUnknownCopy() {
+        let content = content(for: nil)
+
+        XCTAssertEqual(content.category, .integrationError)
+        XCTAssertEqual(content.title, "The paywall couldn't be shown")
+        XCTAssertEqual(content.reasonCode, "unknown")
+        XCTAssertEqual(content.cta, .copyReport)
+    }
+
+    // MARK: - Category mapping
+
+    func testSkipReasonsAreExpected() {
+        for reason in [PaywallSkippedReason.targetingHoldout, .alreadyEntitled] {
+            XCTAssertEqual(mapper.mapSkip(reason).category, .expected)
+        }
+    }
+
+    func testSetupReasonsAreCategorisedAsSetup() {
+        let setup: [PaywallUnavailableReason] = [
+            .notInitialized, .noRootController, .triggerHasNoPaywall, .noProductsIOS,
+            .webCheckoutNoCustomUserId, .webCheckoutNotEnabled,
+        ]
+        for reason in setup {
+            XCTAssertEqual(content(for: reason).category, .setup, reason.rawValue)
+        }
+    }
+
+    func testNetworkReasonsAreCategorisedAsNetwork() {
+        let network: [PaywallUnavailableReason] = [
+            .paywallsNotDownloaded, .configFetchInProgress, .bundlesFetchInProgress,
+            .productsFetchInProgress, .paywallsDownloadFail,
+        ]
+        for reason in network {
+            XCTAssertEqual(content(for: reason).category, .network, reason.rawValue)
+        }
+    }
+
+    func testIntegrationErrorReasonsAreCategorisedAsIntegrationError() {
+        let errors: [PaywallUnavailableReason] = [
+            .couldNotFindBundleUrl, .bundleFetchInvalidUrlDetected, .bundleFetchInvalidUrl,
+            .bundleFetch403, .bundleFetch404, .bundleFetch410, .bundleFetchCannotDecodeContent,
+            .webviewRenderFail, .bridgingError, .secondTryNoMatch, .invalidResolvedConfig,
+        ]
+        for reason in errors {
+            XCTAssertEqual(content(for: reason).category, .integrationError, reason.rawValue)
+        }
+    }
+
+    func testIntentionalNonPresentationIsExpected() {
+        for reason in [PaywallUnavailableReason.alreadyPresented, .forceShowFallback] {
+            XCTAssertEqual(content(for: reason).category, .expected, reason.rawValue)
+        }
+    }
+
+    // MARK: - Product vocabulary
+
+    /// Helium sells digital in-app products and subscriptions. Generic commerce phrasing
+    /// ("nothing to sell", "items", "goods") misdescribes the product and misdirects the fix.
+    func testNoProductsCopyNamesInAppProductsAndTheStore() {
+        let content = content(for: .noProductsIOS)
+
+        XCTAssertTrue(content.body.contains("in-app products"))
+        XCTAssertTrue(content.body.contains("subscriptions"))
+        XCTAssertTrue(content.body.contains("App Store"))
+    }
+
+    func testNoCopyUsesGenericCommercePhrasing() {
+        let banned = ["nothing to sell", "items", "goods", "merchandise"]
+
+        for reason in PaywallUnavailableReason.allCases {
+            let content = content(for: reason)
+            let prose = "\(content.title) \(content.body) \(content.usersWillSee)".lowercased()
+            for phrase in banned {
+                XCTAssertFalse(prose.contains(phrase), "\(reason.rawValue) uses '\(phrase)'")
+            }
+        }
+    }
+
+    // MARK: - Reviewed copy
+
+    /// "Holdout" is internal vocabulary — the dashboard calls this "show no paywall".
+    func testTargetingSkipAvoidsHoldoutVocabulary() {
+        let content = mapper.mapSkip(.targetingHoldout)
+
+        XCTAssertEqual(content.title, "Paywall skipped")
+        let prose = "\(content.title) \(content.body) \(content.usersWillSee)".lowercased()
+        XCTAssertFalse(prose.contains("holdout"))
+    }
+
+    func testAlreadyEntitledTitleIsSimplified() {
+        XCTAssertEqual(mapper.mapSkip(.alreadyEntitled).title, "Already subscribed")
+    }
+
+    /// The trigger here is the second-try trigger, not the paywall the user is looking at.
+    func testSecondTryMissNamesTheTriggerAndLinksTheEditor() {
+        let content = content(for: .secondTryNoMatch)
+
+        XCTAssertEqual(content.title, "No second try paywall found")
+        XCTAssertTrue(content.body.contains("\"\(trigger)\""))
+        XCTAssertEqual(
+            content.cta,
+            .openUrl(label: "Open Paywall Editor", url: "https://app.tryhelium.com/paywalls")
+        )
+    }
+
+    /// The modal only presents when nothing rendered, so a forced fallback reaching it means the
+    /// fallback itself failed. The title and body state the cause — true in both the modal and the
+    /// fallback-shown log — while the outcome lives in the users line the modal alone renders.
+    func testForcedFallbackTitleStatesTheCauseAndTheUsersLineTheModalOnlyOutcome() {
+        let content = content(for: .forceShowFallback)
+
+        XCTAssertEqual(content.title, "Fallback paywall forced for this trigger")
+        XCTAssertTrue(content.body.contains("configured to force the bundled fallback"))
+        XCTAssertTrue(content.usersWillSee.contains("could not be rendered"))
+    }
+
+    // MARK: - Context enrichment
+
+    func testPaywallEditorCtaDeepLinksWhenThePaywallIdResolves() {
+        let content = mapper.mapUnavailable(.noProductsIOS, context: context(paywallId: "abc-123"))
+
+        XCTAssertEqual(
+            content.cta,
+            .openUrl(label: "Open Paywall Editor", url: "https://app.tryhelium.com/paywalls/abc-123")
+        )
+    }
+
+    func testPaywallEditorCtaUsesThePaywallListWhenTheIdIsUnknown() {
+        XCTAssertEqual(
+            content(for: .noProductsIOS).cta,
+            .openUrl(label: "Open Paywall Editor", url: "https://app.tryhelium.com/paywalls")
+        )
+    }
+
+    func testWebCheckoutNotEnabledAppendsTheEnabledProcessors() {
+        let content = mapper.mapUnavailable(
+            .webCheckoutNotEnabled,
+            context: context(processors: .stripe)
+        )
+
+        XCTAssertTrue(content.body.contains("Currently enabled: stripe."))
+    }
+
+    /// The empty set is the config default, so this is the state most likely to produce the reason.
+    func testWebCheckoutNotEnabledOmitsProcessorsWhenNoneAreEnabled() {
+        let content = mapper.mapUnavailable(
+            .webCheckoutNotEnabled,
+            context: context(processors: [])
+        )
+
+        XCTAssertFalse(content.body.contains("Currently enabled"))
+    }
+
+    /// The remediation must name an API that exists — `Helium.identify.userId` is the public
+    /// surface for setting a custom user ID.
+    func testWebCheckoutUserIdCopyNamesTheIdentifyApi() {
+        XCTAssertTrue(
+            content(for: .webCheckoutNoCustomUserId).body.contains("Helium.identify.userId")
+        )
+    }
+
+    // MARK: - CTAs
+
+    func testUnactionableFailuresCopyTheReport() {
+        let errors: [PaywallUnavailableReason] = [
+            .couldNotFindBundleUrl, .webviewRenderFail, .bridgingError, .invalidResolvedConfig,
+        ]
+        for reason in errors {
+            XCTAssertEqual(content(for: reason).cta, .copyReport, reason.rawValue)
+        }
+    }
+
+    func testTargetingSkipOpensWorkflows() {
+        XCTAssertEqual(
+            mapper.mapSkip(.targetingHoldout).cta,
+            .openUrl(label: "Open Workflows", url: "https://app.tryhelium.com/workflows")
+        )
+    }
+
+    func testAlreadyEntitledOpensEntitlementDocs() {
+        XCTAssertEqual(
+            mapper.mapSkip(.alreadyEntitled).cta,
+            .openUrl(
+                label: "Entitlement Docs",
+                url: "https://docs.tryhelium.com/sdk/quickstart-ios#checking-subscription-status-%26-entitlements"
+            )
+        )
+    }
+
+    /// Existing grep-based log workflows key off this wording.
+    func testAlreadyPresentedKeepsItsExistingLogWording() {
+        XCTAssertEqual(
+            content(for: .alreadyPresented).title,
+            "A Helium paywall is already being presented"
+        )
+    }
+}

--- a/Tests/helium-swiftTests/DiagnosticLogLineMapperTests.swift
+++ b/Tests/helium-swiftTests/DiagnosticLogLineMapperTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import Helium
+
+final class DiagnosticLogLineMapperTests: XCTestCase {
+
+    private let contentMapper = DiagnosticContentMapper()
+    private let mapper = DiagnosticLogLineMapper()
+
+    private func logLine(for reason: PaywallUnavailableReason) -> String {
+        let content = contentMapper.mapUnavailable(
+            reason,
+            context: DiagnosticContext(trigger: "onboarding_end")
+        )
+        return mapper.map(content)
+    }
+
+    func testUrlCtaCarriesTheReasonCodeAndTheUrl() {
+        let line = logLine(for: .triggerHasNoPaywall)
+
+        XCTAssertTrue(line.hasPrefix("[triggerHasNoPaywall] "))
+        XCTAssertTrue(line.contains("No paywall is connected to this trigger."))
+        XCTAssertTrue(line.hasSuffix("https://app.tryhelium.com/workflows"))
+    }
+
+    func testCopyReportCtaAppendsNoUrl() {
+        let line = logLine(for: .webviewRenderFail)
+
+        XCTAssertTrue(line.hasPrefix("[webviewRenderFail] The paywall failed to render."))
+        XCTAssertFalse(line.contains("http"))
+    }
+
+    /// Existing grep-based log workflows key off this wording.
+    func testAlreadyPresentedKeepsItsExistingWording() {
+        XCTAssertTrue(
+            logLine(for: .alreadyPresented).contains("A Helium paywall is already being presented")
+        )
+    }
+
+    func testEveryReasonLeadsWithItsBracketedReasonCode() {
+        for reason in PaywallUnavailableReason.allCases {
+            XCTAssertTrue(
+                logLine(for: reason).hasPrefix("[\(reason.rawValue)] "),
+                reason.rawValue
+            )
+        }
+    }
+}

--- a/Tests/helium-swiftTests/DiagnosticReportMapperTests.swift
+++ b/Tests/helium-swiftTests/DiagnosticReportMapperTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import Helium
+
+final class DiagnosticReportMapperTests: XCTestCase {
+
+    private let contentMapper = DiagnosticContentMapper()
+    private let mapper = DiagnosticReportMapper()
+
+    /// The format is shared verbatim with the Android SDK so support tooling can parse either.
+    func testReportMatchesTheCrossPlatformFormat() {
+        let content = contentMapper.mapUnavailable(
+            .webviewRenderFail,
+            context: DiagnosticContext(trigger: "onboarding_end")
+        )
+
+        XCTAssertEqual(
+            mapper.map(content, trigger: "onboarding_end", sdkVersion: "1.2.3"),
+            """
+            Helium paywall diagnostic
+            trigger: onboarding_end
+            reason: webviewRenderFail (integrationError)
+            sdk: helium-swift 1.2.3
+            The paywall failed to render — The paywall's web view failed to render, or could not communicate with the SDK. Retry once; if it reproduces, copy the diagnostic report and contact Helium.
+            """
+        )
+    }
+
+    func testReportNamesTheNetworkCategory() {
+        let content = contentMapper.mapUnavailable(
+            .paywallsDownloadFail,
+            context: DiagnosticContext(trigger: "checkout")
+        )
+
+        XCTAssertEqual(
+            mapper.map(content, trigger: "checkout", sdkVersion: "9.9.9"),
+            """
+            Helium paywall diagnostic
+            trigger: checkout
+            reason: paywallsDownloadFail (network)
+            sdk: helium-swift 9.9.9
+            Paywalls failed to download — Paywalls failed to download. Check this device's connection and your Helium API key.
+            """
+        )
+    }
+}

--- a/Tests/helium-swiftTests/HeliumDiagnosticGateTests.swift
+++ b/Tests/helium-swiftTests/HeliumDiagnosticGateTests.swift
@@ -10,6 +10,7 @@ final class HeliumDiagnosticGateTests: XCTestCase {
         reason: PaywallUnavailableReason? = nil,
         fallbackShown: Bool = false,
         isPreviewTrigger: Bool = false,
+        isDebugBuild: Bool = false,
         environment: AppReceiptsHelper.Environment = .debug,
         displayEnabled: Bool = true,
         enabledInTestFlight: Bool = true,
@@ -20,6 +21,7 @@ final class HeliumDiagnosticGateTests: XCTestCase {
             unavailableReason: reason ?? showableReason,
             fallbackShown: fallbackShown,
             isPreviewTrigger: isPreviewTrigger,
+            isDebugBuild: isDebugBuild,
             environment: environment,
             displayEnabled: displayEnabled,
             enabledInTestFlight: enabledInTestFlight,
@@ -59,6 +61,7 @@ final class HeliumDiagnosticGateTests: XCTestCase {
                 unavailableReason: nil,
                 fallbackShown: false,
                 isPreviewTrigger: false,
+                isDebugBuild: true,
                 environment: .debug,
                 displayEnabled: true,
                 enabledInTestFlight: true,
@@ -98,10 +101,10 @@ final class HeliumDiagnosticGateTests: XCTestCase {
         XCTAssertFalse(shouldShow(environment: .sandbox, displayEnabled: false))
     }
 
-    // MARK: - Environment gate
+    // MARK: - Build / environment gate
 
-    func testDebugShows() {
-        XCTAssertTrue(shouldShow(environment: .debug))
+    func testDebugBuildShows() {
+        XCTAssertTrue(shouldShow(isDebugBuild: true, environment: .debug))
     }
 
     /// An App Store build structurally cannot show the modal.
@@ -115,9 +118,16 @@ final class HeliumDiagnosticGateTests: XCTestCase {
         XCTAssertFalse(shouldShow(environment: .sandbox, enabledInTestFlight: false))
     }
 
-    /// Leaving the TestFlight opt-in off must not silence DEBUG diagnostics.
-    func testTestFlightOptInOffDoesNotAffectDebug() {
-        XCTAssertTrue(shouldShow(environment: .debug, enabledInTestFlight: false))
+    /// A .debug receipt environment without a DEBUG-compiled build — a release-configuration
+    /// simulator run — is gated by the same opt-in as TestFlight.
+    func testDebugEnvironmentInAReleaseBuildRequiresTheOptIn() {
+        XCTAssertTrue(shouldShow(isDebugBuild: false, environment: .debug, enabledInTestFlight: true))
+        XCTAssertFalse(shouldShow(isDebugBuild: false, environment: .debug, enabledInTestFlight: false))
+    }
+
+    /// Leaving the TestFlight opt-in off must not silence DEBUG-build diagnostics.
+    func testTestFlightOptInOffDoesNotAffectDebugBuilds() {
+        XCTAssertTrue(shouldShow(isDebugBuild: true, environment: .debug, enabledInTestFlight: false))
     }
 
     // MARK: - Server kill switch

--- a/Tests/helium-swiftTests/HeliumDiagnosticGateTests.swift
+++ b/Tests/helium-swiftTests/HeliumDiagnosticGateTests.swift
@@ -1,0 +1,156 @@
+import XCTest
+@testable import Helium
+
+final class HeliumDiagnosticGateTests: XCTestCase {
+
+    /// A reason that is never suppressed, so each test isolates the gate under exercise.
+    private let showableReason = PaywallUnavailableReason.triggerHasNoPaywall
+
+    private func shouldShow(
+        reason: PaywallUnavailableReason? = nil,
+        fallbackShown: Bool = false,
+        isPreviewTrigger: Bool = false,
+        environment: AppReceiptsHelper.Environment = .debug,
+        displayEnabled: Bool = true,
+        enabledInTestFlight: Bool = true,
+        serverFlagEnabled: Bool = true,
+        doNotShowAgain: @escaping () -> Bool = { false }
+    ) -> Bool {
+        HeliumDiagnosticGate.shouldShow(
+            unavailableReason: reason ?? showableReason,
+            fallbackShown: fallbackShown,
+            isPreviewTrigger: isPreviewTrigger,
+            environment: environment,
+            displayEnabled: displayEnabled,
+            enabledInTestFlight: enabledInTestFlight,
+            serverFlagEnabled: serverFlagEnabled,
+            doNotShowAgain: doNotShowAgain
+        )
+    }
+
+    // MARK: - Suppression
+
+    /// A paywall is already on screen, so a modal would cover the thing under inspection.
+    func testAlreadyPresentedNeverShows() {
+        XCTAssertFalse(shouldShow(reason: .alreadyPresented))
+    }
+
+    func testAlreadyPresentedIsSuppressedEvenForThePreviewTrigger() {
+        XCTAssertFalse(shouldShow(reason: .alreadyPresented, isPreviewTrigger: true))
+    }
+
+    /// A failed second try leaves a dead button behind a live paywall, and a forced fallback that
+    /// didn't render leaves a blank screen. Both are worth interrupting for.
+    func testSecondTryMissAndForcedFallbackShow() {
+        XCTAssertTrue(shouldShow(reason: .secondTryNoMatch))
+        XCTAssertTrue(shouldShow(reason: .forceShowFallback))
+    }
+
+    func testOnlyAlreadyPresentedIsSuppressed() {
+        let suppressed = PaywallUnavailableReason.allCases.filter { !shouldShow(reason: $0) }
+
+        XCTAssertEqual(suppressed, [.alreadyPresented])
+    }
+
+    /// A skip passes a nil reason and is never suppressed.
+    func testSkipIsNotSuppressed() {
+        XCTAssertTrue(
+            HeliumDiagnosticGate.shouldShow(
+                unavailableReason: nil,
+                fallbackShown: false,
+                isPreviewTrigger: false,
+                environment: .debug,
+                displayEnabled: true,
+                enabledInTestFlight: true,
+                serverFlagEnabled: true,
+                doNotShowAgain: { false }
+            )
+        )
+    }
+
+    // MARK: - Modal / badge exclusivity
+
+    /// The invariant that makes the modal's "no fallback was available" copy truthful.
+    func testARenderedFallbackNeverShowsTheModal() {
+        XCTAssertFalse(shouldShow(fallbackShown: true))
+        XCTAssertFalse(shouldShow(fallbackShown: true, isPreviewTrigger: true))
+    }
+
+    // MARK: - Preview bypass
+
+    func testPreviewTriggerShowsEvenWhenEveryOtherGateIsClosed() {
+        XCTAssertTrue(
+            shouldShow(
+                isPreviewTrigger: true,
+                environment: .production,
+                displayEnabled: false,
+                enabledInTestFlight: false,
+                serverFlagEnabled: false,
+                doNotShowAgain: { true }
+            )
+        )
+    }
+
+    // MARK: - Master flag
+
+    func testMasterFlagOffNeverShows() {
+        XCTAssertFalse(shouldShow(displayEnabled: false))
+        XCTAssertFalse(shouldShow(environment: .sandbox, displayEnabled: false))
+    }
+
+    // MARK: - Environment gate
+
+    func testDebugShows() {
+        XCTAssertTrue(shouldShow(environment: .debug))
+    }
+
+    /// An App Store build structurally cannot show the modal.
+    func testProductionNeverShows() {
+        XCTAssertFalse(shouldShow(environment: .production))
+        XCTAssertFalse(shouldShow(environment: .production, enabledInTestFlight: true))
+    }
+
+    func testTestFlightShowsOnlyWhenOptedIn() {
+        XCTAssertTrue(shouldShow(environment: .sandbox, enabledInTestFlight: true))
+        XCTAssertFalse(shouldShow(environment: .sandbox, enabledInTestFlight: false))
+    }
+
+    /// Leaving the TestFlight opt-in off must not silence DEBUG diagnostics.
+    func testTestFlightOptInOffDoesNotAffectDebug() {
+        XCTAssertTrue(shouldShow(environment: .debug, enabledInTestFlight: false))
+    }
+
+    // MARK: - Server kill switch
+
+    func testServerKillSwitchOffNeverShows() {
+        XCTAssertFalse(shouldShow(serverFlagEnabled: false))
+        XCTAssertFalse(shouldShow(environment: .sandbox, serverFlagEnabled: false))
+    }
+
+    // MARK: - Do-not-show-again
+
+    func testDevicePrefSuppresses() {
+        XCTAssertFalse(shouldShow(doNotShowAgain: { true }))
+    }
+
+    func testEveryGateOpenShows() {
+        XCTAssertTrue(shouldShow())
+    }
+
+    /// The preference is backed by storage, so an earlier closed gate must short-circuit before it
+    /// is ever read.
+    func testAnEarlierClosedGateNeverReadsTheDevicePref() {
+        var reads = 0
+        let counting: () -> Bool = { reads += 1; return false }
+
+        _ = shouldShow(reason: .alreadyPresented, doNotShowAgain: counting)
+        _ = shouldShow(fallbackShown: true, doNotShowAgain: counting)
+        _ = shouldShow(displayEnabled: false, doNotShowAgain: counting)
+        _ = shouldShow(environment: .production, doNotShowAgain: counting)
+        _ = shouldShow(serverFlagEnabled: false, doNotShowAgain: counting)
+        // The preview bypass opens the gate without consulting the preference either.
+        _ = shouldShow(isPreviewTrigger: true, doNotShowAgain: counting)
+
+        XCTAssertEqual(reads, 0)
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes when full-screen diagnostics appear in non-DEBUG builds (TestFlight opt-in) and touches paywall presentation/logging paths, though App Store users remain blocked and behavior is heavily unit-tested.
> 
> **Overview**
> Replaces URL-scraping and hand-written log strings with a **structured diagnostic layer**: reason → `DiagnosticContent` (category, title, body, “what real users see”, explicit CTA), then shared projections for **logs**, **support reports** (Android-aligned format), and the **modal UI** (severity banner, trigger pill, copy-report).
> 
> **Visibility** is centralized in `HeliumDiagnosticGate`: no modal when a fallback rendered or for `.alreadyPresented`; dashboard preview bypasses most gates; DEBUG always eligible; TestFlight/sandbox/release-simulator need `paywallNotShownDiagnosticEnabledInTestFlight`; production App Store never shows; plus master flag, server `diagnosticModalEnabled`, and per-device “do not show again.” Skips now use the same funnel as unavailable reasons.
> 
> **Supporting changes:** typed `AppReceiptsHelper.environment` with atomic `appTransactionEnvironment`; `@HeliumAtomic` on hot config fields read from background threads; control panel dev detection uses the typed environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d43688614495519ebceb5edfb869932ccd88467e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced structured “paywall not shown” diagnostics with categorized banners, curated copy, and CTAs (open URL or copy report), plus a per-device “Do not show again” toggle.
  * Added TestFlight visibility control and a best-effort kill switch for the diagnostic modal.
* **Bug Fixes**
  * Improved environment (debug/sandbox/production) detection and applied updated behavior consistently across diagnostic and control panel logic.
  * Hardened diagnostic URL handling to avoid unsafe opens.
* **Tests**
  * Added automated coverage for diagnostic content/log/report mapping and end-to-end visibility/gating rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->