### PR TITLE
[HEL-6146] | Fix triple tap opening the wrong paywall at checkout 

### DIFF
--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
@@ -2,7 +2,6 @@ import Foundation
 
 struct HeliumControlPanelResponse: Codable {
     let productIds: [String]
-    let stripeProductIds: [String]?
     let paywalls: [HeliumPaywallPreviewEntry]
 }
 
@@ -23,6 +22,7 @@ struct HeliumPaywallPreviewVersion: Codable, Identifiable {
     let stripeProductIds: [String]?
     let paddleProductIds: [String]?
     let webPaddleProductIds: [String]?
+    let webPaywallBundleUrl: String?
     let lastSavedAt: String?
     var id: String { versionId }
 

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
@@ -257,7 +257,8 @@ struct HeliumControlPanelView: View {
                     productIds: version.productIds ?? [],
                     productIdsStripe: version.stripeProductIds ?? [],
                     productIdsPaddle: version.paddleProductIds ?? [],
-                    productIdsPaddleWeb: version.webPaddleProductIds ?? []
+                    productIdsPaddleWeb: version.webPaddleProductIds ?? [],
+                    webPaywallBundleUrl: version.webPaywallBundleUrl
                 )
 
                 await MainActor.run { loadingVersionId = nil }

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -1092,13 +1092,6 @@ public class HeliumFetchedConfigManager {
         if var configJSON = fetchedConfigJSON {
             var sourceJSON = configJSON["triggerToPaywalls"][sourceTrigger]
             sourceJSON["resolvedConfig"]["baseStack"]["componentProps"]["bundleURL"] = JSON(bundleUrl)
-            if sourceJSON["additionalPaywallFields"].exists() {
-                if let webPaywallBundleUrl, !webPaywallBundleUrl.isEmpty {
-                    sourceJSON["additionalPaywallFields"]["webPaywallBundleUrl"] = JSON(webPaywallBundleUrl)
-                } else {
-                    sourceJSON["additionalPaywallFields"]["webPaywallBundleUrl"] = JSON.null
-                }
-            }
             configJSON["triggerToPaywalls"][Self.HELIUM_PREVIEW_TRIGGER] = sourceJSON
             fetchedConfigJSON = configJSON
         }

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -214,8 +214,9 @@ public class HeliumFetchedConfigManager {
     }
 
     /// Inject config for testing purposes only. Accessible via @testable import.
-    func injectConfigForTesting(_ config: HeliumFetchedConfig) {
+    func injectConfigForTesting(_ config: HeliumFetchedConfig, json: JSON? = nil) {
         self.fetchedConfig = config
+        self.fetchedConfigJSON = json
         self._downloadStatus = .downloadSuccess
     }
 
@@ -1027,6 +1028,7 @@ public class HeliumFetchedConfigManager {
         productIdsStripe: [String],
         productIdsPaddle: [String],
         productIdsPaddleWeb: [String],
+        webPaywallBundleUrl: String? = nil,
     ) throws {
         guard var config = fetchedConfig else {
             throw HeliumControlPanelError.noConfigAvailable
@@ -1054,6 +1056,15 @@ public class HeliumFetchedConfigManager {
         // Update additionalPaywallFields
         var additionalFields = previewPaywallInfo.additionalPaywallFields ?? JSON([:])
         additionalFields["paywallBundleUrl"] = JSON(bundleUrl)
+        // Use the previewed version's own web checkout URL. When the preview response
+        // doesn't provide one, the value inherited from the source trigger would open the
+        // wrong web paywall at checkout, so null it and let app2web checkout fail
+        // explicitly (webPaywallBundleUrlMissing) instead.
+        if let webPaywallBundleUrl, !webPaywallBundleUrl.isEmpty {
+            additionalFields["webPaywallBundleUrl"] = JSON(webPaywallBundleUrl)
+        } else {
+            additionalFields["webPaywallBundleUrl"] = JSON.null
+        }
         previewPaywallInfo.additionalPaywallFields = additionalFields
 
         // Update product IDs
@@ -1081,6 +1092,13 @@ public class HeliumFetchedConfigManager {
         if var configJSON = fetchedConfigJSON {
             var sourceJSON = configJSON["triggerToPaywalls"][sourceTrigger]
             sourceJSON["resolvedConfig"]["baseStack"]["componentProps"]["bundleURL"] = JSON(bundleUrl)
+            if sourceJSON["additionalPaywallFields"].exists() {
+                if let webPaywallBundleUrl, !webPaywallBundleUrl.isEmpty {
+                    sourceJSON["additionalPaywallFields"]["webPaywallBundleUrl"] = JSON(webPaywallBundleUrl)
+                } else {
+                    sourceJSON["additionalPaywallFields"]["webPaywallBundleUrl"] = JSON.null
+                }
+            }
             configJSON["triggerToPaywalls"][Self.HELIUM_PREVIEW_TRIGGER] = sourceJSON
             fetchedConfigJSON = configJSON
         }

--- a/Tests/helium-swiftTests/Helpers/TestHelpers.swift
+++ b/Tests/helium-swiftTests/Helpers/TestHelpers.swift
@@ -208,8 +208,8 @@ func makeTestConfig(
     )
 }
 
-func injectConfig(_ config: HeliumFetchedConfig) {
-    HeliumFetchedConfigManager.shared.injectConfigForTesting(config)
+func injectConfig(_ config: HeliumFetchedConfig, json: JSON? = nil) {
+    HeliumFetchedConfigManager.shared.injectConfigForTesting(config, json: json)
 }
 
 func makeTestSession(

--- a/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
+++ b/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
@@ -154,20 +154,13 @@ final class PreviewTriggerConfigTests: XCTestCase {
         XCTAssertEqual(previewInfo?.extractedBundleUrl, previewBundleUrl)
     }
 
-    func testJsonMirrorScrubsWebCheckoutUrlAndUpdatesBundleUrl() throws {
+    func testJsonMirrorUpdatesBundleUrl() throws {
         let config = makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()])
         let configJSON = try JSON(data: JSONEncoder().encode(config))
         injectConfig(config, json: configJSON)
 
         try setPreviewConfig()
 
-        let mirror = HeliumFetchedConfigManager.shared.fetchedConfigJSON?["triggerToPaywalls"][previewTrigger]
-        XCTAssertNotNil(mirror)
-        XCTAssertEqual(
-            mirror?["resolvedConfig"]["baseStack"]["componentProps"]["bundleURL"].string,
-            previewBundleUrl
-        )
-        XCTAssertNil(mirror?["additionalPaywallFields"]["webPaywallBundleUrl"].string)
         XCTAssertEqual(
             HeliumFetchedConfigManager.shared.getResolvedConfigJSONForTrigger(previewTrigger)?["baseStack"]["componentProps"]["bundleURL"].string,
             previewBundleUrl
@@ -198,21 +191,6 @@ final class PreviewTriggerConfigTests: XCTestCase {
         XCTAssertEqual(previewInfo?.productsOfferedIOS, ["second.product"])
         // First preview's checkout URL must not leak into the second
         XCTAssertNil(previewInfo?.webPaywallBundleUrl)
-    }
-
-    func testJsonMirrorUsesProvidedWebCheckoutUrl() throws {
-        let config = makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()])
-        let configJSON = try JSON(data: JSONEncoder().encode(config))
-        injectConfig(config, json: configJSON)
-        let previewWebCheckoutUrl = "https://bundles-staging.clickthrough.to/x/bundle_1778610753360.html"
-
-        try setPreviewConfig(webPaywallBundleUrl: previewWebCheckoutUrl)
-
-        let mirror = HeliumFetchedConfigManager.shared.fetchedConfigJSON?["triggerToPaywalls"][previewTrigger]
-        XCTAssertEqual(
-            mirror?["additionalPaywallFields"]["webPaywallBundleUrl"].string,
-            previewWebCheckoutUrl
-        )
     }
 
     func testThrowsWhenNoConfigAvailable() {

--- a/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
+++ b/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
@@ -1,0 +1,320 @@
+import XCTest
+@testable import Helium
+
+/// Tests for `HeliumFetchedConfigManager.setPreviewTriggerConfig`, which builds the
+/// config for the paywall preview control panel by cloning an existing trigger's
+/// config and overriding selected fields.
+final class PreviewTriggerConfigTests: XCTestCase {
+
+    private let previewTrigger = HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER
+    private let donorBundleUrl = "https://cdn.example.com/bundles/bundle_donor123.html"
+    private let donorWebCheckoutUrl = "https://checkout.example.com/donor-web-paywall"
+    private let previewBundleUrl = "https://cdn.example.com/bundles/bundle_preview456.html"
+
+    override func setUp() {
+        super.setUp()
+        HeliumFetchedConfigManager.reset()
+    }
+
+    override func tearDown() {
+        HeliumFetchedConfigManager.reset()
+        super.tearDown()
+    }
+
+    private func makeDonorPaywallInfo() -> HeliumPaywallInfo {
+        var info = makeTestPaywallInfo(paywallName: "donor_paywall", products: ["donor.product"])
+        info.resolvedConfig = AnyCodable([
+            "baseStack": [
+                "componentProps": [
+                    "bundleURL": donorBundleUrl
+                ]
+            ]
+        ] as [String: Any])
+        info.additionalPaywallFields = JSON([
+            "paywallBundleUrl": donorBundleUrl,
+            "webPaywallBundleUrl": donorWebCheckoutUrl,
+        ])
+        info.productsOfferedStripe = ["donor_stripe:price_1"]
+        info.productsOfferedPaddle = ["donor_paddle:pri_1"]
+        info.webProductsOfferedPaddle = ["donor_paddle_web:pri_2"]
+        info.forceShowFallback = true
+        return info
+    }
+
+    private func setPreviewConfig(
+        productIds: [String] = ["preview.product"],
+        productIdsStripe: [String] = [],
+        productIdsPaddle: [String] = [],
+        productIdsPaddleWeb: [String] = [],
+        webPaywallBundleUrl: String? = nil
+    ) throws {
+        try HeliumFetchedConfigManager.shared.setPreviewTriggerConfig(
+            bundleId: "preview456",
+            bundleUrl: previewBundleUrl,
+            bundleHtml: "<html>preview</html>",
+            productIds: productIds,
+            productIdsStripe: productIdsStripe,
+            productIdsPaddle: productIdsPaddle,
+            productIdsPaddleWeb: productIdsPaddleWeb,
+            webPaywallBundleUrl: webPaywallBundleUrl
+        )
+    }
+
+    private var previewInfo: HeliumPaywallInfo? {
+        HeliumFetchedConfigManager.shared.fetchedConfig?.triggerToPaywalls[previewTrigger]
+    }
+
+    func testPreviewDoesNotInheritWebCheckoutUrl() throws {
+        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
+
+        try setPreviewConfig()
+
+        XCTAssertNotNil(previewInfo)
+        XCTAssertNil(previewInfo?.webPaywallBundleUrl)
+    }
+
+    func testPreviewUsesProvidedWebCheckoutUrl() throws {
+        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
+        let previewWebCheckoutUrl = "https://bundles-staging.clickthrough.to/x/bundle_1778610753360.html"
+
+        try setPreviewConfig(webPaywallBundleUrl: previewWebCheckoutUrl)
+
+        XCTAssertEqual(previewInfo?.webPaywallBundleUrl, previewWebCheckoutUrl)
+    }
+
+    func testPreviewTreatsEmptyWebCheckoutUrlAsMissing() throws {
+        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
+
+        try setPreviewConfig(webPaywallBundleUrl: "")
+
+        XCTAssertNil(previewInfo?.webPaywallBundleUrl)
+    }
+
+    func testDonorTriggerKeepsItsWebCheckoutUrl() throws {
+        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
+
+        try setPreviewConfig()
+
+        let donorInfo = HeliumFetchedConfigManager.shared.fetchedConfig?.triggerToPaywalls["a_trigger"]
+        XCTAssertEqual(donorInfo?.webPaywallBundleUrl, donorWebCheckoutUrl)
+    }
+
+    func testPreviewUsesProvidedBundleUrlAndProducts() throws {
+        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
+
+        try setPreviewConfig(
+            productIds: ["preview.product"],
+            productIdsStripe: ["preview_stripe:price_9"],
+            productIdsPaddle: [],
+            productIdsPaddleWeb: ["preview_paddle_web:pri_9"]
+        )
+
+        XCTAssertEqual(previewInfo?.extractedBundleUrl, previewBundleUrl)
+        XCTAssertEqual(previewInfo?.productsOfferedIOS, ["preview.product"])
+        XCTAssertEqual(previewInfo?.productsOfferedStripe, ["preview_stripe:price_9"])
+        XCTAssertEqual(previewInfo?.productsOfferedPaddle, [])
+        XCTAssertEqual(previewInfo?.webProductsOfferedPaddle, ["preview_paddle_web:pri_9"])
+        XCTAssertEqual(
+            HeliumFetchedConfigManager.shared.fetchedConfig?.bundles?["preview456"],
+            "<html>preview</html>"
+        )
+    }
+
+    func testPreviewClearsForceShowFallback() throws {
+        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
+
+        try setPreviewConfig()
+
+        XCTAssertNil(previewInfo?.forceShowFallback)
+    }
+
+    func testPreviewClonesAlphabeticallyFirstTrigger() throws {
+        var otherInfo = makeTestPaywallInfo(paywallName: "other_paywall")
+        otherInfo.resolvedConfig = AnyCodable([
+            "baseStack": ["componentProps": ["bundleURL": "https://cdn.example.com/bundles/bundle_other.html"]]
+        ] as [String: Any])
+        injectConfig(makeTestConfig(triggers: [
+            "b_trigger": otherInfo,
+            "a_trigger": makeDonorPaywallInfo(),
+        ]))
+
+        try setPreviewConfig()
+
+        XCTAssertEqual(previewInfo?.paywallTemplateName, "donor_paywall")
+    }
+
+    func testPreviewWithoutAdditionalFieldsOnDonor() throws {
+        var donor = makeDonorPaywallInfo()
+        donor.additionalPaywallFields = nil
+        injectConfig(makeTestConfig(triggers: ["a_trigger": donor]))
+
+        try setPreviewConfig()
+
+        XCTAssertNil(previewInfo?.webPaywallBundleUrl)
+        XCTAssertEqual(previewInfo?.extractedBundleUrl, previewBundleUrl)
+    }
+
+    func testJsonMirrorScrubsWebCheckoutUrlAndUpdatesBundleUrl() throws {
+        let config = makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()])
+        let configJSON = try JSON(data: JSONEncoder().encode(config))
+        injectConfig(config, json: configJSON)
+
+        try setPreviewConfig()
+
+        let mirror = HeliumFetchedConfigManager.shared.fetchedConfigJSON?["triggerToPaywalls"][previewTrigger]
+        XCTAssertNotNil(mirror)
+        XCTAssertEqual(
+            mirror?["resolvedConfig"]["baseStack"]["componentProps"]["bundleURL"].string,
+            previewBundleUrl
+        )
+        XCTAssertNil(mirror?["additionalPaywallFields"]["webPaywallBundleUrl"].string)
+        XCTAssertEqual(
+            HeliumFetchedConfigManager.shared.getResolvedConfigJSONForTrigger(previewTrigger)?["baseStack"]["componentProps"]["bundleURL"].string,
+            previewBundleUrl
+        )
+    }
+
+    func testSecondPreviewClonesOriginalTriggerNotThePreview() throws {
+        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
+        let firstWebCheckoutUrl = "https://bundles-staging.clickthrough.to/x/bundle_first.html"
+
+        try setPreviewConfig(webPaywallBundleUrl: firstWebCheckoutUrl)
+        // Simulates backing out of the first preview and selecting another version,
+        // now that helium_preview_trigger itself is in triggerToPaywalls.
+        try HeliumFetchedConfigManager.shared.setPreviewTriggerConfig(
+            bundleId: "preview789",
+            bundleUrl: "https://cdn.example.com/bundles/bundle_preview789.html",
+            bundleHtml: "<html>second</html>",
+            productIds: ["second.product"],
+            productIdsStripe: [],
+            productIdsPaddle: [],
+            productIdsPaddleWeb: [],
+            webPaywallBundleUrl: nil
+        )
+
+        // Cloned from the original trigger, not from the first preview
+        XCTAssertEqual(previewInfo?.paywallTemplateName, "donor_paywall")
+        XCTAssertEqual(previewInfo?.extractedBundleUrl, "https://cdn.example.com/bundles/bundle_preview789.html")
+        XCTAssertEqual(previewInfo?.productsOfferedIOS, ["second.product"])
+        // First preview's checkout URL must not leak into the second
+        XCTAssertNil(previewInfo?.webPaywallBundleUrl)
+    }
+
+    func testJsonMirrorUsesProvidedWebCheckoutUrl() throws {
+        let config = makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()])
+        let configJSON = try JSON(data: JSONEncoder().encode(config))
+        injectConfig(config, json: configJSON)
+        let previewWebCheckoutUrl = "https://bundles-staging.clickthrough.to/x/bundle_1778610753360.html"
+
+        try setPreviewConfig(webPaywallBundleUrl: previewWebCheckoutUrl)
+
+        let mirror = HeliumFetchedConfigManager.shared.fetchedConfigJSON?["triggerToPaywalls"][previewTrigger]
+        XCTAssertEqual(
+            mirror?["additionalPaywallFields"]["webPaywallBundleUrl"].string,
+            previewWebCheckoutUrl
+        )
+    }
+
+    func testThrowsWhenNoConfigAvailable() {
+        XCTAssertThrowsError(try setPreviewConfig()) { error in
+            guard case HeliumControlPanelError.noConfigAvailable = error else {
+                return XCTFail("Expected noConfigAvailable, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - /paywall-previews response decoding
+
+    /// Trimmed real staging response shape (see HEL-6146 contract doc).
+    private let previewsResponseJSON = """
+    {
+      "productIds": ["yearly_2999", "trial_monthly_499"],
+      "paywalls": [
+        {
+          "paywallUuid": "f3e96335-f7df-4f28-b439-9506d37c793e",
+          "paywallName": "Paddle Regular Paywall Test 1",
+          "versions": [
+            {
+              "versionId": "1d9626d4-a8c8-40c1-8a59-c63c6f2b521e",
+              "versionStatus": "published",
+              "versionNumber": 6,
+              "bundleUrl": "https://bundles-staging.heliumpaywall.com/x/bundle_1778611087914.html",
+              "previewUrl": "https://res.cloudinary.com/x/screenshot.png",
+              "productIds": ["yearly_2999", "trial_monthly_499"],
+              "stripeProductIds": [],
+              "paddleProductIds": ["pro_01knraky336brhcn1r0atkk2ac:pri_01knrarqkpxk9kvf785tny0y5e"],
+              "webPaddleProductIds": ["pro_01kppzadma4mq2yx61e5spzgxe:pri_01kpsgnvzp69jyatar1znzxtex"],
+              "webPaywallBundleUrl": "https://bundles-staging.clickthrough.to/x/bundle_1778610753360.html",
+              "lastSavedAt": "2026-05-12T18:38:24.345+00:00"
+            },
+            {
+              "versionId": "32a1d295-60e1-425a-a4f7-c566e31a9f9c",
+              "versionStatus": "draft",
+              "versionNumber": 5,
+              "bundleUrl": "https://bundles-staging.heliumpaywall.com/x/bundle_1776908502633.html",
+              "previewUrl": "https://res.cloudinary.com/x/preview.png",
+              "productIds": ["yearly_2999"],
+              "stripeProductIds": [],
+              "paddleProductIds": [],
+              "webPaddleProductIds": [],
+              "webPaywallBundleUrl": null,
+              "lastSavedAt": "2026-04-23T01:41:50.897123+00:00"
+            }
+          ]
+        }
+      ]
+    }
+    """
+
+    func testDecodesPreviewsResponseWithWebPaywallBundleUrl() throws {
+        let response = try JSONDecoder().decode(
+            HeliumControlPanelResponse.self,
+            from: Data(previewsResponseJSON.utf8)
+        )
+
+        let versions = response.paywalls[0].versions
+        XCTAssertEqual(
+            versions[0].webPaywallBundleUrl,
+            "https://bundles-staging.clickthrough.to/x/bundle_1778610753360.html"
+        )
+        XCTAssertEqual(versions[0].webPaddleProductIds, ["pro_01kppzadma4mq2yx61e5spzgxe:pri_01kpsgnvzp69jyatar1znzxtex"])
+        XCTAssertNil(versions[1].webPaywallBundleUrl)
+    }
+
+    func testDecodesLegacyPreviewsResponseWithoutNewFields() throws {
+        // Response shape before the endpoint change: no per-version webPaywallBundleUrl,
+        // top-level stripeProductIds/paddleProductIds still present.
+        let legacyJSON = """
+        {
+          "productIds": ["yearly_2999"],
+          "stripeProductIds": [],
+          "paddleProductIds": [],
+          "paywalls": [
+            {
+              "paywallUuid": "f3e96335-f7df-4f28-b439-9506d37c793e",
+              "paywallName": "Legacy Paywall",
+              "versions": [
+                {
+                  "versionId": "1d9626d4-a8c8-40c1-8a59-c63c6f2b521e",
+                  "versionStatus": "published",
+                  "versionNumber": 1,
+                  "bundleUrl": "https://bundles.heliumpaywall.com/x/bundle_1.html",
+                  "previewUrl": null,
+                  "productIds": ["yearly_2999"],
+                  "stripeProductIds": [],
+                  "lastSavedAt": null
+                }
+              ]
+            }
+          ]
+        }
+        """
+        let response = try JSONDecoder().decode(
+            HeliumControlPanelResponse.self,
+            from: Data(legacyJSON.utf8)
+        )
+
+        XCTAssertNil(response.paywalls[0].versions[0].webPaywallBundleUrl)
+        XCTAssertNil(response.paywalls[0].versions[0].paddleProductIds)
+    }
+}


### PR DESCRIPTION
## What

Makes the paywall preview (triple-tap control panel) use the previewed version's **own** web checkout URL. Previously an app2web preview opened a *different* paywall's web page at checkout and errored on load. When no web paywall is linked, checkout now fails explicitly instead of opening the wrong page.

## Why (root cause)

`setPreviewTriggerConfig` builds the preview config by cloning the config of whichever existing trigger sorts first alphabetically, then overriding the bundle URL and product IDs. It never overrode `additionalPaywallFields["webPaywallBundleUrl"]`, which is exactly what `ExternalWebCheckoutManager.runCheckoutFlow` reads to decide which web page to open. So every preview kept the cloned trigger's checkout URL:

- Preview **renders** the selected paywall (bundle URL is overridden) — looks correct on screen.
- Checkout **opens** the cloned trigger's web paywall, enriched with the previewed version's product keys, which that page doesn't recognize → error on load.

## Fix

`/paywall-previews` now returns each version's own `webPaywallBundleUrl`, and `setPreviewTriggerConfig` sets it on the preview config (both the typed config and the `fetchedConfigJSON` mirror). When the response has no URL (`null`, no linked web paywall, or an older backend), the inherited value is cleared so checkout fails with the existing `webPaywallBundleUrlMissing` error instead of silently opening the wrong page.

## Tests

14 new tests in `PreviewTriggerConfigTests`, covering:
- inherited checkout URL is scrubbed / provided URL is used (typed config + JSON mirror)
- empty string treated as missing
- cloned trigger's own config stays untouched; re-preview clones the original trigger, not the previous preview
- bundle URL / product ID overrides and `forceShowFallback` clearing locked in
- decoding of both the new and the legacy `/paywall-previews` response shapes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to debug/TestFlight preview flow and API decoding; checkout behavior for production triggers is unchanged aside from explicit nulling when preview has no web URL.
> 
> **Overview**
> Fixes **triple-tap paywall preview** opening the **wrong web paywall at app2web checkout**. Preview config was cloned from another trigger and only the in-app bundle URL was overridden, so checkout still used the donor trigger’s `webPaywallBundleUrl`.
> 
> The control panel now decodes each preview version’s **`webPaywallBundleUrl`** (and drops obsolete top-level `stripeProductIds` on the response model). **`setPreviewTriggerConfig`** applies that URL to `additionalPaywallFields`, or sets it to **null** when missing/empty so checkout fails with **`webPaywallBundleUrlMissing`** instead of loading another paywall. The control panel passes the version URL when launching a preview.
> 
> Test helpers can inject optional **`fetchedConfigJSON`**; **`PreviewTriggerConfigTests`** covers URL scrubbing, re-preview behavior, and new/legacy `/paywall-previews` decoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f54c3e495da181b7ed2ffa7066b10af4b59e9c44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for web paywall bundle URLs in paywall previews.
  * Preview configurations now apply web checkout details while preserving original paywall settings.
  * Added compatibility for control panel responses with optional web paywall data.

* **Bug Fixes**
  * Prevented checkout URLs from leaking between repeated preview configurations.
  * Ensured missing or empty web paywall URLs are cleared correctly.

* **Tests**
  * Added coverage for preview configuration, JSON synchronization, cloning behavior, and legacy response compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->