### PR TITLE
[HEL-6198] CI/CD Fixes for UI Tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,11 +21,27 @@ jobs:
       SIMULATOR_NAME: iPhone 17
     steps:
       - uses: actions/checkout@v4
+      - name: Select simulator runtime
+        run: |
+          # Pin the destination OS to the newest stable iOS runtime (the highest
+          # runtime <= the default Xcode's simulator SDK version). Without an OS,
+          # xcodebuild picks the highest-version matching device, which on WarpBuild
+          # images can be a beta runtime with broken/slow XCUITest support.
+          SDK_VERSION=$(xcrun --sdk iphonesimulator --show-sdk-version)
+          IOS_TEST_OS=$(xcrun simctl list runtimes -j | python3 -c "
+          import json, sys
+          sdk = tuple(map(int, '$SDK_VERSION'.split('.')))
+          def v(s): return tuple(map(int, s.split('.')))
+          rts = [r['version'] for r in json.load(sys.stdin)['runtimes']
+                 if r['platform'] == 'iOS' and r['isAvailable'] and v(r['version'])[:len(sdk)] <= sdk]
+          print(max(rts, key=v))")
+          echo "Using iOS $IOS_TEST_OS (SDK $SDK_VERSION)"
+          echo "IOS_TEST_OS=$IOS_TEST_OS" >> "$GITHUB_ENV"
       - name: Run SwiftPM tests with Thread Sanitizer
         run: |
           xcodebuild test \
             -scheme helium-swift \
-            -destination "platform=iOS Simulator,name=$SIMULATOR_NAME" \
+            -destination "platform=iOS Simulator,name=$SIMULATOR_NAME,OS=$IOS_TEST_OS" \
             -enableThreadSanitizer YES \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO
@@ -57,22 +73,45 @@ jobs:
       - name: Check Xcode version and available simulators
         run: |
           xcodebuild -version
+          echo "=== Installed Simulator Runtimes ==="
+          xcrun simctl list runtimes
           echo "=== Available iOS Simulators ==="
           xcrun simctl list devices available | grep -E "iPhone"
 
-#add back preboot if seeing simulator issues
-#      - name: Pre-boot simulator
-#        run: |
-#          xcrun simctl boot "$SIMULATOR_NAME" 2>/dev/null || true
-#          xcrun simctl bootstatus "$SIMULATOR_NAME" -b
-#          echo "Simulator ready"
+      - name: Select simulator runtime and pre-boot simulator
+        run: |
+          # Pick the newest stable iOS runtime (the highest runtime <= the default
+          # Xcode's simulator SDK version). Without a runtime pin, xcodebuild picks
+          # the highest-version matching device, which on WarpBuild images can be a
+          # beta runtime with broken/slow XCUITest support.
+          SDK_VERSION=$(xcrun --sdk iphonesimulator --show-sdk-version)
+          IOS_RUNTIME_ID=$(xcrun simctl list runtimes -j | python3 -c "
+          import json, sys
+          sdk = tuple(map(int, '$SDK_VERSION'.split('.')))
+          def v(s): return tuple(map(int, s.split('.')))
+          rts = [r for r in json.load(sys.stdin)['runtimes']
+                 if r['platform'] == 'iOS' and r['isAvailable'] and v(r['version'])[:len(sdk)] <= sdk]
+          print(max(rts, key=lambda r: v(r['version']))['identifier'])")
+          echo "Using runtime $IOS_RUNTIME_ID (SDK $SDK_VERSION)"
+
+          # Create a dedicated simulator and boot it ahead of the test run. UI tests
+          # run directly on this settled device (cloning disabled via
+          # -parallel-testing-enabled NO): on a freshly-booted simulator clone, the
+          # app's paywall config fetch competes with the first-boot daemon storm and
+          # can exceed the paywall loading budget, which breaks the loading-state test.
+          SIM_UDID=$(xcrun simctl create "ci-test-iphone" "$SIMULATOR_NAME" "$IOS_RUNTIME_ID")
+          echo "Created simulator $SIM_UDID"
+          xcrun simctl boot "$SIM_UDID"
+          xcrun simctl bootstatus "$SIM_UDID" -b
+          echo "Simulator ready"
+          echo "SIM_UDID=$SIM_UDID" >> "$GITHUB_ENV"
 
       - name: Build for testing
         run: |
           xcodebuild build-for-testing \
             -project HeliumExample/HeliumExample.xcodeproj \
             -scheme "CI HeliumExample" \
-            -destination "platform=iOS Simulator,name=$SIMULATOR_NAME" \
+            -destination "id=$SIM_UDID" \
             HELIUM_API_KEY="${{ secrets.HELIUM_API_KEY }}" \
             HELIUM_TRIGGER_KEY="${{ secrets.HELIUM_TRIGGER_KEY }}" \
             CODE_SIGN_IDENTITY="" \
@@ -93,8 +132,9 @@ jobs:
             xcodebuild test-without-building \
               -project HeliumExample/HeliumExample.xcodeproj \
               -scheme "CI HeliumExample" \
-              -destination "platform=iOS Simulator,name=$SIMULATOR_NAME" \
+              -destination "id=$SIM_UDID" \
               $RUN_ONLY_TESTING \
+              -parallel-testing-enabled NO \
               -disable-concurrent-destination-testing \
               HELIUM_API_KEY="${{ secrets.HELIUM_API_KEY }}" \
               HELIUM_TRIGGER_KEY="${{ secrets.HELIUM_TRIGGER_KEY }}" \


### PR DESCRIPTION
## What

Makes the `run-tests.yml` UI test job reliable again. Since ~June 22 the ui-tests job failed on ~80% of runs with `testLoadingStateThenPaywall()` → "Subscribe button not found", inflated test durations (76–318s), and a 600s "collecting diagnostics" hang padding every failure.

## Why (root cause)

Two compounding issues, both environment-related (no product or test bug):

1. **Unpinned destination picks a beta runtime.** The WarpBuild `warp-macos-26-arm64-*` image update (~June 22–25) added Xcode 27.0 beta, whose **iOS 27.0 beta** simulator runtime is installed system-wide. Our destination was `name=iPhone 17` with no OS, and when several runtimes have that device, xcodebuild picks the **highest** OS — the beta. Its XCUITest/accessibility layer is slow/broken (`kAXErrorIPCTimeout`, the 600s diagnostics hang).

2. **Cold-booted simulator clones starve the paywall config fetch.** XCUITest boots a fresh simulator clone per run. The loading-state test launches the app immediately at boot, and the config fetch races the SDK's 35s loading budget against the clone's first-boot daemon storm. When it loses, the SDK correctly presents the **fallback paywall** ("Premium Access"), which has no "START MY FREE TRIAL" button — hence the literal assertion failure. Reproduced locally on stable iOS 26.5: same sim + same test passes in 15s pre-booted without cloning (1.1s config fetch), fails in 69s on a fresh clone. Screen recordings and the failure UI hierarchy show the fallback paywall on screen; the real bundle and config endpoint are healthy (<0.5s via curl).

## Fix

`.github/workflows/run-tests.yml` only:

- New step selects the newest **stable** iOS runtime (highest installed runtime ≤ the default Xcode's simulator SDK version — a beta can never win), creates a dedicated simulator on it, and **pre-boots** it with `simctl bootstatus` so it is fully settled before testing.
- Both xcodebuild invocations target that device by UDID; UI tests run with `-parallel-testing-enabled NO` so they use the settled device instead of cold-booting a clone.
- unit-tests job gets the same stable-OS pin; the diagnostics step now prints `simctl list runtimes` so future image changes are visible in job logs.

## Tests

- Full `HeliumExampleUITests` suite run locally under the exact new CI configuration (pre-booted dedicated sim, cloning disabled): **4/4 pass**, loading-state test 13.4s, SDK logs confirm 1.3s config download.
- Control experiments isolating each variable (clone vs no clone, cold vs settled boot).
- Runtime-selection script exercised end-to-end locally (selects `iOS-26-5`, exports env var).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only CI changes with no app or SDK code touched; main risk is mis-selection of runtime on future Xcode images.
> 
> **Overview**
> Hardens **`run-tests.yml`** so CI stops picking beta iOS simulator runtimes and cold simulator clones that were flaking UI tests.
> 
> **Unit tests** get a new step that derives the newest **stable** iOS version (highest installed runtime ≤ the default Xcode simulator SDK) and passes it as `OS=` on the `xcodebuild test` destination instead of name-only `iPhone 17`.
> 
> **UI tests** add runtime listing to diagnostics, then select the same stable runtime, **create** a dedicated `ci-test-iphone` simulator, **boot** it to completion, and target build/test by **`id=$SIM_UDID`**. UI test runs add **`-parallel-testing-enabled NO`** so tests use that settled device instead of fresh clones that could time out paywall config loading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ffcda6899efe875b43b28868c38bf32b2ade09c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved macOS test reliability by selecting a specific, stable iOS Simulator runtime.
  * UI tests now run on a dedicated simulator created for each test run.
  * Added simulator readiness checks and explicit test destination targeting.
  * Disabled parallel UI testing to provide more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->