### PR TITLE
[HEL-6109] | Non-intrusive fallback badge

### DIFF
--- a/Sources/Helium/HeliumCore/FallbackDebugBanner.swift
+++ b/Sources/Helium/HeliumCore/FallbackDebugBanner.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+
+/// A floating banner overlaid on a Helium fallback paywall, so a developer can tell at a glance
+/// that the live remote paywall was not the one that rendered.
+///
+/// Shown from DEBUG builds only. The SDK ships as source rather than a binary, so `#if DEBUG`
+/// resolves against the host app's build configuration and this never reaches a TestFlight or
+/// App Store build.
+///
+/// Sits top-center and stays narrow, because that is the one region paywalls reliably leave free:
+/// their close button sits in a top corner, their purchase call to action along the bottom edge.
+/// The card is interactive, so whatever it covers it also blocks.
+struct FallbackDebugBanner: View {
+
+    let trigger: String
+    let fallbackReason: PaywallUnavailableReason?
+
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var isPresented = false
+
+    private var backgroundColor: Color {
+        colorScheme == .dark
+            ? Color(red: 18/255, green: 58/255, blue: 102/255)
+            : Color(red: 220/255, green: 235/255, blue: 255/255)
+    }
+
+    private var foregroundColor: Color {
+        colorScheme == .dark
+            ? Color(red: 207/255, green: 227/255, blue: 255/255)
+            : Color(red: 10/255, green: 61/255, blue: 122/255)
+    }
+
+    private var shape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: 16, style: .continuous)
+    }
+
+    var body: some View {
+        // The banner animates itself in and out, so it needs a container that outlives its own
+        // visibility. An empty ZStack lays out at zero size, leaving the paywall untouched.
+        ZStack {
+            if isPresented {
+                banner.transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
+        .onAppear {
+            withAnimation(.easeOut(duration: 0.25)) {
+                isPresented = true
+            }
+        }
+    }
+
+    private var banner: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "info.circle.fill")
+                .font(.system(size: 17, weight: .semibold))
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Fallback Paywall")
+                    .font(.system(size: 15, weight: .semibold))
+                Text("Tap for details")
+                    .font(.system(size: 12, weight: .regular))
+                    .opacity(0.9)
+            }
+            dismissButton
+                .padding(.leading, 2)
+        }
+        .foregroundColor(foregroundColor)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(shape.fill(backgroundColor))
+        // A soft rim keeps the card legible on a paywall of any colour.
+        .overlay(shape.strokeBorder(Color.black.opacity(0.2), lineWidth: 1))
+        .shadow(color: Color.black.opacity(0.22), radius: 8, y: 3)
+        .contentShape(shape)
+        // The nested dismiss Button resolves first within its own bounds, so this only catches
+        // taps on the rest of the card.
+        .onTapGesture { openDiagnostics() }
+        .accessibilityAction(named: "Show diagnostics") { openDiagnostics() }
+    }
+
+    /// The diagnostic view keeps its own gating, so a tap is silently ignored when the developer
+    /// has turned diagnostics off or ticked "do not show again".
+    private func openDiagnostics() {
+        guard !trigger.isEmpty else { return }
+        let message = PaywallDiagnosticMessages.remediationMessage(
+            for: fallbackReason,
+            trigger: trigger
+        )
+        Task { @MainActor in
+            HeliumPaywallDiagnosticView.presentIfNeeded(trigger: trigger, message: message)
+        }
+    }
+
+    private var dismissButton: some View {
+        Button(action: dismiss) {
+            Image(systemName: "xmark")
+                .font(.system(size: 15, weight: .bold))
+                .opacity(0.85)
+                // Touch area rather than decoration: it grows the target past the glyph.
+                .padding(8)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Dismiss")
+    }
+
+    private func dismiss() {
+        withAnimation(.easeIn(duration: 0.2)) {
+            isPresented = false
+        }
+    }
+}
+
+extension FallbackDebugBanner {
+
+    /// A non-nil reason means Helium resolved a fallback bundle in place of the live remote
+    /// paywall, which is exactly what the banner reports.
+    static func shouldShow(fallbackReason: PaywallUnavailableReason?) -> Bool {
+        return fallbackReason != nil
+    }
+}

--- a/Sources/Helium/HeliumCore/FallbackDebugBanner.swift
+++ b/Sources/Helium/HeliumCore/FallbackDebugBanner.swift
@@ -1,15 +1,16 @@
 import SwiftUI
 
-/// A floating banner overlaid on a Helium fallback paywall, so a developer can tell at a glance
+/// A banner spanning the top edge of a Helium fallback paywall, so a developer can tell at a glance
 /// that the live remote paywall was not the one that rendered.
 ///
 /// Shown from DEBUG builds only. The SDK ships as source rather than a binary, so `#if DEBUG`
 /// resolves against the host app's build configuration and this never reaches a TestFlight or
 /// App Store build.
 ///
-/// Sits top-center and stays narrow, because that is the one region paywalls reliably leave free:
-/// their close button sits in a top corner, their purchase call to action along the bottom edge.
-/// The card is interactive, so whatever it covers it also blocks.
+/// It spans the width so it reads as a notification rather than a chip. That is a deliberate trade:
+/// the card is interactive, so at full width it covers the top corners where paywalls place their
+/// close button, and swallows those taps. Dismissing is the way out, so the paywall's own close
+/// button is never more than one extra tap away.
 struct FallbackDebugBanner: View {
 
     let trigger: String
@@ -31,7 +32,7 @@ struct FallbackDebugBanner: View {
     }
 
     private var shape: RoundedRectangle {
-        RoundedRectangle(cornerRadius: 16, style: .continuous)
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
     }
 
     var body: some View {
@@ -61,12 +62,15 @@ struct FallbackDebugBanner: View {
                     .font(.system(size: 12, weight: .regular))
                     .opacity(0.9)
             }
+            // Taking the slack is what pins the dismiss control to the trailing edge.
+            .frame(maxWidth: .infinity, alignment: .leading)
             dismissButton
                 .padding(.leading, 2)
         }
         .foregroundColor(foregroundColor)
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
+        .frame(maxWidth: .infinity)
         .background(shape.fill(backgroundColor))
         // A soft rim keeps the card legible on a paywall of any colour.
         .overlay(shape.strokeBorder(Color.black.opacity(0.2), lineWidth: 1))

--- a/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
+++ b/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
@@ -90,8 +90,8 @@ public struct DynamicBaseTemplateView: View {
             ZStack(alignment: .top) {
                 paywallWebView
                 // The stack keeps its safe-area inset while the paywall bleeds past it, so the
-                // banner clears the status bar and Dynamic Island. Centering keeps it out of the
-                // top corners, where paywalls place their close button.
+                // full-width banner clears the status bar, the Dynamic Island, and a landscape
+                // notch without measuring any of them.
                 FallbackDebugBanner(
                     trigger: triggerName ?? "",
                     fallbackReason: fallbackReason

--- a/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
+++ b/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
@@ -44,16 +44,7 @@ public struct DynamicBaseTemplateView: View {
     }
     
     public var body: some View {
-        // Use validated componentProps
-        DynamicWebView(
-            filePath: filePath,
-            backupFilePath: backupFilePath,
-            json: componentPropsJSON,
-            actionsDelegate: actionsDelegateWrapper,
-            triggerName: triggerName
-        )
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .edgesIgnoringSafeArea(.all)
+        paywallContent
         .onAppear {
             actionsDelegate.setDismissAction {
                 dismiss()
@@ -77,6 +68,43 @@ public struct DynamicBaseTemplateView: View {
                 }
             }
         }
+    }
+
+    // Use validated componentProps
+    private var paywallWebView: some View {
+        DynamicWebView(
+            filePath: filePath,
+            backupFilePath: backupFilePath,
+            json: componentPropsJSON,
+            actionsDelegate: actionsDelegateWrapper,
+            triggerName: triggerName
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .edgesIgnoringSafeArea(.all)
+    }
+
+    @ViewBuilder
+    private var paywallContent: some View {
+        #if DEBUG
+        if FallbackDebugBanner.shouldShow(fallbackReason: fallbackReason) {
+            ZStack(alignment: .top) {
+                paywallWebView
+                // The stack keeps its safe-area inset while the paywall bleeds past it, so the
+                // banner clears the status bar and Dynamic Island. Centering keeps it out of the
+                // top corners, where paywalls place their close button.
+                FallbackDebugBanner(
+                    trigger: triggerName ?? "",
+                    fallbackReason: fallbackReason
+                )
+                .padding(.top, 12)
+                .padding(.horizontal, 12)
+            }
+        } else {
+            paywallWebView
+        }
+        #else
+        paywallWebView
+        #endif
     }
 }
 

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -329,38 +329,10 @@ class HeliumPaywallDelegateWrapper {
         logMetadata: [String: String]
     ) {
         let logPrefix = fallbackShown ? "Fallback paywall shown!" : "Paywall not shown!"
-        var notShownAddendum: String = ""
-        switch paywallUnavailableReason {
-        case .notInitialized:
-            notShownAddendum = "Helium is not initialized"
-        case .triggerHasNoPaywall:
-            notShownAddendum = "Could not find paywall for trigger \"\(trigger)\". Verify your trigger is in a workflow. Note that changes to a workflow may take a few minutes to be reflected here. https://app.tryhelium.com/workflows"
-        case .paywallsNotDownloaded, .configFetchInProgress, .bundlesFetchInProgress, .productsFetchInProgress:
-            notShownAddendum = "Paywalls have not completed downloading. Check your connection and consider adjusting loading budget or initializing Helium sooner before presenting paywall"
-        case .paywallsDownloadFail:
-            notShownAddendum = "Paywalls failed to download. Check your connection and Helium API key"
-        case .alreadyPresented:
-            notShownAddendum = "A Helium paywall is already being presented"
-        case .noProductsIOS:
-            var paywallLink = "https://app.tryhelium.com/paywalls"
-            let paywallInfo = HeliumFetchedConfigManager.shared.getPaywallInfoForTrigger(trigger)
-            if let paywallId = paywallInfo?.paywallUUID {
-                paywallLink += "/\(paywallId)"
-            }
-            notShownAddendum = "Your paywall does not include any iOS products. Ensure you have synced your iOS products and selected products for your paywall \(paywallLink)"
-        case .webCheckoutNoCustomUserId:
-            notShownAddendum = "External Web Checkout requires a custom user ID to be set"
-        case .webCheckoutNotEnabled:
-            notShownAddendum = "External Web Checkout is not enabled for a payment processor this paywall requires. See Helium.config.enableExternalWebCheckout. Enabled processors: \(Helium.config.webCheckoutProcessors)"
-        case .bundleFetchCannotDecodeContent:
-            notShownAddendum = "Paywall html could not be read. Ensure the paywall is not corrupted and contact Helium if this continues to be an issue."
-        case .bundleFetchInvalidUrl, .bundleFetchInvalidUrlDetected, .bundleFetch403, .bundleFetch404, .bundleFetch410:
-            notShownAddendum = "Could not retrieve paywall. Contact Helium if this continues to be an issue."
-        case .couldNotFindBundleUrl:
-            notShownAddendum = "Could not extract paywall url. Contact Helium if this continues to be an issue."
-        default:
-            notShownAddendum = paywallUnavailableReason?.rawValue ?? ""
-        }
+        let notShownAddendum = PaywallDiagnosticMessages.remediationMessage(
+            for: paywallUnavailableReason,
+            trigger: trigger
+        )
         HeliumLogger.log(.error, category: .fallback, "\(logPrefix) \(notShownAddendum)", metadata: logMetadata)
         
 #if DEBUG

--- a/Sources/Helium/HeliumCore/PaywallDiagnosticMessages.swift
+++ b/Sources/Helium/HeliumCore/PaywallDiagnosticMessages.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// The single source of truth for what a developer is told when a paywall is unavailable. The same
+/// copy reaches the log line and the body of the debug diagnostic view, so the two cannot drift.
+enum PaywallDiagnosticMessages {
+
+    static func remediationMessage(
+        for reason: PaywallUnavailableReason?,
+        trigger: String
+    ) -> String {
+        switch reason {
+        case .notInitialized:
+            return "Helium is not initialized"
+        case .triggerHasNoPaywall:
+            return "Could not find paywall for trigger \"\(trigger)\". Verify your trigger is in a workflow. Note that changes to a workflow may take a few minutes to be reflected here. https://app.tryhelium.com/workflows"
+        case .paywallsNotDownloaded, .configFetchInProgress, .bundlesFetchInProgress, .productsFetchInProgress:
+            return "Paywalls have not completed downloading. Check your connection and consider adjusting loading budget or initializing Helium sooner before presenting paywall"
+        case .paywallsDownloadFail:
+            return "Paywalls failed to download. Check your connection and Helium API key"
+        case .alreadyPresented:
+            return "A Helium paywall is already being presented"
+        case .noProductsIOS:
+            var paywallLink = "https://app.tryhelium.com/paywalls"
+            let paywallInfo = HeliumFetchedConfigManager.shared.getPaywallInfoForTrigger(trigger)
+            if let paywallId = paywallInfo?.paywallUUID {
+                paywallLink += "/\(paywallId)"
+            }
+            return "Your paywall does not include any iOS products. Ensure you have synced your iOS products and selected products for your paywall \(paywallLink)"
+        case .webCheckoutNoCustomUserId:
+            return "External Web Checkout requires a custom user ID to be set"
+        case .webCheckoutNotEnabled:
+            return "External Web Checkout is not enabled for a payment processor this paywall requires. See Helium.config.enableExternalWebCheckout. Enabled processors: \(Helium.config.webCheckoutProcessors)"
+        case .bundleFetchCannotDecodeContent:
+            return "Paywall html could not be read. Ensure the paywall is not corrupted and contact Helium if this continues to be an issue."
+        case .bundleFetchInvalidUrl, .bundleFetchInvalidUrlDetected, .bundleFetch403, .bundleFetch404, .bundleFetch410:
+            return "Could not retrieve paywall. Contact Helium if this continues to be an issue."
+        case .couldNotFindBundleUrl:
+            return "Could not extract paywall url. Contact Helium if this continues to be an issue."
+        default:
+            return reason?.rawValue ?? ""
+        }
+    }
+}

--- a/Tests/helium-swiftTests/FallbackDebugBannerTests.swift
+++ b/Tests/helium-swiftTests/FallbackDebugBannerTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import Helium
+
+final class FallbackDebugBannerTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        HeliumAnalyticsManager.shared.disableAnalyticsForTesting()
+        Helium.resetHelium()
+    }
+
+    override func tearDown() {
+        Helium.resetHelium()
+        super.tearDown()
+    }
+
+    func testBannerHiddenForLiveRemotePaywall() {
+        XCTAssertFalse(FallbackDebugBanner.shouldShow(fallbackReason: nil))
+    }
+
+    func testBannerShownWhenFallbackReasonPresent() {
+        let reasons: [PaywallUnavailableReason] = [
+            .notInitialized,
+            .triggerHasNoPaywall,
+            .forceShowFallback,
+            .invalidResolvedConfig,
+            .paywallsNotDownloaded,
+            .paywallsDownloadFail,
+            .couldNotFindBundleUrl,
+            .noProductsIOS,
+            .webCheckoutNoCustomUserId,
+            .webCheckoutNotEnabled
+        ]
+
+        for reason in reasons {
+            XCTAssertTrue(
+                FallbackDebugBanner.shouldShow(fallbackReason: reason),
+                "Expected the banner to show for fallback reason \(reason.rawValue)"
+            )
+        }
+    }
+
+    /// This copy reaches developers verbatim, in the diagnostic view's body and in the log line, so
+    /// a rewrite here changes what they are told. Pin it.
+    func testRemediationCopyIsAuthoredNotDerived() {
+        XCTAssertEqual(
+            PaywallDiagnosticMessages.remediationMessage(for: .notInitialized, trigger: "t"),
+            "Helium is not initialized"
+        )
+        XCTAssertEqual(
+            PaywallDiagnosticMessages.remediationMessage(for: .paywallsDownloadFail, trigger: "t"),
+            "Paywalls failed to download. Check your connection and Helium API key"
+        )
+        XCTAssertEqual(
+            PaywallDiagnosticMessages.remediationMessage(for: .webCheckoutNoCustomUserId, trigger: "t"),
+            "External Web Checkout requires a custom user ID to be set"
+        )
+    }
+
+    func testRemediationCopyInterpolatesTheTrigger() {
+        let message = PaywallDiagnosticMessages.remediationMessage(
+            for: .triggerHasNoPaywall,
+            trigger: "onboarding_end"
+        )
+
+        XCTAssertTrue(message.contains("\"onboarding_end\""))
+        XCTAssertTrue(message.contains("https://app.tryhelium.com/workflows"))
+    }
+
+    /// A tapped banner must reach the diagnostic view with real remediation copy, never a bare
+    /// enum case leaking into the modal body.
+    func testRemediationCopyIsNotARawReasonCode() {
+        let reasons: [PaywallUnavailableReason] = [
+            .notInitialized,
+            .triggerHasNoPaywall,
+            .paywallsNotDownloaded,
+            .paywallsDownloadFail,
+            .couldNotFindBundleUrl,
+            .noProductsIOS,
+            .webCheckoutNoCustomUserId,
+            .webCheckoutNotEnabled
+        ]
+
+        for reason in reasons {
+            let message = PaywallDiagnosticMessages.remediationMessage(for: reason, trigger: "t")
+            XCTAssertFalse(message.isEmpty, "no copy for \(reason.rawValue)")
+            XCTAssertNotEqual(
+                message,
+                reason.rawValue,
+                "\(reason.rawValue) leaks its raw code into the diagnostic body"
+            )
+        }
+    }
+
+    func testResolvedFallbackReasonDrivesTheBanner() {
+        Helium.shared.markInitializedForTesting()
+
+        let config = makeTestConfig(triggers: ["other_trigger": makeTestPaywallInfo(trigger: "other_trigger")])
+        injectConfig(config)
+
+        let result = HeliumPaywallPresenter.shared.upsellViewResultFor(
+            trigger: "nonexistent_trigger",
+            presentationContext: PaywallPresentationContext.empty
+        )
+
+        XCTAssertEqual(result.fallbackReason, .triggerHasNoPaywall)
+        XCTAssertTrue(FallbackDebugBanner.shouldShow(fallbackReason: result.fallbackReason))
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are gated to DEBUG UI and a refactor of developer-facing strings; no production paywall or purchase behavior changes.
> 
> **Overview**
> Adds a **DEBUG-only** top banner on fallback paywalls so developers can see at a glance that the remote paywall did not render. The banner can be dismissed or tapped to open the existing `HeliumPaywallDiagnosticView` with remediation text.
> 
> **`DynamicBaseTemplateView`** now stacks the banner over the web paywall when `fallbackReason` is non-nil (`#if DEBUG` only); release builds are unchanged.
> 
> **`PaywallDiagnosticMessages`** centralizes unavailable-paywall remediation strings previously duplicated in **`HeliumPaywallDelegate`** logging/diagnostics, so logs, modals, and the banner share one source of truth.
> 
> Tests cover banner visibility rules, pinned remediation copy, and integration with presenter fallback resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5b8317f95818e235d5cbefed1dd1be5d48e9ae5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a developer-only diagnostic banner for fallback paywalls.
  * Developers can open detailed diagnostics or dismiss the banner directly from the paywall.

* **Bug Fixes**
  * Improved and centralized remediation messages for unavailable paywalls.
  * Diagnostic messages now provide clearer guidance across common configuration and loading issues.

* **Tests**
  * Added coverage for banner visibility, diagnostic actions, and remediation message accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->