### PR TITLE
Add code comment guidance to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,12 @@ iOS SDK for Helium paywalls. Lets mobile apps show remotely-configured, A/B-test
 - `Tests/helium-swiftTests/` — Unit tests.
 - `HeliumExample/` — Example app with UI tests.
 
+## Code comments
+
+- **Comment only when it adds genuine value; otherwise write none.** Most well-written code reads fine on its own. A comment should explain something the code can't — a non-obvious "why", a subtle invariant, a gotcha — not restate what the code plainly does.
+- **Keep comments durable and self-contained.** Don't reference other files or specific line numbers, and don't describe details that will drift out of date as the code changes.
+- **Never write change-narrating comments.** No notes about what the code used to be, why it changed, or what a comment replaced. That context belongs in the commit/PR, not the source — it's meaningless to a future reader who never saw the old version.
+
 ## Conventions
 
 - Version is tracked in `Sources/Helium/HeliumCore/BuildConstants.swift`.


### PR DESCRIPTION
Adds a **Code comments** section to `CLAUDE.md` to curb overly verbose, brittle agent-authored comments.

Three principles:
- **Value-add only** — no comment unless it explains something the code can't (a non-obvious "why", an invariant, a gotcha); don't restate what the code plainly does.
- **Durable and self-contained** — no cross-file references or line numbers, and no details that drift out of date as code changes.
- **No change-narrating comments** — nothing about what code used to be or why it changed relative to removed code; that context belongs in the commit/PR, not the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to contributor/AI guidance; no runtime or SDK behavior impact.
> 
> **Overview**
> Adds a **Code comments** section to `CLAUDE.md` so agents and contributors follow consistent comment style.
> 
> The new rules require comments only when they add non-obvious “why” or invariants, keep wording durable without cross-file or line-number references, and avoid change-narrating notes that belong in commits/PRs instead of source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bbf51dac741bc208869cfba2a3664260b5e12a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidelines for writing concise, durable, and useful code comments.
  - Clarified when comments are appropriate and discouraged comments that merely describe changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->