### PR TITLE
[HEL-6258] Parse webProductsOfferedStripe with in-app safety net

### DIFF
--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
@@ -22,6 +22,7 @@ struct HeliumPaywallPreviewVersion: Codable, Identifiable {
     let stripeProductIds: [String]?
     let paddleProductIds: [String]?
     let webPaddleProductIds: [String]?
+    let webStripeProductIds: [String]?
     let webPaywallBundleUrl: String?
     let lastSavedAt: String?
     var id: String { versionId }

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
@@ -258,6 +258,7 @@ struct HeliumControlPanelView: View {
                     productIdsStripe: version.stripeProductIds ?? [],
                     productIdsPaddle: version.paddleProductIds ?? [],
                     productIdsPaddleWeb: version.webPaddleProductIds ?? [],
+                    productIdsStripeWeb: version.webStripeProductIds ?? [],
                     webPaywallBundleUrl: version.webPaywallBundleUrl
                 )
 

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -1028,6 +1028,7 @@ public class HeliumFetchedConfigManager {
         productIdsStripe: [String],
         productIdsPaddle: [String],
         productIdsPaddleWeb: [String],
+        productIdsStripeWeb: [String],
         webPaywallBundleUrl: String? = nil,
     ) throws {
         guard var config = fetchedConfig else {
@@ -1072,6 +1073,7 @@ public class HeliumFetchedConfigManager {
         previewPaywallInfo.productsOfferedStripe = productIdsStripe
         previewPaywallInfo.productsOfferedPaddle = productIdsPaddle
         previewPaywallInfo.webProductsOfferedPaddle = productIdsPaddleWeb
+        previewPaywallInfo.webProductsOfferedStripe = productIdsStripeWeb
 
         // Clear fields inherited from source trigger that would interfere with preview
         previewPaywallInfo.forceShowFallback = nil

--- a/Sources/Helium/HeliumCore/Models.swift
+++ b/Sources/Helium/HeliumCore/Models.swift
@@ -39,6 +39,7 @@ public struct HeliumPaywallInfo: Codable {
     var productsOfferedStripe: [String]?
     var productsOfferedPaddle: [String]?
     var webProductsOfferedPaddle: [String]?
+    var webProductsOfferedStripe: [String]?
     var resolvedConfig: AnyCodable
     var shouldShow: Bool?
     var fallbackPaywallName: String?
@@ -61,7 +62,7 @@ public struct HeliumPaywallInfo: Codable {
     }
 
     var productIdsIncludingWebProductIds: [String] {
-        productIds + (webProductsOfferedPaddle ?? [])
+        productIds + (webProductsOfferedPaddle ?? []) + (webProductsOfferedStripe ?? [])
     }
 
     var hasProducts: Bool {

--- a/Sources/Helium/HeliumCore/StripeCheckout/PaymentProviderConfig.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/PaymentProviderConfig.swift
@@ -14,8 +14,8 @@ struct PaymentProviderConfig {
     let getCheckoutSuccessURL: () -> String?
     let getCheckoutCancelURL: () -> String?
     /// Products this provider considers "offered" for a given paywall.
-    /// `includeInAppSetIfWebEmpty` widens to the in-app Paddle set only when the
-    /// web set is empty — used on the success-redirect path as a safety net
+    /// `includeInAppSetIfWebEmpty` widens to the provider's in-app set only when
+    /// the web set is empty — used on the success-redirect path as a safety net
     /// against server config drift (web bundle URL present, web products missing).
     let getOfferedProducts: (HeliumPaywallInfo, _ includeInAppSetIfWebEmpty: Bool) -> [String]?
     let kind: HeliumPaymentProcessor
@@ -35,7 +35,12 @@ struct PaymentProviderConfig {
         entitlementsPersistenceFileName: "helium_stripe_entitlements.json",
         getCheckoutSuccessURL: { Helium.config.checkoutSuccessURL },
         getCheckoutCancelURL: { Helium.config.checkoutCancelURL },
-        getOfferedProducts: { paywallInfo, _ in paywallInfo.productsOfferedStripe },
+        getOfferedProducts: { paywallInfo, includeInAppSetIfWebEmpty in
+            if let web = paywallInfo.webProductsOfferedStripe, !web.isEmpty {
+                return web
+            }
+            return includeInAppSetIfWebEmpty ? paywallInfo.productsOfferedStripe : nil
+        },
         kind: .stripe
     )
 

--- a/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
+++ b/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
@@ -554,6 +554,7 @@ extension HeliumPaywallPresenter {
             let hasPaddleProducts = !(templatePaywallInfo.productsOfferedPaddle ?? []).isEmpty
                 || !(templatePaywallInfo.webProductsOfferedPaddle ?? []).isEmpty
             let hasStripeProducts = !(templatePaywallInfo.productsOfferedStripe ?? []).isEmpty
+                || !(templatePaywallInfo.webProductsOfferedStripe ?? []).isEmpty
             let hasAppToWebProducts = hasPaddleProducts || hasStripeProducts
             if hasAppToWebProducts && !HeliumIdentityManager.shared.hasCustomUserId() && !Helium.config.allowWebCheckoutWithoutUserId {
                 return fallbackViewFor(trigger: trigger, paywallInfo: templatePaywallInfo, fallbackReason: .webCheckoutNoCustomUserId, presentationContext: presentationContext)

--- a/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
+++ b/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
@@ -46,6 +46,7 @@ final class PreviewTriggerConfigTests: XCTestCase {
         productIdsStripe: [String] = [],
         productIdsPaddle: [String] = [],
         productIdsPaddleWeb: [String] = [],
+        productIdsStripeWeb: [String] = [],
         webPaywallBundleUrl: String? = nil
     ) throws {
         try HeliumFetchedConfigManager.shared.setPreviewTriggerConfig(
@@ -56,6 +57,7 @@ final class PreviewTriggerConfigTests: XCTestCase {
             productIdsStripe: productIdsStripe,
             productIdsPaddle: productIdsPaddle,
             productIdsPaddleWeb: productIdsPaddleWeb,
+            productIdsStripeWeb: productIdsStripeWeb,
             webPaywallBundleUrl: webPaywallBundleUrl
         )
     }
@@ -182,6 +184,7 @@ final class PreviewTriggerConfigTests: XCTestCase {
             productIdsStripe: [],
             productIdsPaddle: [],
             productIdsPaddleWeb: [],
+            productIdsStripeWeb: [],
             webPaywallBundleUrl: nil
         )
 


### PR DESCRIPTION
## Summary

Closes the single remaining SDK gap for external Stripe: `webProductsOfferedStripe` was never parsed, and Stripe product resolution was hardwired to the in-app `productsOfferedStripe` list. This mirrors the existing Paddle web-products flow for Stripe.

- **Parse `webProductsOfferedStripe` on-launch** — added the `Codable` field to `HeliumPaywallInfo` (mirrors `webProductsOfferedPaddle`) and included it in `productIdsIncludingWebProductIds` so entitlement matching covers Stripe web products.
- **Stripe product resolution** — `PaymentProviderConfig.stripe.getOfferedProducts` now returns the web set when present, widening to the in-app `productsOfferedStripe` set only on the success-redirect safety-net path (`includeInAppSetIfWebEmpty`). Previously hardwired to the in-app set.
- **Presenter gating** — `hasStripeProducts` now also counts `webProductsOfferedStripe`.
- **Preview flow** — threaded `webStripeProductIds` through the control-panel preview so previews behave like production.

## Notes

- The release shipping this sets the SDK version floor for the CML targeting preset (>4.5.4) — owner-managed, tracked in the ticket.
- Unblocks HEL-6264 (first proven live purchase through the external Stripe web paywall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment product resolution and web-checkout gating; changes are patterned on existing Paddle web flow but affect live Stripe checkout paths.
> 
> **Overview**
> **Adds first-class support for Stripe web product IDs**, closing the gap where only in-app `productsOfferedStripe` was used.
> 
> `HeliumPaywallInfo` now decodes **`webProductsOfferedStripe`** and folds it into **`productIdsIncludingWebProductIds`** for entitlement matching. **`PaymentProviderConfig.stripe.getOfferedProducts`** prefers the web list when present and only widens to in-app Stripe products on the success-redirect safety-net path (`includeInAppSetIfWebEmpty`), matching Paddle’s behavior.
> 
> **Paywall presentation** treats Stripe web products as app-to-web checkout (`hasStripeProducts` includes the web set). **Control panel previews** decode `webStripeProductIds` and pass them through **`setPreviewTriggerConfig`** so on-device previews match production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c83ab7acf09c30e68448408c830770764bb47f58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring Stripe web product IDs in paywall previews.
  * Stripe checkout now uses web-specific products when available.
  * Combined product availability now includes Stripe web products.

* **Bug Fixes**
  * Improved checkout fallback behavior when web Stripe products are unavailable.

* **Tests**
  * Updated preview configuration coverage for Stripe web products.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->