### PR TITLE
[HEL-6322] Stripe app2web intro-offer eligibility + getStripeCustomerId()

### DIFF
--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -168,6 +168,13 @@ public class ExternalWebCheckoutManager: NSObject {
             )
         }
 
+        var stripeIntroOfferEligibleByProduct: [String: Bool]? = nil
+        if provider.kind == .stripe {
+            stripeIntroOfferEligibleByProduct = buildStripeIntroOfferEligibleByProduct(
+                paywallInfo: paywallSession.paywallInfoWithBackups
+            )
+        }
+
         let enrichedURL = try buildEnrichedCheckoutURL(
             baseURL: baseURL,
             analyticsEvent: loggedEvent,
@@ -177,7 +184,8 @@ public class ExternalWebCheckoutManager: NSObject {
             cancelURL: resolvedCancelURL,
             introOfferEligible: await isIntroOfferEligibleForWebCheckout(paywallInfo: paywallSession.paywallInfoWithBackups),
             paddleBootstraps: paddleBootstrapsDict,
-            paddleAlreadyEntitled: paddleAlreadyEntitledDict
+            paddleAlreadyEntitled: paddleAlreadyEntitledDict,
+            stripeIntroOfferEligibleByProduct: stripeIntroOfferEligibleByProduct
         )
 
         return try await openEnrichedCheckoutURL(enrichedURL, productKey: productKey, paywallSession: paywallSession)
@@ -200,6 +208,25 @@ public class ExternalWebCheckoutManager: NSObject {
         return products.allSatisfy { priceMap[$0]?.subscriptionInfo?.introOfferEligible == true }
     }
 
+    /// Stripe's intro-offer eligibility is genuinely per-product, so the web
+    /// paywall needs the full map rather than the coarse `introOfferEligible` bool.
+    /// Nil (nothing resolvable) leaves that coarse bool as the only signal.
+    private func buildStripeIntroOfferEligibleByProduct(paywallInfo: HeliumPaywallInfo?) -> [String: Bool]? {
+        guard let paywallInfo,
+              let products = provider.getOfferedProducts(paywallInfo, false),
+              !products.isEmpty,
+              let priceMap = HeliumFetchedConfigManager.shared.getStripeProductsPriceMap() else {
+            return nil
+        }
+        var eligibilityByProduct: [String: Bool] = [:]
+        for productKey in products {
+            if let eligible = priceMap[productKey]?.subscription?.introOfferEligible {
+                eligibilityByProduct[productKey] = eligible
+            }
+        }
+        return eligibilityByProduct.isEmpty ? nil : eligibilityByProduct
+    }
+
     /// Builds the enriched checkout URL: existing query items are preserved,
     /// the compressed `ctx` payload is written to the URL fragment.
     func buildEnrichedCheckoutURL(
@@ -211,7 +238,8 @@ public class ExternalWebCheckoutManager: NSObject {
         cancelURL: String,
         introOfferEligible: Bool,
         paddleBootstraps: [String: Any]? = nil,
-        paddleAlreadyEntitled: [String: Any]? = nil
+        paddleAlreadyEntitled: [String: Any]? = nil,
+        stripeIntroOfferEligibleByProduct: [String: Bool]? = nil
     ) throws -> URL {
         guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
             throw WebCheckoutError.invalidBaseURLForComponents
@@ -256,6 +284,9 @@ public class ExternalWebCheckoutManager: NSObject {
         }
         if let paddleAlreadyEntitled = paddleAlreadyEntitled {
             ctx["paddleAlreadyEntitled"] = paddleAlreadyEntitled
+        }
+        if let stripeIntroOfferEligibleByProduct = stripeIntroOfferEligibleByProduct {
+            ctx["stripeIntroOfferEligibleByProduct"] = stripeIntroOfferEligibleByProduct
         }
 
         let ctxData = try JSONSerialization.data(withJSONObject: ctx)

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -340,16 +340,6 @@ public class Helium {
     ///
     /// - Parameter returnUrl: The URL Stripe redirects to after the user finishes in the portal.
     /// - Returns: The portal session URL.
-    ///
-    /// ## Example
-    /// ```swift
-    /// do {
-    ///     let portalURL = try await Helium.shared.createStripePortalSession(returnUrl: "myapp://settings")
-    ///     await UIApplication.shared.open(portalURL)
-    /// } catch {
-    ///     print("Failed to create portal session: \(error)")
-    /// }
-    /// ```
     @available(*, deprecated, message: "Use getStripeCustomerId() and pass the ID to your server to generate a Stripe customer portal session instead.")
     public func createStripePortalSession(returnUrl: String) async throws -> URL {
         return try await StripeCheckoutManager.shared.createPortalSession(returnUrl: returnUrl)

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -350,10 +350,26 @@ public class Helium {
     ///     print("Failed to create portal session: \(error)")
     /// }
     /// ```
+    @available(*, deprecated, message: "Use getStripeCustomerId() and pass the ID to your server to generate a Stripe customer portal session instead.")
     public func createStripePortalSession(returnUrl: String) async throws -> URL {
         return try await StripeCheckoutManager.shared.createPortalSession(returnUrl: returnUrl)
     }
-    
+
+    /// Returns the Stripe customer ID for the current user, if one exists.
+    ///
+    /// Pass this ID to your server to generate a Stripe customer portal session,
+    /// allowing the user to manage their subscriptions.
+    ///
+    /// - Returns: The Stripe customer ID, or `nil` if none has been assigned.
+    public func getStripeCustomerId() async -> String? {
+        if let customerId = HeliumIdentityManager.shared.getStripeCustomerId() {
+            return customerId
+        }
+        guard Helium.config.webCheckoutProcessors.contains(.stripe) else { return nil }
+        await HeliumEntitlementsManager.shared.stripeEntitlementsSource.refreshIfNeeded()
+        return HeliumIdentityManager.shared.getStripeCustomerId()
+    }
+
     /// Resets Stripe entitlements and clears the user ID.
     /// If your app can support multiple Stripe users on the same device, you'll want to call this to effectively "log out" a Stripe user.
     public func resetStripeEntitlements() {

--- a/Tests/helium-swiftTests/CtxCompressionTests.swift
+++ b/Tests/helium-swiftTests/CtxCompressionTests.swift
@@ -476,6 +476,97 @@ final class CtxCompressionTests: XCTestCase {
         XCTAssertNil(parsed["paddleAlreadyEntitled"], "Omitted when caller passes nil")
     }
 
+    // MARK: - stripeIntroOfferEligibleByProduct map round-trips through ctx
+
+    func testBuildEnrichedCheckoutURL_includesStripeIntroOfferEligibleByProductWhenProvided() async throws {
+        Helium.lastApiKeyUsed = "test_api_key_for_compression"
+        defer { Helium.lastApiKeyUsed = nil }
+
+        let provider: PaymentProviderConfig = .stripe
+        let entitlements = HeliumPaymentEntitlementsSource(provider: provider)
+        let manager = ExternalWebCheckoutManager(provider: provider, entitlementsSource: entitlements)
+
+        let baseURL = URL(string: "https://bundles-staging.heliumpaywall.com/o/p/bundle.html")!
+        let templateEvent = PurchaseSucceededEvent(
+            productId: "", triggerName: "t", paywallName: "P",
+            storeKitTransactionId: nil, storeKitOriginalTransactionId: nil,
+            paymentProcessor: provider.kind
+        )
+        let analyticsEvent = HeliumAnalyticsManager.shared.buildLoggedEvent(
+            for: templateEvent,
+            paywallSession: PaywallSession(trigger: "t", paywallInfo: nil, fallbackType: .notFallback, presentationContext: .empty)
+        )
+
+        let eligibleByProduct: [String: Bool] = [
+            "prod_a:pri_yearly": true,
+            "prod_b:pri_monthly": false,
+        ]
+
+        let url = try manager.buildEnrichedCheckoutURL(
+            baseURL: baseURL, analyticsEvent: analyticsEvent,
+            productKey: "prod_a:pri_yearly", triggerName: "t",
+            successURL: "ok", cancelURL: "no",
+            introOfferEligible: true,
+            paddleBootstraps: nil,
+            paddleAlreadyEntitled: nil,
+            stripeIntroOfferEligibleByProduct: eligibleByProduct
+        )
+
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let fragment = try XCTUnwrap(components.fragment, "URL must have a ctx fragment")
+        XCTAssertTrue(fragment.hasPrefix("ctx="), "Fragment must start with `ctx=`; got `\(fragment)`")
+        let ctxValue = String(fragment.dropFirst("ctx=".count))
+        let compressed = try XCTUnwrap(base64URLDecode(ctxValue))
+        let decompressed = try decompressWithAppleZlib(compressed, originalSize: 16_384)
+        let parsed = try XCTUnwrap(JSONSerialization.jsonObject(with: decompressed) as? [String: Any])
+
+        let eligibleMap = try XCTUnwrap(parsed["stripeIntroOfferEligibleByProduct"] as? [String: Any])
+        XCTAssertEqual(eligibleMap["prod_a:pri_yearly"] as? Bool, true)
+        XCTAssertEqual(eligibleMap["prod_b:pri_monthly"] as? Bool, false)
+        // Coarse bool stays as the safety-net signal for older bundles.
+        XCTAssertEqual(parsed["introOfferEligible"] as? Bool, true)
+    }
+
+    func testBuildEnrichedCheckoutURL_omitsStripeIntroOfferEligibleByProductWhenNil() async throws {
+        Helium.lastApiKeyUsed = "test_api_key_for_compression"
+        defer { Helium.lastApiKeyUsed = nil }
+
+        let provider: PaymentProviderConfig = .stripe
+        let entitlements = HeliumPaymentEntitlementsSource(provider: provider)
+        let manager = ExternalWebCheckoutManager(provider: provider, entitlementsSource: entitlements)
+
+        let baseURL = URL(string: "https://bundles-staging.heliumpaywall.com/o/p/bundle.html")!
+        let templateEvent = PurchaseSucceededEvent(
+            productId: "", triggerName: "t", paywallName: "P",
+            storeKitTransactionId: nil, storeKitOriginalTransactionId: nil,
+            paymentProcessor: provider.kind
+        )
+        let analyticsEvent = HeliumAnalyticsManager.shared.buildLoggedEvent(
+            for: templateEvent,
+            paywallSession: PaywallSession(trigger: "t", paywallInfo: nil, fallbackType: .notFallback, presentationContext: .empty)
+        )
+
+        let url = try manager.buildEnrichedCheckoutURL(
+            baseURL: baseURL, analyticsEvent: analyticsEvent,
+            productKey: "prod_a:pri_yearly", triggerName: "t",
+            successURL: "ok", cancelURL: "no",
+            introOfferEligible: true,
+            paddleBootstraps: nil,
+            paddleAlreadyEntitled: nil,
+            stripeIntroOfferEligibleByProduct: nil
+        )
+
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let fragment = try XCTUnwrap(components.fragment, "URL must have a ctx fragment")
+        XCTAssertTrue(fragment.hasPrefix("ctx="), "Fragment must start with `ctx=`; got `\(fragment)`")
+        let ctxValue = String(fragment.dropFirst("ctx=".count))
+        let compressed = try XCTUnwrap(base64URLDecode(ctxValue))
+        let decompressed = try decompressWithAppleZlib(compressed, originalSize: 8_192)
+        let parsed = try XCTUnwrap(JSONSerialization.jsonObject(with: decompressed) as? [String: Any])
+
+        XCTAssertNil(parsed["stripeIntroOfferEligibleByProduct"], "Omitted when caller passes nil")
+    }
+
     // MARK: - Larger realistic payload (regression test)
 
     func testDeflateRaw_roundTripsLargeRealisticPaywallCtx() throws {


### PR DESCRIPTION
## Summary

Two Stripe web-checkout changes:

1. **Per-product intro-offer eligibility in web paywalls (HEL-6322).** Stripe's intro-offer eligibility is genuinely per-product, so a single folded bool can misrepresent mixed states. Build a `{productKey: bool}` map for the offered web Stripe products from the enriched `stripeProducts` map already in memory at handoff, and write it to `ctx["stripeIntroOfferEligibleByProduct"]`. No new network call or model field. The coarse `ctx["introOfferEligible"]` bool is kept as the safety-net signal for older bundles.

2. **`getStripeCustomerId()` + deprecate `createStripePortalSession()`.** Mirrors the Paddle change in `b451aa7` (HEL-6133): expose the Stripe customer ID so the host app can generate a portal session server-side, and deprecate the SDK-side portal creation.

## Fallback precedence
per-product ctx map → coarse `introOfferEligible` bool → baked products-derived values. The bundle tolerates a missing map; this SDK release is what starts sending it.

## Out of scope
Apple Pay sheet trial phases and Paddle-style ineligible-bucket initial selection (deferred / optional follow-ups per the ticket).

## Testing
Added `CtxCompressionTests` coverage: the per-product map round-trips through the compressed ctx (with the coarse bool still present) and is omitted when nil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkout handoff payload and a deprecated public Stripe API; customer ID exposure is intentional but integrators must migrate portal flows to their backend.
> 
> **Overview**
> Stripe app-to-web checkout now sends **per-product** intro-offer eligibility in the compressed paywall `ctx` as `stripeIntroOfferEligibleByProduct`, built from in-memory Stripe product pricing for the offered keys. The existing coarse `introOfferEligible` bool is unchanged for older web bundles.
> 
> The public API adds **`getStripeCustomerId()`** (with optional entitlements refresh when Stripe web checkout is enabled), aligned with the Paddle pattern. **`createStripePortalSession`** is **deprecated** in favor of host-server portal creation using that customer ID.
> 
> Tests assert the new ctx key round-trips when set and is omitted when nil.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70b5ac890d021fbcae5f20ab0e1b0492bcdfc544. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Stripe checkout now supports product-specific introductory-offer eligibility, helping determine which offers are available for individual products.
  - Added an API to retrieve the current Stripe customer ID, including automatic entitlement refresh when needed.

- **Deprecations**
  - The existing Stripe customer portal session method is deprecated. Apps should use the customer ID API and create portal sessions through their server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->