### PR TITLE
[HEL-6111] | Diagnostic content gating

### DIFF
--- a/Sources/Helium/HeliumCore/AppReceiptsHelper.swift
+++ b/Sources/Helium/HeliumCore/AppReceiptsHelper.swift
@@ -17,23 +17,28 @@ class AppReceiptsHelper {
     
     static let shared = AppReceiptsHelper()
     
-    private var appTransactionEnvironment: Environment? = nil
-    private var setupCompleted: Bool = false
-    
-    private var appFirstInstallTime: Date? = nil
-    private var latestInstallTime: Date? = nil
+    @HeliumAtomic private var appTransactionEnvironment: Environment? = nil
+    @HeliumAtomic private var setupCompleted: Bool = false
+
+    @HeliumAtomic private var appFirstInstallTime: Date? = nil
+    @HeliumAtomic private var latestInstallTime: Date? = nil
     private let firstInstallTimeKey = "heliumFirstInstallTime"
-    
+
     func setUp() {
-        if setupCompleted {
+        // Test-and-set so concurrent callers run the body at most once.
+        let alreadySetUp = _setupCompleted.withValue { value in
+            if value { return true }
+            value = true
+            return false
+        }
+        if alreadySetUp {
             return
         }
-        setupCompleted = true
         if Bundle.main.appStoreReceiptURL != nil {
             // AppTransaction.shared can trigger Apple account sign-in dialog in debug/sandbox
             // if not signed into a sandbox account, which is annoying for sdk integrators. So avoid
             // that call if can determine sandbox from receipt.
-            if getEnvironment() == Environment.sandbox.rawValue {
+            if environment == .sandbox {
                 return
             }
         }
@@ -80,19 +85,23 @@ class AppReceiptsHelper {
 #endif
     }
     
-    func getEnvironment() -> String {
+    var environment: Environment {
 #if DEBUG || targetEnvironment(simulator)
-        return Environment.debug.rawValue
+        return .debug
 #else
         if let appTransactionEnvironment {
-            return appTransactionEnvironment.rawValue
+            return appTransactionEnvironment
         }
 
         // Note, if supporting mac catalyst, watch os, etc in the future consider looking at RevenueCat sdk for how they handle these special cases.
 
         let isTestFlight = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
-        return isTestFlight ? Environment.sandbox.rawValue : Environment.production.rawValue
+        return isTestFlight ? .sandbox : .production
 #endif
+    }
+
+    func getEnvironment() -> String {
+        environment.rawValue
     }
     
     func getFirstInstallTime() -> Date? {
@@ -119,8 +128,9 @@ class AppReceiptsHelper {
             return nil
         }
         let attributes = try? FileManager.default.attributesOfItem(atPath: documentsURL.path)
-        latestInstallTime = attributes?[.creationDate] as? Date
-        return latestInstallTime
+        let creationDate = attributes?[.creationDate] as? Date
+        latestInstallTime = creationDate
+        return creationDate
     }
 
 }

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelService.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelService.swift
@@ -11,9 +11,8 @@ class HeliumControlPanelService {
         guard Helium.config.paywallPreviewsAutoEnabledInDevBuilds else {
             return false
         }
-        let env = AppReceiptsHelper.shared.getEnvironment()
-        return env == AppReceiptsHelper.Environment.debug.rawValue
-            || env == AppReceiptsHelper.Environment.sandbox.rawValue
+        let environment = AppReceiptsHelper.shared.environment
+        return environment == .debug || environment == .sandbox
     }
 
     private var heliumBaseURL: String { HeliumAPIEndpoint.baseURL }

--- a/Sources/Helium/HeliumCore/Diagnostic/HeliumDiagnosticGate.swift
+++ b/Sources/Helium/HeliumCore/Diagnostic/HeliumDiagnosticGate.swift
@@ -1,0 +1,150 @@
+//
+//  HeliumDiagnosticGate.swift
+//  Helium
+//
+
+import Foundation
+
+/// Decides whether the paywall diagnostic modal may be presented.
+///
+/// Two questions, deliberately separate. `isEnabled` answers whether diagnostics are available on
+/// this build and device at all, and governs every surface including ones the developer opens
+/// themselves. `shouldShow` adds the rules for interrupting someone unprompted, which is a higher
+/// bar: a modal nobody asked for has to be worth the interruption.
+enum HeliumDiagnosticGate {
+
+    static let doNotShowAgainKey = "heliumDiagnosticDoNotShowAgain"
+
+    /// A Helium paywall is already on screen, so a modal would cover the very thing the developer
+    /// asked to see. Every other failure leaves the developer owed an explanation.
+    static let suppressedReasons: Set<PaywallUnavailableReason> = [.alreadyPresented]
+
+    /// Whether an unprompted modal is warranted for this outcome.
+    static func shouldShow(
+        outcome: DiagnosticOutcome,
+        fallbackShown: Bool,
+        isPreviewTrigger: Bool,
+        isDebugBuild: Bool,
+        environment: AppReceiptsHelper.Environment,
+        displayEnabled: Bool,
+        enabledInTestFlight: Bool,
+        serverFlagEnabled: Bool,
+        doNotShowAgain: @autoclosure () -> Bool
+    ) -> Bool {
+        // A rendered fallback paywall disproves the modal's authored outcome, which describes a user
+        // who got nothing. That case is surfaced by the on-paywall badge instead.
+        if fallbackShown { return false }
+        guard warrantsInterrupting(outcome, isPreviewTrigger: isPreviewTrigger, isDebugBuild: isDebugBuild) else {
+            return false
+        }
+        guard isEnabled(
+            isPreviewTrigger: isPreviewTrigger,
+            isDebugBuild: isDebugBuild,
+            environment: environment,
+            displayEnabled: displayEnabled,
+            enabledInTestFlight: enabledInTestFlight,
+            serverFlagEnabled: serverFlagEnabled
+        ) else { return false }
+        if isPreviewTrigger { return true }
+        return !doNotShowAgain()
+    }
+
+    /// Whether diagnostics are available at all, independent of any single outcome. Also the gate
+    /// for a modal the developer opens deliberately, which is why the do-not-show-again preference
+    /// is not consulted here: it means stop interrupting me, not never let me look.
+    static func isEnabled(
+        isPreviewTrigger: Bool,
+        isDebugBuild: Bool,
+        environment: AppReceiptsHelper.Environment,
+        displayEnabled: Bool,
+        enabledInTestFlight: Bool,
+        serverFlagEnabled: Bool
+    ) -> Bool {
+        if isPreviewTrigger { return true }
+        guard displayEnabled else { return false }
+        guard isVisible(isDebugBuild: isDebugBuild, environment: environment, enabledInTestFlight: enabledInTestFlight) else { return false }
+        return serverFlagEnabled
+    }
+
+    /// The SDK ships as source, so this resolves against the host app's build configuration.
+    static var isDebugBuild: Bool {
+#if DEBUG
+        true
+#else
+        false
+#endif
+    }
+
+    /// A skip is Helium working as configured, so there is nothing for the person holding the phone
+    /// to fix. Outside a debug build it stays in the log rather than taking over the screen of a
+    /// tester who is already subscribed or sitting in a targeting holdout.
+    private static func warrantsInterrupting(
+        _ outcome: DiagnosticOutcome,
+        isPreviewTrigger: Bool,
+        isDebugBuild: Bool
+    ) -> Bool {
+        switch outcome {
+        case .unavailable(let reason):
+            guard let reason else { return true }
+            return !suppressedReasons.contains(reason)
+        case .skipped:
+            return isDebugBuild || isPreviewTrigger
+        }
+    }
+
+    private static func isVisible(
+        isDebugBuild: Bool,
+        environment: AppReceiptsHelper.Environment,
+        enabledInTestFlight: Bool
+    ) -> Bool {
+        if isDebugBuild { return true }
+        switch environment {
+        // In a non-DEBUG build, .debug still means a developer's own run: a release-configuration
+        // simulator build, or a device launched from Xcode (StoreKit's Xcode environment).
+        case .debug, .sandbox: return enabledInTestFlight
+        case .production: return false
+        }
+    }
+}
+
+// MARK: - Live inputs
+
+/// The one place the gate's inputs are bound to live SDK state, so a new input is added once rather
+/// than threaded through every call site.
+extension HeliumDiagnosticGate {
+
+    static func shouldShowNow(outcome: DiagnosticOutcome, fallbackShown: Bool, trigger: String) -> Bool {
+        shouldShow(
+            outcome: outcome,
+            fallbackShown: fallbackShown,
+            isPreviewTrigger: isPreviewTrigger(trigger),
+            isDebugBuild: isDebugBuild,
+            environment: AppReceiptsHelper.shared.environment,
+            displayEnabled: Helium.config.paywallNotShownDiagnosticDisplayEnabled,
+            enabledInTestFlight: Helium.config.paywallNotShownDiagnosticEnabledInTestFlight,
+            serverFlagEnabled: serverFlagEnabled,
+            doNotShowAgain: UserDefaults.standard.bool(forKey: doNotShowAgainKey)
+        )
+    }
+
+    static func isEnabledNow(trigger: String) -> Bool {
+        isEnabled(
+            isPreviewTrigger: isPreviewTrigger(trigger),
+            isDebugBuild: isDebugBuild,
+            environment: AppReceiptsHelper.shared.environment,
+            displayEnabled: Helium.config.paywallNotShownDiagnosticDisplayEnabled,
+            enabledInTestFlight: Helium.config.paywallNotShownDiagnosticEnabledInTestFlight,
+            serverFlagEnabled: serverFlagEnabled
+        )
+    }
+
+    /// Defaults open, so an outcome that fires before the on-launch response arrives is still
+    /// explained.
+    private static var serverFlagEnabled: Bool {
+        HeliumFetchedConfigManager.shared.fetchedConfig?.diagnosticModalEnabled ?? true
+    }
+
+    private static func isPreviewTrigger(_ trigger: String) -> Bool {
+        trigger == HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER
+    }
+}

--- a/Sources/Helium/HeliumCore/Diagnostic/HeliumDiagnosticGate.swift
+++ b/Sources/Helium/HeliumCore/Diagnostic/HeliumDiagnosticGate.swift
@@ -28,7 +28,7 @@ enum HeliumDiagnosticGate {
         environment: AppReceiptsHelper.Environment,
         displayEnabled: Bool,
         enabledInTestFlight: Bool,
-        serverFlagEnabled: Bool,
+        serverAllowsInTestFlight: @autoclosure () -> Bool,
         doNotShowAgain: @autoclosure () -> Bool
     ) -> Bool {
         // A rendered fallback paywall disproves the modal's authored outcome, which describes a user
@@ -43,7 +43,7 @@ enum HeliumDiagnosticGate {
             environment: environment,
             displayEnabled: displayEnabled,
             enabledInTestFlight: enabledInTestFlight,
-            serverFlagEnabled: serverFlagEnabled
+            serverAllowsInTestFlight: serverAllowsInTestFlight()
         ) else { return false }
         if isPreviewTrigger { return true }
         return !doNotShowAgain()
@@ -58,12 +58,16 @@ enum HeliumDiagnosticGate {
         environment: AppReceiptsHelper.Environment,
         displayEnabled: Bool,
         enabledInTestFlight: Bool,
-        serverFlagEnabled: Bool
+        serverAllowsInTestFlight: @autoclosure () -> Bool
     ) -> Bool {
         if isPreviewTrigger { return true }
         guard displayEnabled else { return false }
-        guard isVisible(isDebugBuild: isDebugBuild, environment: environment, enabledInTestFlight: enabledInTestFlight) else { return false }
-        return serverFlagEnabled
+        return isAllowedOnThisBuild(
+            isDebugBuild: isDebugBuild,
+            environment: environment,
+            enabledInTestFlight: enabledInTestFlight,
+            serverAllowsInTestFlight: serverAllowsInTestFlight()
+        )
     }
 
     /// The SDK ships as source, so this resolves against the host app's build configuration.
@@ -92,16 +96,20 @@ enum HeliumDiagnosticGate {
         }
     }
 
-    private static func isVisible(
+    /// The TestFlight opt-in and the server permission exist to keep a developer modal out of a
+    /// tester's hands, and a developer running a DEBUG build of their own app is not a tester.
+    private static func isAllowedOnThisBuild(
         isDebugBuild: Bool,
         environment: AppReceiptsHelper.Environment,
-        enabledInTestFlight: Bool
+        enabledInTestFlight: Bool,
+        serverAllowsInTestFlight: @autoclosure () -> Bool
     ) -> Bool {
         if isDebugBuild { return true }
         switch environment {
         // In a non-DEBUG build, .debug still means a developer's own run: a release-configuration
-        // simulator build, or a device launched from Xcode (StoreKit's Xcode environment).
-        case .debug, .sandbox: return enabledInTestFlight
+        // simulator build, or a device launched from Xcode (StoreKit's Xcode environment). It is a
+        // release binary all the same, so it answers to the same two permissions as TestFlight.
+        case .debug, .sandbox: return enabledInTestFlight && serverAllowsInTestFlight()
         case .production: return false
         }
     }
@@ -122,7 +130,7 @@ extension HeliumDiagnosticGate {
             environment: AppReceiptsHelper.shared.environment,
             displayEnabled: Helium.config.paywallNotShownDiagnosticDisplayEnabled,
             enabledInTestFlight: Helium.config.paywallNotShownDiagnosticEnabledInTestFlight,
-            serverFlagEnabled: serverFlagEnabled,
+            serverAllowsInTestFlight: serverAllowsInTestFlight,
             doNotShowAgain: UserDefaults.standard.bool(forKey: doNotShowAgainKey)
         )
     }
@@ -134,14 +142,14 @@ extension HeliumDiagnosticGate {
             environment: AppReceiptsHelper.shared.environment,
             displayEnabled: Helium.config.paywallNotShownDiagnosticDisplayEnabled,
             enabledInTestFlight: Helium.config.paywallNotShownDiagnosticEnabledInTestFlight,
-            serverFlagEnabled: serverFlagEnabled
+            serverAllowsInTestFlight: serverAllowsInTestFlight
         )
     }
 
-    /// Defaults open, so an outcome that fires before the on-launch response arrives is still
-    /// explained.
-    private static var serverFlagEnabled: Bool {
-        HeliumFetchedConfigManager.shared.fetchedConfig?.diagnosticModalEnabled ?? true
+    /// Absent means the server has not said otherwise, so an outcome that fires before the
+    /// on-launch response arrives is still explained.
+    private static var serverAllowsInTestFlight: Bool {
+        HeliumFetchedConfigManager.shared.fetchedConfig?.paywallDiagnosticModalAllowedInTestFlight ?? true
     }
 
     private static func isPreviewTrigger(_ trigger: String) -> Bool {

--- a/Sources/Helium/HeliumCore/Diagnostic/Model/DiagnosticOutcome.swift
+++ b/Sources/Helium/HeliumCore/Diagnostic/Model/DiagnosticOutcome.swift
@@ -1,0 +1,20 @@
+//
+//  DiagnosticOutcome.swift
+//  Helium
+//
+
+import Foundation
+
+/// Why Helium had no paywall to show, in the two shapes the SDK reports.
+///
+/// The distinction drives more than copy: a skip is Helium working as configured, so it warrants a
+/// far quieter response than a paywall that was meant to appear and didn't.
+enum DiagnosticOutcome {
+
+    /// A paywall was meant to show and could not. The reason is optional because the failing path
+    /// cannot always name one.
+    case unavailable(PaywallUnavailableReason?)
+
+    /// Helium deliberately chose not to show a paywall.
+    case skipped(PaywallSkippedReason)
+}

--- a/Sources/Helium/HeliumCore/FallbackDebugBanner.swift
+++ b/Sources/Helium/HeliumCore/FallbackDebugBanner.swift
@@ -3,9 +3,8 @@ import SwiftUI
 /// A banner spanning the top edge of a Helium fallback paywall, so a developer can tell at a glance
 /// that the live remote paywall was not the one that rendered.
 ///
-/// Shown from DEBUG builds only. The SDK ships as source rather than a binary, so `#if DEBUG`
-/// resolves against the host app's build configuration and this never reaches a TestFlight or
-/// App Store build.
+/// Rendering and tapping are governed by the same predicate, so the card is never on screen
+/// advertising details it would refuse to open.
 ///
 /// It spans the width so it reads as a notification rather than a chip. That is a deliberate trade:
 /// the card is interactive, so at full width it covers the top corners where paywalls place their
@@ -84,8 +83,6 @@ struct FallbackDebugBanner: View {
         .accessibilityAction(named: "Show diagnostics") { openDiagnostics() }
     }
 
-    /// The diagnostic view keeps its own gating, so a tap is silently ignored when the developer
-    /// has turned diagnostics off or ticked "do not show again".
     private func openDiagnostics() {
         guard !trigger.isEmpty else { return }
         let content = Self.diagnosticContentMapper.mapUnavailable(
@@ -125,7 +122,13 @@ extension FallbackDebugBanner {
 
     /// A non-nil reason means Helium resolved a fallback bundle in place of the live remote
     /// paywall, which is exactly what the banner reports.
-    static func shouldShow(fallbackReason: PaywallUnavailableReason?) -> Bool {
-        return fallbackReason != nil
+    ///
+    /// `diagnosticsEnabled` is deferred so a live paywall never pays for a gate check it cannot act
+    /// on.
+    static func shouldShow(
+        fallbackReason: PaywallUnavailableReason?,
+        diagnosticsEnabled: @autoclosure () -> Bool
+    ) -> Bool {
+        fallbackReason != nil && diagnosticsEnabled()
     }
 }

--- a/Sources/Helium/HeliumCore/HeliumAtomic.swift
+++ b/Sources/Helium/HeliumCore/HeliumAtomic.swift
@@ -47,23 +47,12 @@ final class HeliumAtomic<T>: @unchecked Sendable {
     }
     
     /// Performs an atomic read-modify-write operation.
-    /// - Parameter operation: A closure that receives mutable access to the wrapped value
-    /// - Returns: The updated value after the operation completes
-    @discardableResult
-    func withValue(_ operation: (inout T) -> Void) -> T {
-        queue.sync {
-            operation(&self.value)
-            return self.value
-        }
-    }
-
-    /// Performs an atomic operation that returns an arbitrary result.
     /// - Parameter operation: A closure that receives mutable access to the wrapped value and returns a result
     /// - Returns: The result of the operation
     @discardableResult
-    func withValue<R>(_ operation: (inout T) -> R) -> R {
-        queue.sync {
-            operation(&self.value)
+    func withValue<R>(_ operation: (inout T) throws -> R) rethrows -> R {
+        try queue.sync {
+            try operation(&self.value)
         }
     }
 }

--- a/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
+++ b/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
@@ -85,8 +85,10 @@ public struct DynamicBaseTemplateView: View {
 
     @ViewBuilder
     private var paywallContent: some View {
-        #if DEBUG
-        if FallbackDebugBanner.shouldShow(fallbackReason: fallbackReason) {
+        if FallbackDebugBanner.shouldShow(
+            fallbackReason: fallbackReason,
+            diagnosticsEnabled: HeliumDiagnosticGate.isEnabledNow(trigger: triggerName ?? "")
+        ) {
             ZStack(alignment: .top) {
                 paywallWebView
                 // The stack keeps its safe-area inset while the paywall bleeds past it, so the
@@ -102,9 +104,6 @@ public struct DynamicBaseTemplateView: View {
         } else {
             paywallWebView
         }
-        #else
-        paywallWebView
-        #endif
     }
 }
 

--- a/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
@@ -38,7 +38,7 @@ actor HeliumEntitlementsManager {
     
     /// How long until the cache should be considered stale, in seconds.
     private var cacheResetInterval: TimeInterval {
-        let isProduction = AppReceiptsHelper.shared.getEnvironment() == AppReceiptsHelper.Environment.production.rawValue
+        let isProduction = AppReceiptsHelper.shared.environment == .production
         let numMinutes: TimeInterval = isProduction ? 30 : 3
         return 60 * numMinutes
     }

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -1031,80 +1031,111 @@ public class HeliumFetchedConfigManager {
         productIdsStripeWeb: [String],
         webPaywallBundleUrl: String? = nil,
     ) throws {
-        // Clone-and-modify holds the config lock so a fetch completing mid-update cannot be
-        // clobbered by the write-back of an older copy. The JSON mirror is updated while that lock
-        // is held: the only place these two locks nest, and always in this order.
-        //
-        // Nothing inside may touch `self.fetchedConfig` or `self.fetchedConfigJSON`, whose getters
-        // take the very locks held here.
-        try _fetchedConfig.withValue { stored in
+        // Read-modify-write under the lock, so a fetch landing mid-update is not clobbered by the
+        // write-back of a copy taken before it.
+        let sourceTrigger = try _fetchedConfig.withValue { stored -> String in
             guard var config = stored else {
                 throw HeliumControlPanelError.noConfigAvailable
             }
-
-            guard let sourceTrigger = config.triggerToPaywalls.keys
-                .filter({ $0 != Self.HELIUM_PREVIEW_TRIGGER })
-                .sorted()
-                .first,
-                  var previewPaywallInfo = config.triggerToPaywalls[sourceTrigger] else {
-                throw HeliumControlPanelError.noSourceTrigger
-            }
-
-            // Update the bundle URL in resolvedConfig so extractedBundleUrl returns our new URL
-            guard var resolvedConfigDict = previewPaywallInfo.resolvedConfig.value as? [String: Any],
-                  var baseStack = resolvedConfigDict["baseStack"] as? [String: Any],
-                  var componentProps = baseStack["componentProps"] as? [String: Any] else {
-                throw HeliumControlPanelError.invalidResolvedConfig
-            }
-            componentProps["bundleURL"] = bundleUrl
-            baseStack["componentProps"] = componentProps
-            resolvedConfigDict["baseStack"] = baseStack
-            previewPaywallInfo.resolvedConfig = AnyCodable(resolvedConfigDict)
-
-            // Update additionalPaywallFields
-            var additionalFields = previewPaywallInfo.additionalPaywallFields ?? JSON([:])
-            additionalFields["paywallBundleUrl"] = JSON(bundleUrl)
-            // Use the previewed version's own web checkout URL. When the preview response
-            // doesn't provide one, the value inherited from the source trigger would open the
-            // wrong web paywall at checkout, so null it and let app2web checkout fail
-            // explicitly (webPaywallBundleUrlMissing) instead.
-            if let webPaywallBundleUrl, !webPaywallBundleUrl.isEmpty {
-                additionalFields["webPaywallBundleUrl"] = JSON(webPaywallBundleUrl)
-            } else {
-                additionalFields["webPaywallBundleUrl"] = JSON.null
-            }
-            previewPaywallInfo.additionalPaywallFields = additionalFields
-
-            // Update product IDs
-            previewPaywallInfo.productsOfferedIOS = productIds
-            previewPaywallInfo.productsOfferedStripe = productIdsStripe
-            previewPaywallInfo.productsOfferedPaddle = productIdsPaddle
-            previewPaywallInfo.webProductsOfferedPaddle = productIdsPaddleWeb
-            previewPaywallInfo.webProductsOfferedStripe = productIdsStripeWeb
-
-            // Clear fields inherited from source trigger that would interfere with preview
-            previewPaywallInfo.forceShowFallback = nil
-
-            // Store the preview trigger config
-            config.triggerToPaywalls[Self.HELIUM_PREVIEW_TRIGGER] = previewPaywallInfo
-
-            // Store the bundle HTML
-            if config.bundles == nil {
-                config.bundles = [:]
-            }
-            config.bundles?[bundleId] = bundleHtml
-
+            let sourceTrigger = try Self.installPreviewTrigger(
+                in: &config,
+                bundleId: bundleId,
+                bundleUrl: bundleUrl,
+                bundleHtml: bundleHtml,
+                productIds: productIds,
+                productIdsStripe: productIdsStripe,
+                productIdsPaddle: productIdsPaddle,
+                productIdsPaddleWeb: productIdsPaddleWeb,
+                productIdsStripeWeb: productIdsStripeWeb,
+                webPaywallBundleUrl: webPaywallBundleUrl
+            )
             stored = config
-
-            // Also update fetchedConfigJSON so getResolvedConfigJSONForTrigger works
-            _fetchedConfigJSON.withValue { json in
-                guard var configJSON = json else { return }
-                var sourceJSON = configJSON["triggerToPaywalls"][sourceTrigger]
-                sourceJSON["resolvedConfig"]["baseStack"]["componentProps"]["bundleURL"] = JSON(bundleUrl)
-                configJSON["triggerToPaywalls"][Self.HELIUM_PREVIEW_TRIGGER] = sourceJSON
-                json = configJSON
-            }
+            return sourceTrigger
         }
+
+        _fetchedConfigJSON.withValue { json in
+            guard let configJSON = json else { return }
+            json = Self.withPreviewTrigger(configJSON, clonedFrom: sourceTrigger, bundleUrl: bundleUrl)
+        }
+    }
+
+    /// Returns the trigger the preview was cloned from: the JSON mirror has to clone the same
+    /// entry, and only this transform knows which one it picked.
+    private static func installPreviewTrigger(
+        in config: inout HeliumFetchedConfig,
+        bundleId: String,
+        bundleUrl: String,
+        bundleHtml: String,
+        productIds: [String],
+        productIdsStripe: [String],
+        productIdsPaddle: [String],
+        productIdsPaddleWeb: [String],
+        productIdsStripeWeb: [String],
+        webPaywallBundleUrl: String?
+    ) throws -> String {
+        guard let sourceTrigger = config.triggerToPaywalls.keys
+            .filter({ $0 != HELIUM_PREVIEW_TRIGGER })
+            .sorted()
+            .first,
+              var previewPaywallInfo = config.triggerToPaywalls[sourceTrigger] else {
+            throw HeliumControlPanelError.noSourceTrigger
+        }
+
+        // A paywall's bundle URL is resolved from this nested config before any other field, so a
+        // donor URL left in place here would win over the preview's own.
+        guard var resolvedConfigDict = previewPaywallInfo.resolvedConfig.value as? [String: Any],
+              var baseStack = resolvedConfigDict["baseStack"] as? [String: Any],
+              var componentProps = baseStack["componentProps"] as? [String: Any] else {
+            throw HeliumControlPanelError.invalidResolvedConfig
+        }
+        componentProps["bundleURL"] = bundleUrl
+        baseStack["componentProps"] = componentProps
+        resolvedConfigDict["baseStack"] = baseStack
+        previewPaywallInfo.resolvedConfig = AnyCodable(resolvedConfigDict)
+
+        var additionalFields = previewPaywallInfo.additionalPaywallFields ?? JSON([:])
+        additionalFields["paywallBundleUrl"] = JSON(bundleUrl)
+        // Use the previewed version's own web checkout URL. When the preview response
+        // doesn't provide one, the value inherited from the source trigger would open the
+        // wrong web paywall at checkout, so null it and let app2web checkout fail
+        // explicitly (webPaywallBundleUrlMissing) instead.
+        if let webPaywallBundleUrl, !webPaywallBundleUrl.isEmpty {
+            additionalFields["webPaywallBundleUrl"] = JSON(webPaywallBundleUrl)
+        } else {
+            additionalFields["webPaywallBundleUrl"] = JSON.null
+        }
+        previewPaywallInfo.additionalPaywallFields = additionalFields
+
+        previewPaywallInfo.productsOfferedIOS = productIds
+        previewPaywallInfo.productsOfferedStripe = productIdsStripe
+        previewPaywallInfo.productsOfferedPaddle = productIdsPaddle
+        previewPaywallInfo.webProductsOfferedPaddle = productIdsPaddleWeb
+        previewPaywallInfo.webProductsOfferedStripe = productIdsStripeWeb
+
+        // Inherited from the source trigger, where it would send the preview to a fallback paywall
+        // instead of the version the developer picked.
+        previewPaywallInfo.forceShowFallback = nil
+
+        config.triggerToPaywalls[HELIUM_PREVIEW_TRIGGER] = previewPaywallInfo
+
+        if config.bundles == nil {
+            config.bundles = [:]
+        }
+        config.bundles?[bundleId] = bundleHtml
+
+        return sourceTrigger
+    }
+
+    private static func withPreviewTrigger(
+        _ configJSON: JSON,
+        clonedFrom sourceTrigger: String,
+        bundleUrl: String
+    ) -> JSON {
+        var configJSON = configJSON
+        var sourceJSON = configJSON["triggerToPaywalls"][sourceTrigger]
+        sourceJSON["resolvedConfig"]["baseStack"]["componentProps"]["bundleURL"] = JSON(bundleUrl)
+        configJSON["triggerToPaywalls"][HELIUM_PREVIEW_TRIGGER] = sourceJSON
+        return configJSON
     }
 }
 

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -231,9 +231,9 @@ public class HeliumFetchedConfigManager {
     static let MAX_NUM_CONFIG_ATTEMPTS: Int = 6 // roughly 36 seconds of delays in between attempts
     static let MAX_NUM_BUNDLE_ATTEMPTS: Int = 4 // roughly 7 seconds of delays in between attempts
     
-    private(set) var fetchedConfig: HeliumFetchedConfig?
-    private(set) var fetchedConfigJSON: JSON?
-    private(set) var triggersWithSkippedBundleAndReason: [(trigger: String, reason: PaywallUnavailableReason)] = []
+    @HeliumAtomic private(set) var fetchedConfig: HeliumFetchedConfig?
+    @HeliumAtomic private(set) var fetchedConfigJSON: JSON?
+    @HeliumAtomic private(set) var triggersWithSkippedBundleAndReason: [(trigger: String, reason: PaywallUnavailableReason)] = []
     @HeliumAtomic private var localizedPriceMap: [String: LocalizedPrice] = [:]
     
     func fetchConfig(
@@ -355,7 +355,8 @@ public class HeliumFetchedConfigManager {
             
             // Download assets
             
-            if (self.fetchedConfig?.bundles != nil && self.fetchedConfig?.bundles?.count ?? 0 > 0) {
+            let preloadedBundles = self.fetchedConfig?.bundles
+            if let preloadedBundles, !preloadedBundles.isEmpty {
                 // Start price fetch async (with timing), then do sync bundle save, then await price
                 async let priceTask: (UInt64, Bool) = {
                     let start = DispatchTime.now()
@@ -363,8 +364,7 @@ public class HeliumFetchedConfigManager {
                     return (dispatchTimeDifferenceInMS(from: start), success)
                 }()
 
-                let bundles = (self.fetchedConfig?.bundles)!
-                let bytesWritten = saveBundleAssets(bundles: bundles)
+                let bytesWritten = saveBundleAssets(bundles: preloadedBundles)
                 let sizeKB = Int(round(Double(bytesWritten) / 1024.0))
 
                 // Bundles saved, switch to products step
@@ -375,7 +375,7 @@ public class HeliumFetchedConfigManager {
 
                 let metrics = HeliumFetchMetrics(
                     numConfigAttempts: attemptCounter,
-                    numBundles: fetchedConfig?.bundles?.count ?? 0,
+                    numBundles: preloadedBundles.count,
                     numBundlesFromCache: 0,
                     bundleFailCount: 0,
                     configDownloadTimeMS: configDownloadTimeMS,
@@ -414,7 +414,7 @@ public class HeliumFetchedConfigManager {
                 
                 let bundles = bundlesResult.successMapBundleIdToHtml
                 guard !Task.isCancelled else { return }
-                fetchedConfig?.bundles = bundles
+                _fetchedConfig.withValue { $0?.bundles = bundles }
                 let bytesWritten = saveBundleAssets(bundles: bundles)
                 let sizeKB = Int(round(Double(bytesWritten) / 1024.0))
                 
@@ -1031,71 +1031,79 @@ public class HeliumFetchedConfigManager {
         productIdsStripeWeb: [String],
         webPaywallBundleUrl: String? = nil,
     ) throws {
-        guard var config = fetchedConfig else {
-            throw HeliumControlPanelError.noConfigAvailable
-        }
+        // Clone-and-modify holds the config lock so a fetch completing mid-update cannot be
+        // clobbered by the write-back of an older copy. The JSON mirror is updated while that lock
+        // is held: the only place these two locks nest, and always in this order.
+        //
+        // Nothing inside may touch `self.fetchedConfig` or `self.fetchedConfigJSON`, whose getters
+        // take the very locks held here.
+        try _fetchedConfig.withValue { stored in
+            guard var config = stored else {
+                throw HeliumControlPanelError.noConfigAvailable
+            }
 
-        guard let sourceTrigger = config.triggerToPaywalls.keys
-            .filter({ $0 != Self.HELIUM_PREVIEW_TRIGGER })
-            .sorted()
-            .first,
-              var previewPaywallInfo = config.triggerToPaywalls[sourceTrigger] else {
-            throw HeliumControlPanelError.noSourceTrigger
-        }
+            guard let sourceTrigger = config.triggerToPaywalls.keys
+                .filter({ $0 != Self.HELIUM_PREVIEW_TRIGGER })
+                .sorted()
+                .first,
+                  var previewPaywallInfo = config.triggerToPaywalls[sourceTrigger] else {
+                throw HeliumControlPanelError.noSourceTrigger
+            }
 
-        // Update the bundle URL in resolvedConfig so extractedBundleUrl returns our new URL
-        guard var resolvedConfigDict = previewPaywallInfo.resolvedConfig.value as? [String: Any],
-              var baseStack = resolvedConfigDict["baseStack"] as? [String: Any],
-              var componentProps = baseStack["componentProps"] as? [String: Any] else {
-            throw HeliumControlPanelError.invalidResolvedConfig
-        }
-        componentProps["bundleURL"] = bundleUrl
-        baseStack["componentProps"] = componentProps
-        resolvedConfigDict["baseStack"] = baseStack
-        previewPaywallInfo.resolvedConfig = AnyCodable(resolvedConfigDict)
+            // Update the bundle URL in resolvedConfig so extractedBundleUrl returns our new URL
+            guard var resolvedConfigDict = previewPaywallInfo.resolvedConfig.value as? [String: Any],
+                  var baseStack = resolvedConfigDict["baseStack"] as? [String: Any],
+                  var componentProps = baseStack["componentProps"] as? [String: Any] else {
+                throw HeliumControlPanelError.invalidResolvedConfig
+            }
+            componentProps["bundleURL"] = bundleUrl
+            baseStack["componentProps"] = componentProps
+            resolvedConfigDict["baseStack"] = baseStack
+            previewPaywallInfo.resolvedConfig = AnyCodable(resolvedConfigDict)
 
-        // Update additionalPaywallFields
-        var additionalFields = previewPaywallInfo.additionalPaywallFields ?? JSON([:])
-        additionalFields["paywallBundleUrl"] = JSON(bundleUrl)
-        // Use the previewed version's own web checkout URL. When the preview response
-        // doesn't provide one, the value inherited from the source trigger would open the
-        // wrong web paywall at checkout, so null it and let app2web checkout fail
-        // explicitly (webPaywallBundleUrlMissing) instead.
-        if let webPaywallBundleUrl, !webPaywallBundleUrl.isEmpty {
-            additionalFields["webPaywallBundleUrl"] = JSON(webPaywallBundleUrl)
-        } else {
-            additionalFields["webPaywallBundleUrl"] = JSON.null
-        }
-        previewPaywallInfo.additionalPaywallFields = additionalFields
+            // Update additionalPaywallFields
+            var additionalFields = previewPaywallInfo.additionalPaywallFields ?? JSON([:])
+            additionalFields["paywallBundleUrl"] = JSON(bundleUrl)
+            // Use the previewed version's own web checkout URL. When the preview response
+            // doesn't provide one, the value inherited from the source trigger would open the
+            // wrong web paywall at checkout, so null it and let app2web checkout fail
+            // explicitly (webPaywallBundleUrlMissing) instead.
+            if let webPaywallBundleUrl, !webPaywallBundleUrl.isEmpty {
+                additionalFields["webPaywallBundleUrl"] = JSON(webPaywallBundleUrl)
+            } else {
+                additionalFields["webPaywallBundleUrl"] = JSON.null
+            }
+            previewPaywallInfo.additionalPaywallFields = additionalFields
 
-        // Update product IDs
-        previewPaywallInfo.productsOfferedIOS = productIds
-        previewPaywallInfo.productsOfferedStripe = productIdsStripe
-        previewPaywallInfo.productsOfferedPaddle = productIdsPaddle
-        previewPaywallInfo.webProductsOfferedPaddle = productIdsPaddleWeb
-        previewPaywallInfo.webProductsOfferedStripe = productIdsStripeWeb
+            // Update product IDs
+            previewPaywallInfo.productsOfferedIOS = productIds
+            previewPaywallInfo.productsOfferedStripe = productIdsStripe
+            previewPaywallInfo.productsOfferedPaddle = productIdsPaddle
+            previewPaywallInfo.webProductsOfferedPaddle = productIdsPaddleWeb
+            previewPaywallInfo.webProductsOfferedStripe = productIdsStripeWeb
 
-        // Clear fields inherited from source trigger that would interfere with preview
-        previewPaywallInfo.forceShowFallback = nil
+            // Clear fields inherited from source trigger that would interfere with preview
+            previewPaywallInfo.forceShowFallback = nil
 
-        // Store the preview trigger config
-        config.triggerToPaywalls[Self.HELIUM_PREVIEW_TRIGGER] = previewPaywallInfo
+            // Store the preview trigger config
+            config.triggerToPaywalls[Self.HELIUM_PREVIEW_TRIGGER] = previewPaywallInfo
 
-        // Store the bundle HTML
-        if config.bundles == nil {
-            config.bundles = [:]
-        }
-        config.bundles?[bundleId] = bundleHtml
+            // Store the bundle HTML
+            if config.bundles == nil {
+                config.bundles = [:]
+            }
+            config.bundles?[bundleId] = bundleHtml
 
-        // Update the fetched config
-        fetchedConfig = config
+            stored = config
 
-        // Also update fetchedConfigJSON so getResolvedConfigJSONForTrigger works
-        if var configJSON = fetchedConfigJSON {
-            var sourceJSON = configJSON["triggerToPaywalls"][sourceTrigger]
-            sourceJSON["resolvedConfig"]["baseStack"]["componentProps"]["bundleURL"] = JSON(bundleUrl)
-            configJSON["triggerToPaywalls"][Self.HELIUM_PREVIEW_TRIGGER] = sourceJSON
-            fetchedConfigJSON = configJSON
+            // Also update fetchedConfigJSON so getResolvedConfigJSONForTrigger works
+            _fetchedConfigJSON.withValue { json in
+                guard var configJSON = json else { return }
+                var sourceJSON = configJSON["triggerToPaywalls"][sourceTrigger]
+                sourceJSON["resolvedConfig"]["baseStack"]["componentProps"]["bundleURL"] = JSON(bundleUrl)
+                configJSON["triggerToPaywalls"][Self.HELIUM_PREVIEW_TRIGGER] = sourceJSON
+                json = configJSON
+            }
         }
     }
 }

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -348,22 +348,12 @@ class HeliumPaywallDelegateWrapper {
             metadata: logMetadata
         )
 
-#if DEBUG
-        let canShowDiagnosticView = true
-#else
-        let canShowDiagnosticView = trigger == HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER
-#endif
-        if canShowDiagnosticView {
-            if !fallbackShown && paywallUnavailableReason != .alreadyPresented {
-                Task { @MainActor in
-                    HeliumPaywallDiagnosticView.presentIfNeeded(
-                        trigger: trigger,
-                        content: content,
-                        fallbackShown: fallbackShown
-                    )
-                }
-            }
-        }
+        presentDiagnosticIfNeeded(
+            trigger: trigger,
+            content: content,
+            outcome: .unavailable(paywallUnavailableReason),
+            fallbackShown: fallbackShown
+        )
     }
 
     private func logPaywallSkip(
@@ -379,15 +369,33 @@ class HeliumPaywallDelegateWrapper {
             metadata: logMetadata
         )
 
-#if DEBUG
+        presentDiagnosticIfNeeded(
+            trigger: trigger,
+            content: content,
+            outcome: .skipped(skipReason),
+            fallbackShown: false
+        )
+    }
+
+    private func presentDiagnosticIfNeeded(
+        trigger: String,
+        content: DiagnosticContent,
+        outcome: DiagnosticOutcome,
+        fallbackShown: Bool
+    ) {
+        guard HeliumDiagnosticGate.shouldShowNow(
+            outcome: outcome,
+            fallbackShown: fallbackShown,
+            trigger: trigger
+        ) else { return }
+
         Task { @MainActor in
             HeliumPaywallDiagnosticView.presentIfNeeded(
                 trigger: trigger,
                 content: content,
-                fallbackShown: false
+                fallbackShown: fallbackShown
             )
         }
-#endif
     }
 
     // MARK: - Pending Purchase Observation

--- a/Sources/Helium/HeliumCore/HeliumPaywallDiagnosticView.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDiagnosticView.swift
@@ -23,7 +23,7 @@ struct HeliumPaywallDiagnosticView: View {
 
     let onDismiss: () -> Void
 
-    @State private var doNotShowAgain: Bool = UserDefaults.standard.bool(forKey: "heliumDiagnosticDoNotShowAgain")
+    @State private var doNotShowAgain: Bool = UserDefaults.standard.bool(forKey: HeliumDiagnosticGate.doNotShowAgainKey)
 
     private let styleMapper = DiagnosticCategoryStyleMapper()
     private let reportMapper = DiagnosticReportMapper()
@@ -255,7 +255,7 @@ struct HeliumPaywallDiagnosticView: View {
         }
         .toggleStyle(CheckboxToggleStyle())
         .onChange(of: doNotShowAgain) { newValue in
-            UserDefaults.standard.set(newValue, forKey: "heliumDiagnosticDoNotShowAgain")
+            UserDefaults.standard.set(newValue, forKey: HeliumDiagnosticGate.doNotShowAgainKey)
         }
         .padding(.top, 20)
     }
@@ -265,7 +265,7 @@ struct HeliumPaywallDiagnosticView: View {
     private var footer: some View {
         VStack(alignment: .leading, spacing: 10) {
             if !isForPreview {
-                Text("This diagnostic view is only shown in DEBUG builds.\n\nYou can disable it by setting Helium.config.paywallNotShownDiagnosticDisplayEnabled to false.")
+                Text("Visible in debug builds, and in TestFlight builds only if opted in. App Store users never see this.\n\nYou can disable it by setting Helium.config.paywallNotShownDiagnosticDisplayEnabled to false.")
                     .font(.footnote)
                     .foregroundColor(.secondary)
             }
@@ -334,24 +334,17 @@ extension HeliumPaywallDiagnosticView {
         diagnosticWindow = nil
     }
 
+    /// Enforces only what no caller can be trusted to get wrong: that a full-screen developer modal
+    /// never reaches a build where diagnostics are off. Whether a given outcome deserves an
+    /// unprompted modal is the caller's judgement, and is re-checked here because callers reach the
+    /// main actor asynchronously and the flags can change on the way.
+    ///
     /// - Parameter fallbackShown: true when a fallback paywall is on screen behind the diagnostic.
-    ///   Required rather than defaulted, because a caller that omits it is exactly the caller whose
-    ///   modal would claim an outcome its own paywall disproves.
     @MainActor
     static func presentIfNeeded(trigger: String, content: DiagnosticContent, fallbackShown: Bool) {
-        guard shouldPresent(trigger: trigger) else { return }
+        guard !isCurrentlyPresented else { return }
+        guard HeliumDiagnosticGate.isEnabledNow(trigger: trigger) else { return }
         present(content: content, triggerName: trigger, fallbackShown: fallbackShown)
-    }
-
-    @MainActor
-    private static func shouldPresent(trigger: String) -> Bool {
-        guard !isCurrentlyPresented else { return false }
-        if trigger == HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER {
-            return true
-        }
-        guard Helium.config.paywallNotShownDiagnosticDisplayEnabled else { return false }
-        guard !UserDefaults.standard.bool(forKey: "heliumDiagnosticDoNotShowAgain") else { return false }
-        return true
     }
 
     @MainActor

--- a/Sources/Helium/HeliumCore/Models.swift
+++ b/Sources/Helium/HeliumCore/Models.swift
@@ -123,9 +123,10 @@ public struct HeliumFetchedConfig: Codable {
     var stripeCustomerId: String?
     var enableProductionPaywallPreviews: Bool?
 
-    /// Kill switch for the paywall-not-shown diagnostic modal. Best effort: outcomes that fire
-    /// before the on-launch response arrives cannot consult it.
-    var diagnosticModalEnabled: Bool?
+    /// Server-side permission for the paywall-not-shown diagnostic modal outside DEBUG builds:
+    /// TestFlight, plus release builds on a simulator or launched from Xcode. A DEBUG build answers
+    /// to the SDK flag alone and never consults this. Absent means allowed.
+    var paywallDiagnosticModalAllowedInTestFlight: Bool?
     
     var paddleProducts: [String: ServerProductPrice]?
     var paddleCustomerId: String?

--- a/Sources/Helium/HeliumCore/Models.swift
+++ b/Sources/Helium/HeliumCore/Models.swift
@@ -122,6 +122,10 @@ public struct HeliumFetchedConfig: Codable {
     var stripeProducts: [String: ServerProductPrice]?
     var stripeCustomerId: String?
     var enableProductionPaywallPreviews: Bool?
+
+    /// Kill switch for the paywall-not-shown diagnostic modal. Best effort: outcomes that fire
+    /// before the on-launch response arrives cannot consult it.
+    var diagnosticModalEnabled: Bool?
     
     var paddleProducts: [String: ServerProductPrice]?
     var paddleCustomerId: String?

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -706,11 +706,29 @@ public class HeliumConfig {
     /// Adjust the text copy for the dialog that shows when a user attempts to restore purchases but does not have any to restore. You can also disable the dialog from showing.
     public let restorePurchasesDialog = RestorePurchaseConfig()
     
-    /// Controls whether a debug diagnostic view is shown when a paywall fails to display or is skipped.
-    /// Only applies in DEBUG builds. Defaults to `true`.
-    /// The debug view also contains a "Do not show again" checkbox that persists per-device via UserDefaults (resets on app delete).
-    /// Set this to `false` to disable the diagnostic view for all users in DEBUG builds.
+    /// Controls whether a diagnostic view is shown when a paywall fails to display or is skipped.
+    /// Defaults to `true`.
+    ///
+    /// Applies in DEBUG builds. Release builds running through TestFlight, on a simulator, or from
+    /// Xcode on a device also need ``paywallNotShownDiagnosticEnabledInTestFlight``. App Store
+    /// users never see it.
+    /// The diagnostic view also contains a "Do not show again" checkbox that persists per-device via UserDefaults (resets on app delete).
+    ///
+    /// Set this to `false` to turn the diagnostic view off. Paywall previews opened from the Helium
+    /// dashboard are exempt and continue to explain themselves. Helium can also disable the view
+    /// remotely, so `true` permits it rather than guarantees it.
     public var paywallNotShownDiagnosticDisplayEnabled: Bool = true
+
+    /// Controls whether the paywall diagnostic view is shown outside DEBUG builds, which covers
+    /// TestFlight testers and release builds run on a simulator or from Xcode on a device.
+    /// Defaults to `false`, since TestFlight builds reach real testers who would otherwise see a
+    /// full-screen developer modal. Set it to `true` for internal builds whose testers can act on
+    /// the diagnosis.
+    ///
+    /// Even when enabled, the view stays out of the way of anything working as configured: paywalls
+    /// skipped for entitled users or targeting holdouts are logged rather than shown. This has no
+    /// effect on App Store builds, which never show the diagnostic view.
+    public var paywallNotShownDiagnosticEnabledInTestFlight: Bool = false
 
     /// Controls whether the triple-tap paywall previews gesture is enabled in DEBUG and TestFlight builds.
     ///
@@ -1063,7 +1081,7 @@ public class HeliumTesting {
     }
 
     private var isProductionEnvironment: Bool {
-        AppReceiptsHelper.shared.getEnvironment() == AppReceiptsHelper.Environment.production.rawValue
+        AppReceiptsHelper.shared.environment == .production
     }
 }
 

--- a/Tests/helium-swiftTests/FallbackDebugBannerTests.swift
+++ b/Tests/helium-swiftTests/FallbackDebugBannerTests.swift
@@ -15,7 +15,23 @@ final class FallbackDebugBannerTests: XCTestCase {
     }
 
     func testBannerHiddenForLiveRemotePaywall() {
-        XCTAssertFalse(FallbackDebugBanner.shouldShow(fallbackReason: nil))
+        XCTAssertFalse(FallbackDebugBanner.shouldShow(fallbackReason: nil, diagnosticsEnabled: true))
+    }
+
+    /// The card's only action is opening the diagnostic modal, so it goes away with it rather than
+    /// sitting on the paywall offering details it would refuse to show.
+    func testBannerHiddenWhenDiagnosticsAreDisabled() {
+        XCTAssertFalse(
+            FallbackDebugBanner.shouldShow(fallbackReason: .triggerHasNoPaywall, diagnosticsEnabled: false)
+        )
+    }
+
+    func testTheGateIsNotConsultedForALiveRemotePaywall() {
+        var reads = 0
+
+        _ = FallbackDebugBanner.shouldShow(fallbackReason: nil, diagnosticsEnabled: { reads += 1; return true }())
+
+        XCTAssertEqual(reads, 0)
     }
 
     func testBannerShownWhenFallbackReasonPresent() {
@@ -34,7 +50,7 @@ final class FallbackDebugBannerTests: XCTestCase {
 
         for reason in reasons {
             XCTAssertTrue(
-                FallbackDebugBanner.shouldShow(fallbackReason: reason),
+                FallbackDebugBanner.shouldShow(fallbackReason: reason, diagnosticsEnabled: true),
                 "Expected the banner to show for fallback reason \(reason.rawValue)"
             )
         }
@@ -52,6 +68,8 @@ final class FallbackDebugBannerTests: XCTestCase {
         )
 
         XCTAssertEqual(result.fallbackReason, .triggerHasNoPaywall)
-        XCTAssertTrue(FallbackDebugBanner.shouldShow(fallbackReason: result.fallbackReason))
+        XCTAssertTrue(
+            FallbackDebugBanner.shouldShow(fallbackReason: result.fallbackReason, diagnosticsEnabled: true)
+        )
     }
 }

--- a/Tests/helium-swiftTests/HeliumDiagnosticGateTests.swift
+++ b/Tests/helium-swiftTests/HeliumDiagnosticGateTests.swift
@@ -14,7 +14,7 @@ final class HeliumDiagnosticGateTests: XCTestCase {
         environment: AppReceiptsHelper.Environment = .debug,
         displayEnabled: Bool = true,
         enabledInTestFlight: Bool = true,
-        serverFlagEnabled: Bool = true,
+        serverAllowsInTestFlight: () -> Bool = { true },
         doNotShowAgain: () -> Bool = { false }
     ) -> Bool {
         HeliumDiagnosticGate.shouldShow(
@@ -25,7 +25,7 @@ final class HeliumDiagnosticGateTests: XCTestCase {
             environment: environment,
             displayEnabled: displayEnabled,
             enabledInTestFlight: enabledInTestFlight,
-            serverFlagEnabled: serverFlagEnabled,
+            serverAllowsInTestFlight: serverAllowsInTestFlight(),
             doNotShowAgain: doNotShowAgain()
         )
     }
@@ -36,7 +36,7 @@ final class HeliumDiagnosticGateTests: XCTestCase {
         environment: AppReceiptsHelper.Environment = .debug,
         displayEnabled: Bool = true,
         enabledInTestFlight: Bool = true,
-        serverFlagEnabled: Bool = true
+        serverAllowsInTestFlight: () -> Bool = { true }
     ) -> Bool {
         HeliumDiagnosticGate.isEnabled(
             isPreviewTrigger: isPreviewTrigger,
@@ -44,7 +44,7 @@ final class HeliumDiagnosticGateTests: XCTestCase {
             environment: environment,
             displayEnabled: displayEnabled,
             enabledInTestFlight: enabledInTestFlight,
-            serverFlagEnabled: serverFlagEnabled
+            serverAllowsInTestFlight: serverAllowsInTestFlight()
         )
     }
 
@@ -126,7 +126,7 @@ final class HeliumDiagnosticGateTests: XCTestCase {
                 environment: .production,
                 displayEnabled: false,
                 enabledInTestFlight: false,
-                serverFlagEnabled: false,
+                serverAllowsInTestFlight: { false },
                 doNotShowAgain: { true }
             )
         )
@@ -166,11 +166,50 @@ final class HeliumDiagnosticGateTests: XCTestCase {
         XCTAssertTrue(shouldShow(isDebugBuild: true, environment: .debug, enabledInTestFlight: false))
     }
 
-    // MARK: - Server kill switch
+    // MARK: - Server permission
 
-    func testServerKillSwitchOffNeverShows() {
-        XCTAssertFalse(shouldShow(serverFlagEnabled: false))
-        XCTAssertFalse(shouldShow(environment: .sandbox, serverFlagEnabled: false))
+    func testTheServerFlagClosesBuildsThatAreNotDebug() {
+        XCTAssertFalse(shouldShow(serverAllowsInTestFlight: { false }))
+        XCTAssertFalse(shouldShow(environment: .sandbox, serverAllowsInTestFlight: { false }))
+    }
+
+    /// The remote permission exists to keep a developer modal out of a tester's hands. A developer
+    /// running their own debug build is not a tester, so nothing remote can take the fallback badge
+    /// or the modal it opens away from them.
+    func testTheServerFlagDoesNotReachDebugBuilds() {
+        XCTAssertTrue(shouldShow(isDebugBuild: true, serverAllowsInTestFlight: { false }))
+        XCTAssertTrue(isEnabled(isDebugBuild: true, serverAllowsInTestFlight: { false }))
+        XCTAssertTrue(
+            isEnabled(
+                isDebugBuild: true,
+                environment: .sandbox,
+                enabledInTestFlight: false,
+                serverAllowsInTestFlight: { false }
+            )
+        )
+    }
+
+    func testTheSdkFlagIsTheOnlyThingThatClosesADebugBuild() {
+        XCTAssertFalse(
+            shouldShow(isDebugBuild: true, displayEnabled: false, serverAllowsInTestFlight: { false })
+        )
+        XCTAssertFalse(isEnabled(isDebugBuild: true, displayEnabled: false))
+    }
+
+    /// Reading the permission takes a lock a paywall render should never wait on, so every gate that
+    /// can answer without it has to.
+    func testAGateThatCanAnswerWithoutTheServerFlagNeverReadsIt() {
+        var reads = 0
+        let counting: () -> Bool = { reads += 1; return true }
+
+        _ = isEnabled(isDebugBuild: true, serverAllowsInTestFlight: counting)
+        _ = isEnabled(displayEnabled: false, serverAllowsInTestFlight: counting)
+        _ = isEnabled(environment: .production, serverAllowsInTestFlight: counting)
+        _ = isEnabled(environment: .sandbox, enabledInTestFlight: false, serverAllowsInTestFlight: counting)
+        _ = isEnabled(isPreviewTrigger: true, serverAllowsInTestFlight: counting)
+        _ = shouldShow(isDebugBuild: true, serverAllowsInTestFlight: counting)
+
+        XCTAssertEqual(reads, 0)
     }
 
     // MARK: - Do-not-show-again
@@ -194,7 +233,7 @@ final class HeliumDiagnosticGateTests: XCTestCase {
         _ = shouldShow(fallbackShown: true, doNotShowAgain: counting)
         _ = shouldShow(displayEnabled: false, doNotShowAgain: counting)
         _ = shouldShow(environment: .production, doNotShowAgain: counting)
-        _ = shouldShow(serverFlagEnabled: false, doNotShowAgain: counting)
+        _ = shouldShow(serverAllowsInTestFlight: { false }, doNotShowAgain: counting)
         _ = shouldShow(isPreviewTrigger: true, doNotShowAgain: counting)
 
         XCTAssertEqual(reads, 0)
@@ -213,7 +252,7 @@ final class HeliumDiagnosticGateTests: XCTestCase {
         XCTAssertFalse(isEnabled(displayEnabled: false))
         XCTAssertFalse(isEnabled(environment: .production))
         XCTAssertFalse(isEnabled(environment: .sandbox, enabledInTestFlight: false))
-        XCTAssertFalse(isEnabled(serverFlagEnabled: false))
+        XCTAssertFalse(isEnabled(serverAllowsInTestFlight: { false }))
     }
 
     func testDeliberatePathShowsWhenEveryPreferenceAllowsIt() {
@@ -229,7 +268,7 @@ final class HeliumDiagnosticGateTests: XCTestCase {
                 environment: .production,
                 displayEnabled: false,
                 enabledInTestFlight: false,
-                serverFlagEnabled: false
+                serverAllowsInTestFlight: { false }
             )
         )
     }

--- a/Tests/helium-swiftTests/HeliumDiagnosticGateTests.swift
+++ b/Tests/helium-swiftTests/HeliumDiagnosticGateTests.swift
@@ -1,0 +1,236 @@
+import XCTest
+@testable import Helium
+
+final class HeliumDiagnosticGateTests: XCTestCase {
+
+    /// Never suppressed, so each test isolates the gate under exercise.
+    private let showableOutcome = DiagnosticOutcome.unavailable(.triggerHasNoPaywall)
+
+    private func shouldShow(
+        outcome: DiagnosticOutcome? = nil,
+        fallbackShown: Bool = false,
+        isPreviewTrigger: Bool = false,
+        isDebugBuild: Bool = false,
+        environment: AppReceiptsHelper.Environment = .debug,
+        displayEnabled: Bool = true,
+        enabledInTestFlight: Bool = true,
+        serverFlagEnabled: Bool = true,
+        doNotShowAgain: () -> Bool = { false }
+    ) -> Bool {
+        HeliumDiagnosticGate.shouldShow(
+            outcome: outcome ?? showableOutcome,
+            fallbackShown: fallbackShown,
+            isPreviewTrigger: isPreviewTrigger,
+            isDebugBuild: isDebugBuild,
+            environment: environment,
+            displayEnabled: displayEnabled,
+            enabledInTestFlight: enabledInTestFlight,
+            serverFlagEnabled: serverFlagEnabled,
+            doNotShowAgain: doNotShowAgain()
+        )
+    }
+
+    private func isEnabled(
+        isPreviewTrigger: Bool = false,
+        isDebugBuild: Bool = false,
+        environment: AppReceiptsHelper.Environment = .debug,
+        displayEnabled: Bool = true,
+        enabledInTestFlight: Bool = true,
+        serverFlagEnabled: Bool = true
+    ) -> Bool {
+        HeliumDiagnosticGate.isEnabled(
+            isPreviewTrigger: isPreviewTrigger,
+            isDebugBuild: isDebugBuild,
+            environment: environment,
+            displayEnabled: displayEnabled,
+            enabledInTestFlight: enabledInTestFlight,
+            serverFlagEnabled: serverFlagEnabled
+        )
+    }
+
+    // MARK: - Suppression
+
+    func testAlreadyPresentedNeverShows() {
+        XCTAssertFalse(shouldShow(outcome: .unavailable(.alreadyPresented)))
+    }
+
+    func testAlreadyPresentedIsSuppressedEvenForThePreviewTrigger() {
+        XCTAssertFalse(shouldShow(outcome: .unavailable(.alreadyPresented), isPreviewTrigger: true))
+    }
+
+    func testSecondTryMissAndForcedFallbackShow() {
+        XCTAssertTrue(shouldShow(outcome: .unavailable(.secondTryNoMatch)))
+        XCTAssertTrue(shouldShow(outcome: .unavailable(.forceShowFallback)))
+    }
+
+    func testOnlyAlreadyPresentedIsSuppressed() {
+        let suppressed = PaywallUnavailableReason.allCases.filter { !shouldShow(outcome: .unavailable($0)) }
+
+        XCTAssertEqual(suppressed, [.alreadyPresented])
+    }
+
+    func testAFailureWithNoNamedReasonStillShows() {
+        XCTAssertTrue(shouldShow(outcome: .unavailable(nil)))
+    }
+
+    // MARK: - Skips
+
+    /// A skip is Helium working as configured, so it is worth a developer's attention but never a
+    /// tester's.
+    func testSkipsShowInDebugBuildsOnly() {
+        for reason in PaywallSkippedReason.allCases {
+            XCTAssertTrue(
+                shouldShow(outcome: .skipped(reason), isDebugBuild: true),
+                "Expected \(reason.rawValue) to show in a debug build"
+            )
+            XCTAssertFalse(
+                shouldShow(outcome: .skipped(reason), isDebugBuild: false, environment: .sandbox),
+                "Expected \(reason.rawValue) to stay out of TestFlight"
+            )
+        }
+    }
+
+    func testTheTestFlightOptInDoesNotBringSkipsWithIt() {
+        XCTAssertFalse(
+            shouldShow(
+                outcome: .skipped(.alreadyEntitled),
+                isDebugBuild: false,
+                environment: .sandbox,
+                enabledInTestFlight: true
+            )
+        )
+    }
+
+    func testSkipsStillExplainThemselvesInADashboardPreview() {
+        XCTAssertTrue(shouldShow(outcome: .skipped(.alreadyEntitled), isPreviewTrigger: true))
+    }
+
+    /// The rule is about skips, not about everything outside a debug build.
+    func testAFailureStillShowsOutsideADebugBuild() {
+        XCTAssertTrue(shouldShow(isDebugBuild: false, environment: .sandbox))
+    }
+
+    // MARK: - Modal / badge exclusivity
+
+    func testARenderedFallbackNeverShowsTheModalUnprompted() {
+        XCTAssertFalse(shouldShow(fallbackShown: true))
+        XCTAssertFalse(shouldShow(fallbackShown: true, isPreviewTrigger: true))
+    }
+
+    // MARK: - Preview bypass
+
+    func testPreviewTriggerShowsEvenWhenEveryOtherGateIsClosed() {
+        XCTAssertTrue(
+            shouldShow(
+                isPreviewTrigger: true,
+                environment: .production,
+                displayEnabled: false,
+                enabledInTestFlight: false,
+                serverFlagEnabled: false,
+                doNotShowAgain: { true }
+            )
+        )
+    }
+
+    // MARK: - Master flag
+
+    func testMasterFlagOffNeverShows() {
+        XCTAssertFalse(shouldShow(displayEnabled: false))
+        XCTAssertFalse(shouldShow(environment: .sandbox, displayEnabled: false))
+    }
+
+    // MARK: - Build / environment gate
+
+    func testDebugBuildShows() {
+        XCTAssertTrue(shouldShow(isDebugBuild: true, environment: .debug))
+    }
+
+    func testProductionNeverShows() {
+        XCTAssertFalse(shouldShow(environment: .production))
+        XCTAssertFalse(shouldShow(environment: .production, enabledInTestFlight: true))
+    }
+
+    func testTestFlightShowsOnlyWhenOptedIn() {
+        XCTAssertTrue(shouldShow(environment: .sandbox, enabledInTestFlight: true))
+        XCTAssertFalse(shouldShow(environment: .sandbox, enabledInTestFlight: false))
+    }
+
+    /// A .debug environment without a DEBUG-compiled build is a release-configuration run by a
+    /// developer: a simulator, or a device launched from Xcode.
+    func testDebugEnvironmentInAReleaseBuildRequiresTheOptIn() {
+        XCTAssertTrue(shouldShow(isDebugBuild: false, environment: .debug, enabledInTestFlight: true))
+        XCTAssertFalse(shouldShow(isDebugBuild: false, environment: .debug, enabledInTestFlight: false))
+    }
+
+    func testTestFlightOptInOffDoesNotAffectDebugBuilds() {
+        XCTAssertTrue(shouldShow(isDebugBuild: true, environment: .debug, enabledInTestFlight: false))
+    }
+
+    // MARK: - Server kill switch
+
+    func testServerKillSwitchOffNeverShows() {
+        XCTAssertFalse(shouldShow(serverFlagEnabled: false))
+        XCTAssertFalse(shouldShow(environment: .sandbox, serverFlagEnabled: false))
+    }
+
+    // MARK: - Do-not-show-again
+
+    func testDevicePrefSuppresses() {
+        XCTAssertFalse(shouldShow(doNotShowAgain: { true }))
+    }
+
+    func testEveryGateOpenShows() {
+        XCTAssertTrue(shouldShow())
+    }
+
+    /// The preference is backed by storage, so an earlier closed gate must short-circuit before it
+    /// is read.
+    func testAnEarlierClosedGateNeverReadsTheDevicePref() {
+        var reads = 0
+        let counting: () -> Bool = { reads += 1; return false }
+
+        _ = shouldShow(outcome: .unavailable(.alreadyPresented), doNotShowAgain: counting)
+        _ = shouldShow(outcome: .skipped(.alreadyEntitled), doNotShowAgain: counting)
+        _ = shouldShow(fallbackShown: true, doNotShowAgain: counting)
+        _ = shouldShow(displayEnabled: false, doNotShowAgain: counting)
+        _ = shouldShow(environment: .production, doNotShowAgain: counting)
+        _ = shouldShow(serverFlagEnabled: false, doNotShowAgain: counting)
+        _ = shouldShow(isPreviewTrigger: true, doNotShowAgain: counting)
+
+        XCTAssertEqual(reads, 0)
+    }
+
+    // MARK: - Deliberate path
+
+    /// The checkbox means stop interrupting me, not never let me look, so opening the modal from
+    /// the fallback badge keeps working after it is ticked.
+    func testTheDevicePrefDoesNotCloseTheDeliberatePath() {
+        XCTAssertFalse(shouldShow(doNotShowAgain: { true }))
+        XCTAssertTrue(isEnabled())
+    }
+
+    func testDeliberatePathHonoursEveryOtherStandingPreference() {
+        XCTAssertFalse(isEnabled(displayEnabled: false))
+        XCTAssertFalse(isEnabled(environment: .production))
+        XCTAssertFalse(isEnabled(environment: .sandbox, enabledInTestFlight: false))
+        XCTAssertFalse(isEnabled(serverFlagEnabled: false))
+    }
+
+    func testDeliberatePathShowsWhenEveryPreferenceAllowsIt() {
+        XCTAssertTrue(isEnabled())
+        XCTAssertTrue(isEnabled(isDebugBuild: true))
+        XCTAssertTrue(isEnabled(environment: .sandbox, enabledInTestFlight: true))
+    }
+
+    func testDeliberatePathKeepsThePreviewBypass() {
+        XCTAssertTrue(
+            isEnabled(
+                isPreviewTrigger: true,
+                environment: .production,
+                displayEnabled: false,
+                enabledInTestFlight: false,
+                serverFlagEnabled: false
+            )
+        )
+    }
+}

--- a/Tests/helium-swiftTests/OnLaunchResponseDecodingTests.swift
+++ b/Tests/helium-swiftTests/OnLaunchResponseDecodingTests.swift
@@ -34,4 +34,26 @@ final class OnLaunchResponseDecodingTests: XCTestCase {
 
         XCTAssertNil(decoded.paddleClientToken)
     }
+
+    // ---------- paywallDiagnosticModalAllowedInTestFlight contract ----------
+
+    func testDiagnosticModalPermissionDecodesFromJSON() throws {
+        let json = try makeOnLaunchJSON(extras: [
+            "paywallDiagnosticModalAllowedInTestFlight": false,
+        ])
+
+        let decoded = try JSONDecoder().decode(HeliumFetchedConfig.self, from: json)
+
+        XCTAssertEqual(decoded.paywallDiagnosticModalAllowedInTestFlight, false)
+    }
+
+    /// Absent is how a customer's own fallbacks file always looks, so absent has to read as
+    /// permission granted rather than withheld.
+    func testDiagnosticModalPermissionIsNilWhenAbsent() throws {
+        let json = try makeOnLaunchJSON(extras: [:])
+
+        let decoded = try JSONDecoder().decode(HeliumFetchedConfig.self, from: json)
+
+        XCTAssertNil(decoded.paywallDiagnosticModalAllowedInTestFlight)
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes who sees full-screen diagnostic modals in non-DEBUG builds and touches concurrent config/receipt setup; mis-gating could annoy TestFlight users or hide needed diagnostics, but App Store production remains blocked.
> 
> **Overview**
> **Centralizes when paywall diagnostics may appear** via new `HeliumDiagnosticGate`, replacing scattered `#if DEBUG` checks. Unprompted modals use `shouldShow` (outcome type, fallback on screen, do-not-show-again); deliberate opens (fallback banner tap) use `isEnabled` only.
> 
> **Extends diagnostics beyond DEBUG** with `paywallNotShownDiagnosticEnabledInTestFlight` and server field `paywallDiagnosticModalAllowedInTestFlight`. App Store production stays blocked; TestFlight/simulator/Xcode release builds need both SDK opt-in and server permission. Dashboard preview triggers bypass most gates. Skip outcomes interrupt only in debug or preview; failures still can in sandbox when allowed.
> 
> **Wires the gate** through `HeliumPaywallDelegate`, `HeliumPaywallDiagnosticView.presentIfNeeded`, and `FallbackDebugBanner` / `HeliumBaseTemplateView` so the fallback banner renders only when diagnostics are enabled.
> 
> **Hardens shared state**: `@HeliumAtomic` on `AppReceiptsHelper` and fetched config fields, test-and-set `setUp()`, atomic preview config read-modify-write, and typed `AppReceiptsHelper.environment` used across control panel and entitlements caching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a91b58a4f90de9d08cf736f74a2a293002922ee4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added paywall diagnostics that explain when a paywall is unavailable or skipped.
  * Added runtime controls for displaying diagnostics in debug and TestFlight builds.
  * Added safeguards to prevent duplicate or unwanted diagnostic prompts.
  * Added a remote configuration switch to disable diagnostic prompts.

* **Bug Fixes**
  * Improved environment detection and synchronized configuration updates for more reliable behavior.
  * Ensured fallback banners appear only when diagnostics are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->