### PR TITLE
[HEL-6388] | Observability event for fallback configuration

### DIFF
--- a/Sources/Helium/HeliumCore/HeliumFallbackViewManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumFallbackViewManager.swift
@@ -49,13 +49,6 @@ public class HeliumFallbackViewManager {
                     loadedConfigJSON = json
                 }
 
-                HeliumObservabilityManager.shared.track(
-                    FallbackPaywallsConfigured(
-                        generatedAt: decodedConfig.generatedAt,
-                        triggerToPaywallUUID: decodedConfig.triggerToPaywalls.mapValues { $0.paywallUUID }
-                    )
-                )
-
                 if let bundles = loadedConfig?.bundles, !bundles.isEmpty {
                     HeliumAssetManager.shared.writeBundles(bundles: bundles)
                     let generatedAtDisplay = formatDateForDisplay(decodedConfig.generatedAt)
@@ -68,6 +61,15 @@ public class HeliumFallbackViewManager {
                     } else if generatedAtDisplay == invalidDateString {
                         HeliumLogger.log(.warn, category: .fallback, "👷 Your fallbacks are outdated! ⚠️ Consider updating them\nhttps://docs.tryhelium.com/guides/fallback-bundle")
                     }
+
+                    HeliumObservabilityManager.shared.track(
+                        FallbackPaywallsConfigured(
+                            generatedAt: decodedConfig.generatedAt,
+                            organizationID: decodedConfig.organizationID,
+                            triggerToPaywallUUID: decodedConfig.triggerToPaywalls.mapValues { $0.paywallUUID }
+                        ),
+                        scope: nil
+                    )
                 } else {
                     HeliumLogger.log(.error, category: .fallback, "👷 No bundles found in fallbacks file ‼️⚠️‼️")
                 }

--- a/Sources/Helium/HeliumCore/HeliumFallbackViewManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumFallbackViewManager.swift
@@ -17,7 +17,7 @@ public class HeliumFallbackViewManager {
     
     // **MARK: - Properties**
     private let defaultFallbacksName = "helium-fallbacks"
-    private let defaultFallbackTrigger = "hlm_ios_default_flbk"
+    static let defaultFallbackTrigger = "hlm_ios_default_flbk"
     
     private var loadedConfig: HeliumFetchedConfig?
     private var loadedConfigJSON: JSON?
@@ -48,6 +48,13 @@ public class HeliumFallbackViewManager {
                 if let json = try? JSON(data: data) {
                     loadedConfigJSON = json
                 }
+
+                HeliumObservabilityManager.shared.track(
+                    FallbackPaywallsConfigured(
+                        generatedAt: decodedConfig.generatedAt,
+                        triggerToPaywallUUID: decodedConfig.triggerToPaywalls.mapValues { $0.paywallUUID }
+                    )
+                )
 
                 if let bundles = loadedConfig?.bundles, !bundles.isEmpty {
                     HeliumAssetManager.shared.writeBundles(bundles: bundles)
@@ -92,7 +99,7 @@ public class HeliumFallbackViewManager {
         if fallbackPaywallInfo?.hasProducts == true && hasResolvedConfig {
             return trigger
         }
-        return defaultFallbackTrigger
+        return Self.defaultFallbackTrigger
     }
     
     func getFallbackInfo(trigger: String) -> HeliumPaywallInfo? {

--- a/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
+++ b/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
@@ -292,6 +292,7 @@ struct WebCheckoutPurchaseCheckExhausted: HeliumObservabilityEvent {
 /// `triggerCount` but are absent from `triggerPaywallUUIDs`, so the two can disagree.
 struct FallbackPaywallsConfigured: HeliumObservabilityEvent {
     let generatedAt: String?
+    let organizationID: String?
     let triggerToPaywallUUID: [String: String?]
 
     var name: String { "fallback_paywalls_configured" }
@@ -302,6 +303,7 @@ struct FallbackPaywallsConfigured: HeliumObservabilityEvent {
             "triggerPaywallUUIDs": resolvedUUIDs,
         ]
         if let generatedAt { p["generatedAt"] = generatedAt }
+        if let organizationID { p["organizationId"] = organizationID }
         // Surfaced separately so consumers don't need to know the per-platform
         // default trigger name; the enriched `platform` property disambiguates.
         if let defaultUUID = resolvedUUIDs[HeliumFallbackViewManager.defaultFallbackTrigger] {

--- a/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
+++ b/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
@@ -283,3 +283,30 @@ struct WebCheckoutPurchaseCheckExhausted: HeliumObservabilityEvent {
         return p
     }
 }
+
+/// Reports the fallback bundle an app ships. The event's presence in the stream is
+/// itself the "this app has fallbacks configured" signal, so it is only emitted when
+/// a bundle was found and parsed.
+///
+/// A trigger maps to nil when it has no resolved paywall. Such triggers count toward
+/// `triggerCount` but are absent from `triggerPaywallUUIDs`, so the two can disagree.
+struct FallbackPaywallsConfigured: HeliumObservabilityEvent {
+    let generatedAt: String?
+    let triggerToPaywallUUID: [String: String?]
+
+    var name: String { "fallback_paywalls_configured" }
+    var properties: [String: Any] {
+        let resolvedUUIDs = triggerToPaywallUUID.compactMapValues { $0 }
+        var p: [String: Any] = [
+            "triggerCount": triggerToPaywallUUID.count,
+            "triggerPaywallUUIDs": resolvedUUIDs,
+        ]
+        if let generatedAt { p["generatedAt"] = generatedAt }
+        // Surfaced separately so consumers don't need to know the per-platform
+        // default trigger name; the enriched `platform` property disambiguates.
+        if let defaultUUID = resolvedUUIDs[HeliumFallbackViewManager.defaultFallbackTrigger] {
+            p["defaultPaywallUUID"] = defaultUUID
+        }
+        return p
+    }
+}

--- a/Sources/Helium/HeliumCore/Observability/HeliumObservabilityManager.swift
+++ b/Sources/Helium/HeliumCore/Observability/HeliumObservabilityManager.swift
@@ -35,7 +35,7 @@ class HeliumObservabilityManager {
 
     func track(
         _ event: any HeliumObservabilityEvent,
-        scope: PaywallObservabilityScope
+        scope: PaywallObservabilityScope? = nil
     ) {
         let eventName = event.name
         let eventProps = event.properties
@@ -53,9 +53,9 @@ class HeliumObservabilityManager {
         }
     }
 
-    private func enrich(
+    func enrich(
         eventProps: [String: Any],
-        scope: PaywallObservabilityScope
+        scope: PaywallObservabilityScope?
     ) -> [String: Any] {
         var p = eventProps
         p["sdkVersion"] = BuildConstants.version
@@ -66,10 +66,12 @@ class HeliumObservabilityManager {
             p["revenueCatAppUserId"] = rcId
         }
         p["heliumSessionId"] = HeliumIdentityManager.shared.getHeliumSessionId()
-        p["heliumPaywallSessionId"] = scope.sessionId
-        p["triggerName"] = scope.trigger
-        if let uuid = scope.paywallUUID {
-            p["paywallUUID"] = uuid
+        if let scope {
+            p["heliumPaywallSessionId"] = scope.sessionId
+            p["triggerName"] = scope.trigger
+            if let uuid = scope.paywallUUID {
+                p["paywallUUID"] = uuid
+            }
         }
         if let orgId = HeliumFetchedConfigManager.shared.getOrganizationID() {
             p["organizationId"] = orgId

--- a/Sources/Helium/HeliumCore/Observability/HeliumObservabilityManager.swift
+++ b/Sources/Helium/HeliumCore/Observability/HeliumObservabilityManager.swift
@@ -35,7 +35,7 @@ class HeliumObservabilityManager {
 
     func track(
         _ event: any HeliumObservabilityEvent,
-        scope: PaywallObservabilityScope? = nil
+        scope: PaywallObservabilityScope?
     ) {
         let eventName = event.name
         let eventProps = event.properties

--- a/Tests/helium-swiftTests/HeliumObservabilityEventsTests.swift
+++ b/Tests/helium-swiftTests/HeliumObservabilityEventsTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import Helium
+
+/// Locks down the observability wire format for per-event payloads, before the
+/// manager attaches identity, scope, and platform enrichment.
+///
+/// These names and keys must stay aligned with the Android SDK so both platforms
+/// land in the same dashboards. Do not change the expectations without also
+/// changing Android.
+final class HeliumObservabilityEventsTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Payload round-tripped through SegmentJSON + JSONEncoder, i.e. exactly what
+    /// goes on the wire.
+    private func wireProperties(for event: any HeliumObservabilityEvent) throws -> NSDictionary {
+        let json = try SegmentJSON(event.properties)
+        let data = try JSONEncoder().encode(json)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? NSDictionary)
+    }
+
+    // MARK: - FallbackPaywallsConfigured
+
+    func testFullyPopulatedBundleCarriesGeneratedAtDefaultUUIDCountAndMap() throws {
+        let event = FallbackPaywallsConfigured(
+            generatedAt: "2025-10-01T12:00:00Z",
+            triggerToPaywallUUID: [
+                HeliumFallbackViewManager.defaultFallbackTrigger: "default-uuid",
+                "onboarding": "onboarding-uuid",
+            ]
+        )
+
+        XCTAssertEqual(event.name, "fallback_paywalls_configured")
+        XCTAssertEqual(try wireProperties(for: event), NSDictionary(dictionary: [
+            "generatedAt": "2025-10-01T12:00:00Z",
+            "defaultPaywallUUID": "default-uuid",
+            "triggerCount": 2,
+            "triggerPaywallUUIDs": [
+                HeliumFallbackViewManager.defaultFallbackTrigger: "default-uuid",
+                "onboarding": "onboarding-uuid",
+            ],
+        ]))
+    }
+
+    func testBundleWithoutGeneratedAtOmitsTheKey() throws {
+        let event = FallbackPaywallsConfigured(
+            generatedAt: nil,
+            triggerToPaywallUUID: ["onboarding": "onboarding-uuid"]
+        )
+
+        XCTAssertNil(try wireProperties(for: event)["generatedAt"])
+    }
+
+    func testBundleWithNoDefaultTriggerOmitsTheDefaultPaywallUUID() throws {
+        let event = FallbackPaywallsConfigured(
+            generatedAt: nil,
+            triggerToPaywallUUID: ["onboarding": "onboarding-uuid"]
+        )
+
+        XCTAssertNil(try wireProperties(for: event)["defaultPaywallUUID"])
+    }
+
+    func testDefaultTriggerWithoutAPaywallOmitsTheDefaultPaywallUUID() throws {
+        let event = FallbackPaywallsConfigured(
+            generatedAt: nil,
+            triggerToPaywallUUID: [HeliumFallbackViewManager.defaultFallbackTrigger: nil]
+        )
+
+        XCTAssertNil(try wireProperties(for: event)["defaultPaywallUUID"])
+    }
+
+    func testTriggerWithNoResolvedPaywallCountsButIsAbsentFromTheMap() throws {
+        let event = FallbackPaywallsConfigured(
+            generatedAt: nil,
+            triggerToPaywallUUID: ["configured": "configured-uuid", "unconfigured": nil]
+        )
+
+        XCTAssertEqual(try wireProperties(for: event), NSDictionary(dictionary: [
+            "triggerCount": 2,
+            "triggerPaywallUUIDs": ["configured": "configured-uuid"],
+        ]))
+    }
+
+    func testEmptyBundleReportsZeroTriggersAndAnEmptyMap() throws {
+        let event = FallbackPaywallsConfigured(generatedAt: nil, triggerToPaywallUUID: [:])
+
+        XCTAssertEqual(try wireProperties(for: event), NSDictionary(dictionary: [
+            "triggerCount": 0,
+            "triggerPaywallUUIDs": [String: String](),
+        ]))
+    }
+}

--- a/Tests/helium-swiftTests/HeliumObservabilityEventsTests.swift
+++ b/Tests/helium-swiftTests/HeliumObservabilityEventsTests.swift
@@ -21,9 +21,10 @@ final class HeliumObservabilityEventsTests: XCTestCase {
 
     // MARK: - FallbackPaywallsConfigured
 
-    func testFullyPopulatedBundleCarriesGeneratedAtDefaultUUIDCountAndMap() throws {
+    func testFullyPopulatedBundleCarriesGeneratedAtOrgDefaultUUIDCountAndMap() throws {
         let event = FallbackPaywallsConfigured(
             generatedAt: "2025-10-01T12:00:00Z",
+            organizationID: "org-1",
             triggerToPaywallUUID: [
                 HeliumFallbackViewManager.defaultFallbackTrigger: "default-uuid",
                 "onboarding": "onboarding-uuid",
@@ -33,6 +34,7 @@ final class HeliumObservabilityEventsTests: XCTestCase {
         XCTAssertEqual(event.name, "fallback_paywalls_configured")
         XCTAssertEqual(try wireProperties(for: event), NSDictionary(dictionary: [
             "generatedAt": "2025-10-01T12:00:00Z",
+            "organizationId": "org-1",
             "defaultPaywallUUID": "default-uuid",
             "triggerCount": 2,
             "triggerPaywallUUIDs": [
@@ -45,15 +47,27 @@ final class HeliumObservabilityEventsTests: XCTestCase {
     func testBundleWithoutGeneratedAtOmitsTheKey() throws {
         let event = FallbackPaywallsConfigured(
             generatedAt: nil,
+            organizationID: "org-1",
             triggerToPaywallUUID: ["onboarding": "onboarding-uuid"]
         )
 
         XCTAssertNil(try wireProperties(for: event)["generatedAt"])
     }
 
+    func testBundleWithoutAnOrganizationOmitsTheKey() throws {
+        let event = FallbackPaywallsConfigured(
+            generatedAt: nil,
+            organizationID: nil,
+            triggerToPaywallUUID: ["onboarding": "onboarding-uuid"]
+        )
+
+        XCTAssertNil(try wireProperties(for: event)["organizationId"])
+    }
+
     func testBundleWithNoDefaultTriggerOmitsTheDefaultPaywallUUID() throws {
         let event = FallbackPaywallsConfigured(
             generatedAt: nil,
+            organizationID: nil,
             triggerToPaywallUUID: ["onboarding": "onboarding-uuid"]
         )
 
@@ -63,6 +77,7 @@ final class HeliumObservabilityEventsTests: XCTestCase {
     func testDefaultTriggerWithoutAPaywallOmitsTheDefaultPaywallUUID() throws {
         let event = FallbackPaywallsConfigured(
             generatedAt: nil,
+            organizationID: nil,
             triggerToPaywallUUID: [HeliumFallbackViewManager.defaultFallbackTrigger: nil]
         )
 
@@ -72,6 +87,7 @@ final class HeliumObservabilityEventsTests: XCTestCase {
     func testTriggerWithNoResolvedPaywallCountsButIsAbsentFromTheMap() throws {
         let event = FallbackPaywallsConfigured(
             generatedAt: nil,
+            organizationID: nil,
             triggerToPaywallUUID: ["configured": "configured-uuid", "unconfigured": nil]
         )
 
@@ -82,7 +98,11 @@ final class HeliumObservabilityEventsTests: XCTestCase {
     }
 
     func testEmptyBundleReportsZeroTriggersAndAnEmptyMap() throws {
-        let event = FallbackPaywallsConfigured(generatedAt: nil, triggerToPaywallUUID: [:])
+        let event = FallbackPaywallsConfigured(
+            generatedAt: nil,
+            organizationID: nil,
+            triggerToPaywallUUID: [:]
+        )
 
         XCTAssertEqual(try wireProperties(for: event), NSDictionary(dictionary: [
             "triggerCount": 0,

--- a/Tests/helium-swiftTests/HeliumObservabilityManagerTests.swift
+++ b/Tests/helium-swiftTests/HeliumObservabilityManagerTests.swift
@@ -7,6 +7,24 @@ import XCTest
 /// context. Identity values depend on device/session state and are not pinned here.
 final class HeliumObservabilityManagerTests: XCTestCase {
 
+    override func setUp() {
+        super.setUp()
+        // Enrichment reads the organization off the downloaded config; clear it so
+        // the no-downloaded-config path is what's under test.
+        HeliumFetchedConfigManager.reset()
+    }
+
+    /// Events that carry their own organization must keep it when no downloaded
+    /// config is available, otherwise early-startup telemetry loses its org.
+    func testEnrichKeepsAnEventSuppliedOrganizationWhenNoConfigIsDownloaded() {
+        let enriched = HeliumObservabilityManager.shared.enrich(
+            eventProps: ["organizationId": "org-from-bundle"],
+            scope: nil
+        )
+
+        XCTAssertEqual(enriched["organizationId"] as? String, "org-from-bundle")
+    }
+
     func testEnrichWithoutScopeOmitsPaywallScopeKeys() {
         let enriched = HeliumObservabilityManager.shared.enrich(eventProps: [:], scope: nil)
 

--- a/Tests/helium-swiftTests/HeliumObservabilityManagerTests.swift
+++ b/Tests/helium-swiftTests/HeliumObservabilityManagerTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import Helium
+
+/// Covers the common enrichment the observability manager attaches to every event.
+///
+/// Assertions deliberately cover only the paywall-scope keys and static platform
+/// context. Identity values depend on device/session state and are not pinned here.
+final class HeliumObservabilityManagerTests: XCTestCase {
+
+    func testEnrichWithoutScopeOmitsPaywallScopeKeys() {
+        let enriched = HeliumObservabilityManager.shared.enrich(eventProps: [:], scope: nil)
+
+        XCTAssertNil(enriched["heliumPaywallSessionId"])
+        XCTAssertNil(enriched["triggerName"])
+        XCTAssertNil(enriched["paywallUUID"])
+        XCTAssertEqual(enriched["platform"] as? String, "ios")
+    }
+
+    func testEnrichWithScopeIncludesPaywallScopeKeys() {
+        let scope = PaywallObservabilityScope(
+            sessionId: "session_1",
+            trigger: "onboarding",
+            paywallUUID: "uuid_1"
+        )
+
+        let enriched = HeliumObservabilityManager.shared.enrich(eventProps: [:], scope: scope)
+
+        XCTAssertEqual(enriched["heliumPaywallSessionId"] as? String, "session_1")
+        XCTAssertEqual(enriched["triggerName"] as? String, "onboarding")
+        XCTAssertEqual(enriched["paywallUUID"] as? String, "uuid_1")
+    }
+
+    func testEnrichWithScopeMissingAPaywallUUIDOmitsOnlyThatKey() {
+        let scope = PaywallObservabilityScope(
+            sessionId: "session_1",
+            trigger: "onboarding",
+            paywallUUID: nil
+        )
+
+        let enriched = HeliumObservabilityManager.shared.enrich(eventProps: [:], scope: scope)
+
+        XCTAssertNil(enriched["paywallUUID"])
+        XCTAssertEqual(enriched["heliumPaywallSessionId"] as? String, "session_1")
+        XCTAssertEqual(enriched["triggerName"] as? String, "onboarding")
+    }
+
+    func testEnrichPreservesEventProperties() {
+        let enriched = HeliumObservabilityManager.shared.enrich(
+            eventProps: ["triggerCount": 2],
+            scope: nil
+        )
+
+        XCTAssertEqual(enriched["triggerCount"] as? Int, 2)
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive telemetry and a backward-compatible optional scope on observability tracking; no paywall or purchase path changes.
> 
> **Overview**
> Adds **`fallback_paywalls_configured`** observability when a shipped fallback JSON loads successfully (non-empty bundles), carrying `generatedAt`, org id, trigger count, resolved trigger→paywall UUID map, and a separate **`defaultPaywallUUID`** for the iOS default trigger.
> 
> **`HeliumObservabilityManager.track`** now accepts an optional **`PaywallObservabilityScope`** so startup telemetry can run without paywall session fields; enrichment only adds paywall keys when scope is present, and event-supplied **`organizationId`** is preserved when no downloaded config exists. **`defaultFallbackTrigger`** is exposed as **`static`** on **`HeliumFallbackViewManager`** for consistent resolution and event wiring.
> 
> New tests lock the event wire format (Android-aligned) and optional-scope enrichment behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e9fd70a328a31684519fb73c99b5002d8155523. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an observability event for configured fallback paywalls, including configuration timestamps and trigger-to-paywall mappings.
  * Observability events can now be tracked without paywall-specific context (optional scope), with paywall fields omitted when not provided.
* **Bug Fixes**
  * Improved fallback trigger handling by consistently using the shared default fallback trigger when no valid configuration can be resolved.
* **Tests**
  * Added event wire-format tests for fallback paywalls configuration and coverage for optional paywall-scope enrichment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->