### PR TITLE
[HEL-6281] | Disable second try flows in paywall previews

### DIFF
--- a/Sources/Helium/HeliumCore/Diagnostic/Mapper/DiagnosticContentMapper.swift
+++ b/Sources/Helium/HeliumCore/Diagnostic/Mapper/DiagnosticContentMapper.swift
@@ -111,6 +111,24 @@ struct DiagnosticContentMapper {
         }
     }
 
+    /// Maps a second try request coming from a triple-tap paywall preview, where second try flows
+    /// are disabled entirely. Not keyed by a `PaywallUnavailableReason`: the paywall itself rendered
+    /// fine, so no not-shown event carries this state — the presentation layer asks for it directly.
+    func mapSecondTryInPreview() -> DiagnosticContent {
+        DiagnosticContent(
+            category: .expected,
+            title: "Second try flows can't be previewed",
+            body: "This paywall asked Helium to open its second try paywall, but second try flows "
+                + "are not supported in paywall previews. Add this paywall to a workflow and "
+                + "trigger it from there to test its second try flow.",
+            usersWillSee: "This only applies to paywall previews. Users who reach this paywall "
+                + "through a workflow see its second try flow normally.",
+            usersWillSeeLink: nil,
+            cta: .openUrl(label: "Open Workflows", url: Url.workflows),
+            reasonCode: "secondTryNotSupportedInPreview"
+        )
+    }
+
     // MARK: - EXPECTED
 
     private func targetingHoldout() -> DiagnosticContent {

--- a/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
@@ -197,8 +197,8 @@ class HeliumActionsDelegate: ObservableObject {
     }
     
     private func showSecondTryUnsupportedInPreviewDiagnostic() {
-        HeliumLogger.log(.info, category: .ui, "Second try flows are not supported in paywall previews", metadata: ["trigger": trigger])
         let content = DiagnosticContentMapper().mapSecondTryInPreview()
+        HeliumLogger.log(.info, category: .ui, DiagnosticLogLineMapper().map(content), metadata: ["trigger": trigger])
         Task { @MainActor in
             HeliumPaywallDiagnosticView.presentIfNeeded(
                 trigger: trigger,

--- a/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
@@ -167,6 +167,10 @@ class HeliumActionsDelegate: ObservableObject {
     
     func showSecondaryPaywall(uuid: String?) {
         if !isLoading {
+            if trigger == HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER {
+                showSecondTryUnsupportedInPreviewDiagnostic()
+                return
+            }
             // Re-use same presentation context as underlying paywall. Integrator can check
             // isSecondTry to distinguish events.
             let presentationContext = paywallSession.presentationContext
@@ -192,6 +196,18 @@ class HeliumActionsDelegate: ObservableObject {
         }
     }
     
+    private func showSecondTryUnsupportedInPreviewDiagnostic() {
+        HeliumLogger.log(.info, category: .ui, "Second try flows are not supported in paywall previews", metadata: ["trigger": trigger])
+        let content = DiagnosticContentMapper().mapSecondTryInPreview()
+        Task { @MainActor in
+            HeliumPaywallDiagnosticView.presentIfNeeded(
+                trigger: trigger,
+                content: content,
+                fallbackShown: false
+            )
+        }
+    }
+
     func onCTAPress(contentComponentName: String) {
         if (!isLoading) {
             let event = PaywallButtonPressedEvent(

--- a/Tests/helium-swiftTests/DiagnosticContentMapperTests.swift
+++ b/Tests/helium-swiftTests/DiagnosticContentMapperTests.swift
@@ -15,11 +15,12 @@ final class DiagnosticContentMapperTests: XCTestCase {
         mapper.mapUnavailable(reason, context: context())
     }
 
-    /// Every authored record: both skip reasons, every unavailable reason, and the nil path.
+    /// Every authored record: both skip reasons, every unavailable reason, the nil path, and the
+    /// preview-only second try record.
     private func allContent() -> [DiagnosticContent] {
         PaywallSkippedReason.allCases.map { mapper.mapSkip($0) }
             + PaywallUnavailableReason.allCases.map { content(for: $0) }
-            + [content(for: nil)]
+            + [content(for: nil), mapper.mapSecondTryInPreview()]
     }
 
     // MARK: - Forward compat: no raw codes leak into displayed prose
@@ -177,6 +178,22 @@ final class DiagnosticContentMapperTests: XCTestCase {
             content.cta,
             .openUrl(label: "Open Paywall Editor", url: "https://app.tryhelium.com/paywalls")
         )
+    }
+
+    /// Nothing is broken when a preview declines a second try, so the record is expected-category,
+    /// names the workflow remediation, and reassures that real users are unaffected.
+    func testSecondTryInPreviewAdvisesAWorkflowAndReassuresAboutRealUsers() {
+        let content = mapper.mapSecondTryInPreview()
+
+        XCTAssertEqual(content.category, .expected)
+        XCTAssertEqual(content.title, "Second try flows can't be previewed")
+        XCTAssertTrue(content.body.contains("Add this paywall to a workflow"))
+        XCTAssertTrue(content.usersWillSee.contains("see its second try flow normally"))
+        XCTAssertEqual(
+            content.cta,
+            .openUrl(label: "Open Workflows", url: "https://app.tryhelium.com/workflows")
+        )
+        XCTAssertEqual(content.reasonCode, "secondTryNotSupportedInPreview")
     }
 
     /// The modal only presents when nothing rendered, so a forced fallback reaching it means the


### PR DESCRIPTION
## What

Disables second try flows entirely when a paywall is opened from a triple-tap paywall preview. Instead of presenting the second try paywall, the SDK shows the paywall diagnostic screen explaining that second try flows aren't supported in previews and that the paywall should be added to a workflow to test it.

## Why

Testing second try flows from triple-tap previews doesn't work, especially when the paywall isn't in a workflow yet: the uuid / `<trigger>_second_try` lookups resolve against the fetched workflow config, which the previewed paywall may not be in. For now the flow is disabled in previews outright and says so (HEL-6281).

## Fix

- `HeliumActionsDelegate.showSecondaryPaywall` — the single entry point for second try presentation (both the paywall-uuid path and the `<trigger>_second_try` path) — returns early when the current trigger is `HELIUM_PREVIEW_TRIGGER` and presents the diagnostic instead.
- New authored record `mapSecondTryInPreview()` in `DiagnosticContentMapper`: `.expected` category, "add this paywall to a workflow" remediation, "Open Workflows" CTA, reason code `secondTryNotSupportedInPreview`. It's a separate entry point rather than a new `PaywallUnavailableReason` because the paywall itself rendered fine — no not-shown event carries this state, and no `PaywallOpenFailedEvent` is fired.
- The diagnostic presents in its own window above the preview paywall, which stays on screen behind it.

## Tests

- Added the new record to the `allContent()` invariant sweep in `DiagnosticContentMapperTests` (no URLs or raw reason codes in prose, authored links openable).
- New `testSecondTryInPreviewAdvisesAWorkflowAndReassuresAboutRealUsers` pins the category, copy, CTA, and reason code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to preview trigger only; production second-try behavior is unchanged and the change is diagnostic UX plus an early return.
> 
> **Overview**
> Triple-tap **paywall preview** no longer attempts to open a second-try paywall. When the paywall asks for a secondary flow while the session uses `helium_preview_trigger`, `showSecondaryPaywall` returns early and shows the paywall diagnostic instead of uuid / `_second_try` lookup and presentation.
> 
> New authored diagnostic **`mapSecondTryInPreview()`** explains that second-try flows are preview-only limitations, points integrators to test via **workflows** (Open Workflows CTA), and uses reason code `secondTryNotSupportedInPreview` without a new `PaywallUnavailableReason` or failed-open event. The preview paywall stays visible behind the diagnostic.
> 
> Tests include the new copy in the `allContent()` invariant sweep and a focused test for category, messaging, CTA, and reason code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aba1b195c1901d2bf222ae7612c9d77ca548c7c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a diagnostic message for preview scenarios where second-try flows aren’t available.
  * The message explains the limitation, reassures users about real-user behavior, and provides an **Open Workflows** action.

* **Bug Fixes**
  * Preview flows now avoid attempting to present an unsupported secondary paywall and instead show clear guidance.

* **Tests**
  * Added coverage validating the preview diagnostic content, messaging, category, and Workflows link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->