### PR TITLE
[HEL-6243] | onEntitled receives the relevant purchase/restore/skip event

### DIFF
--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -304,21 +304,9 @@ class HeliumPaywallDelegateWrapper {
         }
         
         // Mark session for onEntitled callback on purchase/restore success
-        if let sessionId = overridePaywallSessionId ?? paywallSession?.sessionId {
-            let entitledEvent: PaywallEntitledEvent?
-            switch event {
-            case let purchased as PurchaseSucceededEvent:
-                entitledEvent = .purchased(purchased)
-            case let restored as PurchaseRestoredEvent:
-                entitledEvent = .restored(restored)
-            case let alreadyEntitled as PurchaseAlreadyEntitledEvent:
-                entitledEvent = .alreadyEntitled(alreadyEntitled)
-            default:
-                entitledEvent = nil
-            }
-            if let entitledEvent {
-                HeliumPaywallPresenter.shared.markSessionAsEntitled(sessionId: sessionId, event: entitledEvent)
-            }
+        if let sessionId = overridePaywallSessionId ?? paywallSession?.sessionId,
+           let entitledEvent = PaywallEntitledEvent(entitlingEvent: event) {
+            HeliumPaywallPresenter.shared.markSessionAsEntitled(sessionId: sessionId, event: entitledEvent)
         }
 
         if event is PaywallCloseEvent, let paywallSession {

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -305,10 +305,19 @@ class HeliumPaywallDelegateWrapper {
         
         // Mark session for onEntitled callback on purchase/restore success
         if let sessionId = overridePaywallSessionId ?? paywallSession?.sessionId {
-            if event is PurchaseSucceededEvent ||
-                event is PurchaseRestoredEvent ||
-                event is PurchaseAlreadyEntitledEvent {
-                HeliumPaywallPresenter.shared.markSessionAsEntitled(sessionId: sessionId)
+            let entitledEvent: PaywallEntitledEvent?
+            switch event {
+            case let purchased as PurchaseSucceededEvent:
+                entitledEvent = .purchased(purchased)
+            case let restored as PurchaseRestoredEvent:
+                entitledEvent = .restored(restored)
+            case let alreadyEntitled as PurchaseAlreadyEntitledEvent:
+                entitledEvent = .alreadyEntitled(alreadyEntitled)
+            default:
+                entitledEvent = nil
+            }
+            if let entitledEvent {
+                HeliumPaywallPresenter.shared.markSessionAsEntitled(sessionId: sessionId, event: entitledEvent)
             }
         }
 

--- a/Sources/Helium/HeliumCore/PaywallEvents.swift
+++ b/Sources/Helium/HeliumCore/PaywallEvents.swift
@@ -897,6 +897,21 @@ public enum PaywallEntitledEvent {
         case .skipped: return nil
         }
     }
+
+    /// Wraps a purchase-flow event that grants entitlement; `nil` for any other event.
+    /// `.skipped` is excluded — it is constructed directly at the skip site and never marks a session.
+    init?(entitlingEvent event: HeliumEvent) {
+        switch event {
+        case let purchased as PurchaseSucceededEvent:
+            self = .purchased(purchased)
+        case let restored as PurchaseRestoredEvent:
+            self = .restored(restored)
+        case let alreadyEntitled as PurchaseAlreadyEntitledEvent:
+            self = .alreadyEntitled(alreadyEntitled)
+        default:
+            return nil
+        }
+    }
 }
 
 /// Event fired when StoreKit returns .pending status (e.g., waiting for parental approval)

--- a/Sources/Helium/HeliumCore/PaywallEvents.swift
+++ b/Sources/Helium/HeliumCore/PaywallEvents.swift
@@ -866,6 +866,39 @@ public struct PurchaseAlreadyEntitledEvent: ProductEvent {
     }
 }
 
+/// The entitling event passed to `onEntitled`, identifying how the user became (or was found to be) entitled.
+public enum PaywallEntitledEvent {
+    /// A new purchase completed successfully.
+    case purchased(PurchaseSucceededEvent)
+    /// An existing entitlement was surfaced via restore.
+    case restored(PurchaseRestoredEvent)
+    /// A purchase attempt resolved to an entitlement the user already had.
+    case alreadyEntitled(PurchaseAlreadyEntitledEvent)
+    /// The paywall was not shown because the user is already entitled
+    /// (requires `PaywallPresentationConfig.dontShowIfAlreadyEntitled`).
+    case skipped(PaywallSkippedEvent)
+
+    /// The underlying SDK event.
+    public var event: HeliumEvent {
+        switch self {
+        case .purchased(let event): return event
+        case .restored(let event): return event
+        case .alreadyEntitled(let event): return event
+        case .skipped(let event): return event
+        }
+    }
+
+    /// The product involved, when known; `nil` for `.skipped`.
+    public var productId: String? {
+        switch self {
+        case .purchased(let event): return event.productId
+        case .restored(let event): return event.productId
+        case .alreadyEntitled(let event): return event.productId
+        case .skipped: return nil
+        }
+    }
+}
+
 /// Event fired when StoreKit returns .pending status (e.g., waiting for parental approval)
 /// - Note: Transaction is awaiting external action before completion
 public struct PurchasePendingEvent: ProductEvent {

--- a/Sources/Helium/HeliumCore/PaywallSession.swift
+++ b/Sources/Helium/HeliumCore/PaywallSession.swift
@@ -17,7 +17,7 @@ enum FallbackPaywallType {
 struct PaywallPresentationContext {
     let config: PaywallPresentationConfig
     let eventHandlers: PaywallEventHandlers?
-    let onEntitled: (() -> Void)?
+    let onEntitled: ((PaywallEntitledEvent) -> Void)?
     let onPaywallNotShown: ((PaywallNotShownReason) -> Void)?
     
     var customPaywallTraits: HeliumUserTraits? {

--- a/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
+++ b/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
@@ -31,7 +31,7 @@ class HeliumPaywallPresenter {
     
     /// Mark a session as having achieved entitlement (purchase/restore succeeded).
     /// The onEntitled callback will be called with the event when the paywall closes.
-    /// If a session produces multiple entitling events, the most recent one wins.
+    /// A session is expected to produce at most one entitling event; if more occur, the most recent wins.
     func markSessionAsEntitled(sessionId: String, event: PaywallEntitledEvent) {
         _sessionsWithEntitlement.withValue { $0[sessionId] = event }
     }

--- a/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
+++ b/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
@@ -21,7 +21,7 @@ class HeliumPaywallPresenter {
     }
     
     private var paywallsDisplayed: [HeliumViewController] = []
-    @HeliumAtomic private var sessionsWithEntitlement: Set<String> = []
+    @HeliumAtomic private var sessionsWithEntitlement: [String: PaywallEntitledEvent] = [:]
     
     func isSecondTryPaywall(trigger: String) -> Bool {
         return paywallsDisplayed.contains {
@@ -30,30 +30,41 @@ class HeliumPaywallPresenter {
     }
     
     /// Mark a session as having achieved entitlement (purchase/restore succeeded).
-    /// The onEntitled callback will be called when the paywall closes.
-    func markSessionAsEntitled(sessionId: String) {
-        _sessionsWithEntitlement.withValue { $0.insert(sessionId) }
+    /// The onEntitled callback will be called with the event when the paywall closes.
+    /// If a session produces multiple entitling events, the most recent one wins.
+    func markSessionAsEntitled(sessionId: String, event: PaywallEntitledEvent) {
+        _sessionsWithEntitlement.withValue { $0[sessionId] = event }
+    }
+
+    /// Removes and returns the entitling event for a session, if one was marked.
+    func consumeEntitledEvent(forSessionId sessionId: String) -> PaywallEntitledEvent? {
+        return _sessionsWithEntitlement.withValue { $0.removeValue(forKey: sessionId) }
     }
     
     private func paywallEntitlementsCheck(trigger: String, context: PaywallPresentationContext) async -> Bool {
         if context.config.dontShowIfAlreadyEntitled {
             let skipIt = await Helium.entitlements.hasEntitlementForPaywall(trigger: trigger)
             if skipIt == true {
-                Task { @MainActor in
-                    if let onEntitled = context.onEntitled {
-                        onEntitled()
-                    } else {
-                        context.onPaywallNotShown?(.alreadyEntitled)
-                    }
-                }
-                HeliumPaywallDelegateWrapper.shared.fireEvent(
-                    PaywallSkippedEvent(triggerName: trigger, skipReason: .alreadyEntitled),
-                    paywallSession: nil
-                )
+                handleAlreadyEntitledSkip(trigger: trigger, context: context)
                 return true
             }
         }
         return false
+    }
+
+    func handleAlreadyEntitledSkip(trigger: String, context: PaywallPresentationContext) {
+        let skipEvent = PaywallSkippedEvent(triggerName: trigger, skipReason: .alreadyEntitled)
+        Task { @MainActor in
+            if let onEntitled = context.onEntitled {
+                onEntitled(.skipped(skipEvent))
+            } else {
+                context.onPaywallNotShown?(.alreadyEntitled)
+            }
+        }
+        HeliumPaywallDelegateWrapper.shared.fireEvent(
+            skipEvent,
+            paywallSession: nil
+        )
     }
     
     func skipPaywallIfNeeded(trigger: String, presentationContext: PaywallPresentationContext) -> Bool {
@@ -477,11 +488,9 @@ class HeliumPaywallPresenter {
 
         // Call onEntitled if this session had a successful purchase/restore
         let sessionId = paywallVC.paywallSession.sessionId
-        var wasEntitled = false
-        _sessionsWithEntitlement.withValue { wasEntitled = $0.remove(sessionId) != nil }
-        if wasEntitled {
+        if let entitledEvent = consumeEntitledEvent(forSessionId: sessionId) {
             Task { @MainActor in
-                paywallVC.presentationContext.onEntitled?()
+                paywallVC.presentationContext.onEntitled?(entitledEvent)
             }
         }
     }

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -86,8 +86,10 @@ public class Helium {
     ///   - trigger: The trigger configured in the Helium dashboard.
     ///   - config: Optional configuration for this paywall presentation. Defaults to `PaywallPresentationConfig()`.
     ///   - eventHandlers: Optional event handlers for paywall lifecycle events.
-    ///   - onEntitled: (Optional) Called upon purchase success or purchase restore. If you set `dontShowIfAlreadyEntitled`
-    ///    to true, this handler will also be called when paywall not shown to users who already have entitlement for a product in the paywall.
+    ///   - onEntitled: (Optional) Called with the entitling event upon purchase success (`.purchased`), purchase restore (`.restored`),
+    ///    or a purchase attempt resolving to an existing entitlement (`.alreadyEntitled`) — in these cases it is called when the paywall closes.
+    ///    If you set `dontShowIfAlreadyEntitled` to true, this handler is also called immediately with `.skipped` when the paywall
+    ///    is not shown to users who already have entitlement for a product in the paywall.
     ///   - onPaywallNotShown: Called if desired paywall and fallback paywall did not show for any reason.
     ///
     /// - Important: If user is already entitled and `config.dontShowIfAlreadyEntitled` is true,  `onEntitled` will be called if provided otherwise `onPaywallNotShown(.alreadyEntitled)` will be called.
@@ -95,11 +97,11 @@ public class Helium {
         trigger: String,
         config: PaywallPresentationConfig = PaywallPresentationConfig(),
         eventHandlers: PaywallEventHandlers? = nil,
-        onEntitled: (() -> Void)? = nil,
+        onEntitled: ((PaywallEntitledEvent) -> Void)? = nil,
         onPaywallNotShown: @escaping (PaywallNotShownReason) -> Void
     ) {
         HeliumLogger.log(.info, category: .ui, "presentUpsell called", metadata: ["trigger": trigger])
-        
+
         let presentationContext = PaywallPresentationContext(
             config: config,
             eventHandlers: eventHandlers,
@@ -110,8 +112,25 @@ public class Helium {
             HeliumLogger.log(.debug, category: .ui, "Paywall skipped for trigger", metadata: ["trigger": trigger])
             return
         }
-        
+
         HeliumPaywallPresenter.shared.presentUpsellWithLoadingBudget(trigger: trigger, presentationContext: presentationContext)
+    }
+
+    @available(*, deprecated, message: "Use onEntitled: ((PaywallEntitledEvent) -> Void) to receive the relevant purchase/restore/skip event.")
+    public func presentPaywall(
+        trigger: String,
+        config: PaywallPresentationConfig = PaywallPresentationConfig(),
+        eventHandlers: PaywallEventHandlers? = nil,
+        onEntitled: @escaping () -> Void,
+        onPaywallNotShown: @escaping (PaywallNotShownReason) -> Void
+    ) {
+        presentPaywall(
+            trigger: trigger,
+            config: config,
+            eventHandlers: eventHandlers,
+            onEntitled: { _ in onEntitled() },
+            onPaywallNotShown: onPaywallNotShown
+        )
     }
     
     /// Hide the top-most paywall that was shown via presentPaywall, if any are currently displayed.

--- a/Tests/helium-swiftTests/PaywallEntitledEventTests.swift
+++ b/Tests/helium-swiftTests/PaywallEntitledEventTests.swift
@@ -1,0 +1,182 @@
+import XCTest
+@testable import Helium
+
+final class PaywallEntitledEventTests: HeliumTestCase {
+
+    // MARK: - Mark/consume semantics
+
+    func testConsumeReturnsMarkedEventOnce() {
+        let purchased = PurchaseSucceededEvent(
+            productId: "com.test.product", triggerName: "t", paywallName: "p",
+            storeKitTransactionId: nil, storeKitOriginalTransactionId: nil
+        )
+        let sessionId = UUID().uuidString
+        HeliumPaywallPresenter.shared.markSessionAsEntitled(sessionId: sessionId, event: .purchased(purchased))
+
+        let consumed = HeliumPaywallPresenter.shared.consumeEntitledEvent(forSessionId: sessionId)
+        guard case .purchased(let event)? = consumed else {
+            return XCTFail("Expected .purchased, got \(String(describing: consumed))")
+        }
+        XCTAssertEqual(event.productId, "com.test.product")
+
+        XCTAssertNil(HeliumPaywallPresenter.shared.consumeEntitledEvent(forSessionId: sessionId))
+    }
+
+    func testConsumeReturnsNilForUnmarkedSession() {
+        XCTAssertNil(HeliumPaywallPresenter.shared.consumeEntitledEvent(forSessionId: UUID().uuidString))
+    }
+
+    func testLastEntitlingEventWins() {
+        let purchased = PurchaseSucceededEvent(
+            productId: "com.test.product", triggerName: "t", paywallName: "p",
+            storeKitTransactionId: nil, storeKitOriginalTransactionId: nil
+        )
+        let restored = PurchaseRestoredEvent(
+            productId: "com.test.restored", triggerName: "t", paywallName: "p",
+            restoreOrigin: .restorePurchases, paymentProcessor: .appStore
+        )
+        let sessionId = UUID().uuidString
+        HeliumPaywallPresenter.shared.markSessionAsEntitled(sessionId: sessionId, event: .purchased(purchased))
+        HeliumPaywallPresenter.shared.markSessionAsEntitled(sessionId: sessionId, event: .restored(restored))
+
+        let consumed = HeliumPaywallPresenter.shared.consumeEntitledEvent(forSessionId: sessionId)
+        guard case .restored(let event)? = consumed else {
+            return XCTFail("Expected .restored, got \(String(describing: consumed))")
+        }
+        XCTAssertEqual(event.productId, "com.test.restored")
+    }
+
+    // MARK: - fireEvent marks the session with the matching event
+
+    func testFireEventMarksSessionForPurchaseSucceeded() {
+        let session = makeTestSession(trigger: "t")
+        let event = PurchaseSucceededEvent(
+            productId: "com.test.product", triggerName: "t", paywallName: "p",
+            storeKitTransactionId: "txn_1", storeKitOriginalTransactionId: nil
+        )
+        HeliumPaywallDelegateWrapper.shared.fireEvent(event, paywallSession: session)
+        waitForEventDispatch { self.listener.eventsOfType(PurchaseSucceededEvent.self).count == 1 }
+
+        let consumed = HeliumPaywallPresenter.shared.consumeEntitledEvent(forSessionId: session.sessionId)
+        guard case .purchased(let marked)? = consumed else {
+            return XCTFail("Expected .purchased, got \(String(describing: consumed))")
+        }
+        XCTAssertEqual(marked.productId, "com.test.product")
+        XCTAssertEqual(consumed?.productId, "com.test.product")
+    }
+
+    func testFireEventMarksSessionForPurchaseRestored() {
+        let session = makeTestSession(trigger: "t")
+        let event = PurchaseRestoredEvent(
+            productId: "com.test.product", triggerName: "t", paywallName: "p",
+            restoreOrigin: .duringPurchase, paymentProcessor: .appStore
+        )
+        HeliumPaywallDelegateWrapper.shared.fireEvent(event, paywallSession: session)
+        waitForEventDispatch { self.listener.eventsOfType(PurchaseRestoredEvent.self).count == 1 }
+
+        let consumed = HeliumPaywallPresenter.shared.consumeEntitledEvent(forSessionId: session.sessionId)
+        guard case .restored(let marked)? = consumed else {
+            return XCTFail("Expected .restored, got \(String(describing: consumed))")
+        }
+        XCTAssertEqual(marked.restoreOrigin, .duringPurchase)
+    }
+
+    func testFireEventMarksSessionForPurchaseAlreadyEntitled() {
+        let session = makeTestSession(trigger: "t")
+        let event = PurchaseAlreadyEntitledEvent(
+            productId: "com.test.product", triggerName: "t", paywallName: "p",
+            storeKitTransactionId: nil, storeKitOriginalTransactionId: nil
+        )
+        HeliumPaywallDelegateWrapper.shared.fireEvent(event, paywallSession: session)
+        waitForEventDispatch { self.listener.eventsOfType(PurchaseAlreadyEntitledEvent.self).count == 1 }
+
+        let consumed = HeliumPaywallPresenter.shared.consumeEntitledEvent(forSessionId: session.sessionId)
+        guard case .alreadyEntitled? = consumed else {
+            return XCTFail("Expected .alreadyEntitled, got \(String(describing: consumed))")
+        }
+    }
+
+    func testFireEventDoesNotMarkSessionForNonEntitlingEvent() {
+        let session = makeTestSession(trigger: "t")
+        let event = PurchaseFailedEvent(productId: "com.test.product", triggerName: "t", paywallName: "p", paymentProcessor: .appStore)
+        HeliumPaywallDelegateWrapper.shared.fireEvent(event, paywallSession: session)
+        waitForEventDispatch { self.listener.eventsOfType(PurchaseFailedEvent.self).count == 1 }
+
+        XCTAssertNil(HeliumPaywallPresenter.shared.consumeEntitledEvent(forSessionId: session.sessionId))
+    }
+
+    // MARK: - Already-entitled skip path
+
+    func testAlreadyEntitledSkipCallsOnEntitledWithSkippedEvent() {
+        var received: PaywallEntitledEvent?
+        var notShownReason: PaywallNotShownReason?
+        let context = PaywallPresentationContext(
+            config: PaywallPresentationConfig(dontShowIfAlreadyEntitled: true),
+            eventHandlers: nil,
+            onEntitled: { received = $0 },
+            onPaywallNotShown: { notShownReason = $0 }
+        )
+
+        HeliumPaywallPresenter.shared.handleAlreadyEntitledSkip(trigger: "entitled_trigger", context: context)
+        waitForEventDispatch { received != nil }
+
+        guard case .skipped(let skipEvent)? = received else {
+            return XCTFail("Expected .skipped, got \(String(describing: received))")
+        }
+        XCTAssertEqual(skipEvent.triggerName, "entitled_trigger")
+        XCTAssertEqual(skipEvent.skipReason, .alreadyEntitled)
+        XCTAssertNil(received?.productId)
+        XCTAssertNil(notShownReason)
+
+        // The same skip event is also fired through the event system
+        waitForEventDispatch { self.listener.eventsOfType(PaywallSkippedEvent.self).count == 1 }
+        XCTAssertEqual(listener.lastEvent(ofType: PaywallSkippedEvent.self)?.skipReason, .alreadyEntitled)
+    }
+
+    func testAlreadyEntitledSkipWithoutOnEntitledCallsOnPaywallNotShown() {
+        var notShownReason: PaywallNotShownReason?
+        let context = PaywallPresentationContext(
+            config: PaywallPresentationConfig(dontShowIfAlreadyEntitled: true),
+            eventHandlers: nil,
+            onEntitled: nil,
+            onPaywallNotShown: { notShownReason = $0 }
+        )
+
+        HeliumPaywallPresenter.shared.handleAlreadyEntitledSkip(trigger: "entitled_trigger", context: context)
+        waitForEventDispatch { notShownReason != nil }
+
+        XCTAssertEqual(notShownReason, .alreadyEntitled)
+    }
+
+    // MARK: - Accessors
+
+    func testEventAccessorReturnsUnderlyingEvent() {
+        let skipEvent = PaywallSkippedEvent(triggerName: "t", skipReason: .alreadyEntitled)
+        let entitled = PaywallEntitledEvent.skipped(skipEvent)
+        XCTAssertTrue(entitled.event is PaywallSkippedEvent)
+        XCTAssertNil(entitled.productId)
+
+        let purchased = PurchaseSucceededEvent(
+            productId: "com.test.product", triggerName: "t", paywallName: "p",
+            storeKitTransactionId: nil, storeKitOriginalTransactionId: nil
+        )
+        XCTAssertEqual(PaywallEntitledEvent.purchased(purchased).productId, "com.test.product")
+        XCTAssertTrue(PaywallEntitledEvent.purchased(purchased).event is PurchaseSucceededEvent)
+    }
+
+    // MARK: - Overload resolution (compile-time check, never executed)
+
+    private let overloadResolutionCheck: () -> Void = {
+        // Zero-arg closure resolves to the deprecated overload; one-arg closure to the new one.
+        let zeroArg = {
+            Helium.shared.presentPaywall(trigger: "t", onEntitled: {}, onPaywallNotShown: { _ in })
+        }
+        let oneArg = {
+            Helium.shared.presentPaywall(trigger: "t", onEntitled: { (_: PaywallEntitledEvent) in }, onPaywallNotShown: { _ in })
+        }
+        let omitted = {
+            Helium.shared.presentPaywall(trigger: "t", onPaywallNotShown: { _ in })
+        }
+        _ = (zeroArg, oneArg, omitted)
+    }
+}


### PR DESCRIPTION
## What

`onEntitled` on `presentPaywall` now receives a `PaywallEntitledEvent` argument identifying how the user became entitled: `.purchased`, `.restored`, `.alreadyEntitled` (purchase attempt resolved to an existing entitlement), or `.skipped` (paywall not shown due to `dontShowIfAlreadyEntitled`). The enum carries the concrete event and exposes `productId` and the underlying `event` for serialization.

## Why

`onEntitled` only signaled *that* the user was entitled, not *how*. Apps that need to branch on new purchase vs restore vs already-entitled (and see which product) had no way to know. Internally, the purchase/restore path only stored the session id when marking a session entitled, so the triggering event was discarded before the callback fired on paywall close.

## Fix

The entitlement marker now stores the event itself (`Set<String>` → `[String: PaywallEntitledEvent]`), captured where entitling events are fired and delivered when the paywall closes. The already-entitled skip path passes the same `PaywallSkippedEvent` instance it fires through analytics. A deprecated zero-arg `presentPaywall` overload keeps existing callers (including RN/Flutter wrappers) compiling with just a warning — no source break.

## Tests

New `PaywallEntitledEventTests` (10 tests): mark/consume semantics (once-only, last-wins), fireEvent-to-event mapping for all three entitling events plus a non-entitling negative case, both skip-path callbacks, enum accessors, and a compile-time check that all `presentPaywall` call shapes resolve. Full suite passes: 268 tests, 0 failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API change to a purchase/entitlement callback path; behavior is additive with a deprecated overload, but integrators must handle the new enum to branch correctly on purchase vs restore vs skip.
> 
> **Overview**
> **`presentPaywall`’s `onEntitled` now receives a `PaywallEntitledEvent`** so apps can tell *how* the user became entitled, not only that they did.
> 
> The new enum covers **`.purchased`**, **`.restored`**, **`.alreadyEntitled`**, and **`.skipped`** (when `dontShowIfAlreadyEntitled` skips the paywall). It exposes the underlying SDK event and **`productId`** where applicable.
> 
> Entitlement tracking changes from a per-session boolean to **`[sessionId: PaywallEntitledEvent]`**: entitling purchase events are wrapped in `fireEvent` and stored until paywall close, then delivered via **`consumeEntitledEvent`**. The already-entitled skip path invokes **`onEntitled(.skipped(...))`** immediately with the same `PaywallSkippedEvent` sent to analytics.
> 
> A **deprecated** zero-argument `onEntitled` overload preserves compile compatibility for existing callers. **`PaywallEntitledEventTests`** covers mark/consume, `fireEvent` wiring, and skip-path behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a1e86078529c0092575cea539536832c7b46982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Entitlement callbacks now include details about the entitlement outcome and associated product when applicable.
  * Added support for reporting skipped paywalls when the customer is already entitled.
  * Entitlement events are delivered when the paywall closes, including purchases, restores, and already-entitled outcomes.

* **Compatibility**
  * Existing no-argument entitlement callbacks remain supported through a deprecated compatibility option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->