### PR TITLE
Stop routing unregistered Paddle/Stripe price keys to StoreKit

### DIFF
--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -102,6 +102,16 @@ class HeliumPaywallDelegateWrapper {
                 } catch {
                     transactionStatus = .failed(error)
                 }
+            } else if HeliumPaymentProcessor.isWebProcessorCompositeKey(productKey) {
+                // Neither price map claimed a Paddle/Stripe-shaped key, so the
+                // paywall is offering a product the on-launch response never
+                // registered. StoreKit cannot own this identifier; passing it
+                // through would surface as "product not found in App Store
+                // Connect" and send the reader hunting through App Store
+                // Connect for a product that was never meant to live there.
+                HeliumLogger.log(.error, category: .core,
+                    "Product \(productKey) is a Paddle/Stripe price key but is absent from the on-launch paddleProducts/stripeProducts maps; refusing to route it to StoreKit.")
+                transactionStatus = .failed(HeliumPaymentRoutingError.unregisteredWebProductKey(productKey))
             } else {
                 transactionStatus = await delegate.makePurchase(productId: productKey)
             }

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -104,20 +104,9 @@ class HeliumPaywallDelegateWrapper {
                 }
             } else if paymentProcessor == .appStore,
                       HeliumPaymentProcessor.isWebProcessorCompositeKey(productKey) {
-                // `.appStore` means neither price map claimed the key, yet it is
-                // shaped like a Paddle/Stripe composite: the paywall is offering
-                // a product the on-launch response never registered. StoreKit
-                // cannot own this identifier, so passing it through surfaces as
-                // "product not found in App Store Connect" and sends the reader
-                // hunting through App Store Connect for a product that was never
-                // meant to live there.
-                //
-                // The processor check is load-bearing. A REGISTERED Stripe key
-                // reaches this point whenever Apple Pay is available, because
-                // the first branch requires !stripeApplePayFlowEnabled, and it
-                // has to continue on to the delegate.
-                HeliumLogger.log(.error, category: .core,
-                    "Product \(productKey) is a Paddle/Stripe price key but is absent from the on-launch paddleProducts/stripeProducts maps; refusing to route it to StoreKit.")
+                // The .appStore check is load-bearing: a registered Stripe key
+                // reaches here whenever Apple Pay is available, since the first
+                // branch requires !stripeApplePayFlowEnabled.
                 transactionStatus = .failed(HeliumPaymentRoutingError.unregisteredWebProductKey(productKey))
             } else {
                 transactionStatus = await delegate.makePurchase(productId: productKey)

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -102,13 +102,20 @@ class HeliumPaywallDelegateWrapper {
                 } catch {
                     transactionStatus = .failed(error)
                 }
-            } else if HeliumPaymentProcessor.isWebProcessorCompositeKey(productKey) {
-                // Neither price map claimed a Paddle/Stripe-shaped key, so the
-                // paywall is offering a product the on-launch response never
-                // registered. StoreKit cannot own this identifier; passing it
-                // through would surface as "product not found in App Store
-                // Connect" and send the reader hunting through App Store
-                // Connect for a product that was never meant to live there.
+            } else if paymentProcessor == .appStore,
+                      HeliumPaymentProcessor.isWebProcessorCompositeKey(productKey) {
+                // `.appStore` means neither price map claimed the key, yet it is
+                // shaped like a Paddle/Stripe composite: the paywall is offering
+                // a product the on-launch response never registered. StoreKit
+                // cannot own this identifier, so passing it through surfaces as
+                // "product not found in App Store Connect" and sends the reader
+                // hunting through App Store Connect for a product that was never
+                // meant to live there.
+                //
+                // The processor check is load-bearing. A REGISTERED Stripe key
+                // reaches this point whenever Apple Pay is available, because
+                // the first branch requires !stripeApplePayFlowEnabled, and it
+                // has to continue on to the delegate.
                 HeliumLogger.log(.error, category: .core,
                     "Product \(productKey) is a Paddle/Stripe price key but is absent from the on-launch paddleProducts/stripeProducts maps; refusing to route it to StoreKit.")
                 transactionStatus = .failed(HeliumPaymentRoutingError.unregisteredWebProductKey(productKey))

--- a/Sources/Helium/HeliumCore/PaywallEvents.swift
+++ b/Sources/Helium/HeliumCore/PaywallEvents.swift
@@ -536,6 +536,41 @@ public enum HeliumPaymentProcessor: String, Codable, Sendable {
         }
         return .appStore
     }
+
+    /// True for a `<productId>:<priceId>` composite in Paddle (`pro_…:pri_…`) or
+    /// Stripe (`prod_…:price_…`) form.
+    ///
+    /// `resolve` answers `.appStore` for anything absent from both server price
+    /// maps, which is right for a bare StoreKit identifier but not for one of
+    /// these: App Store Connect has no product under a composite key, so the
+    /// purchase can only fail, and it fails reporting a missing App Store
+    /// product rather than the missing server-side registration that actually
+    /// caused it. Both halves are checked so a StoreKit identifier that merely
+    /// happens to contain a colon isn't caught.
+    static func isWebProcessorCompositeKey(_ productKey: String) -> Bool {
+        let parts = productKey.split(separator: ":", omittingEmptySubsequences: false)
+        guard parts.count == 2 else { return false }
+        let product = parts[0]
+        let price = parts[1]
+        let paddle = product.hasPrefix("pro_") && price.hasPrefix("pri_")
+        let stripe = product.hasPrefix("prod_") && price.hasPrefix("price_")
+        return paddle || stripe
+    }
+}
+
+/// Raised when a purchase cannot be routed to a payment processor.
+public enum HeliumPaymentRoutingError: LocalizedError {
+    /// A Paddle/Stripe composite product key that neither server price map
+    /// knows about. Handing it to StoreKit would fail with a misleading App
+    /// Store Connect error, so the flow stops here instead.
+    case unregisteredWebProductKey(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unregisteredWebProductKey(let key):
+            return "Product \(key) looks like a Paddle or Stripe price but was not in the on-launch product list, so it cannot be purchased through the App Store. Check that this product is configured on this paywall in the Helium dashboard."
+        }
+    }
 }
 
 /// Event fired when a purchase completes successfully.

--- a/Sources/Helium/HeliumCore/PaywallEvents.swift
+++ b/Sources/Helium/HeliumCore/PaywallEvents.swift
@@ -538,15 +538,8 @@ public enum HeliumPaymentProcessor: String, Codable, Sendable {
     }
 
     /// True for a `<productId>:<priceId>` composite in Paddle (`pro_…:pri_…`) or
-    /// Stripe (`prod_…:price_…`) form.
-    ///
-    /// `resolve` answers `.appStore` for anything absent from both server price
-    /// maps, which is right for a bare StoreKit identifier but not for one of
-    /// these: App Store Connect has no product under a composite key, so the
-    /// purchase can only fail, and it fails reporting a missing App Store
-    /// product rather than the missing server-side registration that actually
-    /// caused it. Both halves are checked so a StoreKit identifier that merely
-    /// happens to contain a colon isn't caught.
+    /// Stripe (`prod_…:price_…`) form. Both halves must match one provider, so a
+    /// StoreKit identifier that merely contains a colon is not caught.
     static func isWebProcessorCompositeKey(_ productKey: String) -> Bool {
         let parts = productKey.split(separator: ":", omittingEmptySubsequences: false)
         guard parts.count == 2 else { return false }
@@ -555,25 +548,6 @@ public enum HeliumPaymentProcessor: String, Codable, Sendable {
         let paddle = product.hasPrefix("pro_") && price.hasPrefix("pri_")
         let stripe = product.hasPrefix("prod_") && price.hasPrefix("price_")
         return paddle || stripe
-    }
-}
-
-/// Raised when a purchase cannot be routed to a payment processor.
-///
-/// Internal: host apps still read the text through `localizedDescription` on
-/// the `Error` delivered by `.failed`, so keeping the type out of the public
-/// surface costs them nothing but the ability to pattern-match the case.
-enum HeliumPaymentRoutingError: LocalizedError {
-    /// A Paddle/Stripe composite product key that neither server price map
-    /// knows about. Handing it to StoreKit would fail with a misleading App
-    /// Store Connect error, so the flow stops here instead.
-    case unregisteredWebProductKey(String)
-
-    var errorDescription: String? {
-        switch self {
-        case .unregisteredWebProductKey(let key):
-            return "Product \(key) looks like a Paddle or Stripe price but was not in the on-launch product list, so it cannot be purchased through the App Store. Check that this product is configured on this paywall in the Helium dashboard."
-        }
     }
 }
 

--- a/Sources/Helium/HeliumCore/PaywallEvents.swift
+++ b/Sources/Helium/HeliumCore/PaywallEvents.swift
@@ -559,13 +559,17 @@ public enum HeliumPaymentProcessor: String, Codable, Sendable {
 }
 
 /// Raised when a purchase cannot be routed to a payment processor.
-public enum HeliumPaymentRoutingError: LocalizedError {
+///
+/// Internal: host apps still read the text through `localizedDescription` on
+/// the `Error` delivered by `.failed`, so keeping the type out of the public
+/// surface costs them nothing but the ability to pattern-match the case.
+enum HeliumPaymentRoutingError: LocalizedError {
     /// A Paddle/Stripe composite product key that neither server price map
     /// knows about. Handing it to StoreKit would fail with a misleading App
     /// Store Connect error, so the flow stops here instead.
     case unregisteredWebProductKey(String)
 
-    public var errorDescription: String? {
+    var errorDescription: String? {
         switch self {
         case .unregisteredWebProductKey(let key):
             return "Product \(key) looks like a Paddle or Stripe price but was not in the on-launch product list, so it cannot be purchased through the App Store. Check that this product is configured on this paywall in the Helium dashboard."

--- a/Sources/Helium/HeliumCore/StripeCheckout/WebCheckoutModels.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/WebCheckoutModels.swift
@@ -249,6 +249,19 @@ public enum PaddlePrefetchError: LocalizedError {
     }
 }
 
+/// Raised when a purchase cannot be routed to any payment processor.
+enum HeliumPaymentRoutingError: LocalizedError {
+    /// A Paddle/Stripe composite product key absent from both server price maps.
+    case unregisteredWebProductKey(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unregisteredWebProductKey(let key):
+            return "\(key) is not set up as a purchasable product on this paywall. Add it to the paywall's products in the Helium dashboard and republish, or remove it from the paywall."
+        }
+    }
+}
+
 enum WebCheckoutError: LocalizedError {
     case cannotPresentCheckout
     case checkoutURLsNotConfigured

--- a/Tests/helium-swiftTests/PaymentProcessorRoutingTests.swift
+++ b/Tests/helium-swiftTests/PaymentProcessorRoutingTests.swift
@@ -64,6 +64,8 @@ final class PaymentProcessorRoutingTests: XCTestCase {
 
         XCTAssertTrue(description.contains(key))
         XCTAssertTrue(description.contains("on-launch"),
-                      "the message must point at the server product list, not App Store Connect")
+                      "the message must point at the server product list")
+        XCTAssertFalse(description.contains("App Store Connect"),
+                       "naming App Store Connect is what sent the last investigation the wrong way")
     }
 }

--- a/Tests/helium-swiftTests/PaymentProcessorRoutingTests.swift
+++ b/Tests/helium-swiftTests/PaymentProcessorRoutingTests.swift
@@ -57,15 +57,14 @@ final class PaymentProcessorRoutingTests: XCTestCase {
 
     // MARK: - Error surface
 
-    func testUnregisteredWebProductKeyErrorNamesTheProductAndTheRealCause() throws {
+    func testUnregisteredWebProductKeyErrorNamesTheProduct() throws {
         let key = "pro_01krypc7fqwabtc3hcxsg54qfw:pri_01kxv658enrjcre5b3sr78j72p"
         let description = try XCTUnwrap(
             HeliumPaymentRoutingError.unregisteredWebProductKey(key).errorDescription)
 
-        XCTAssertTrue(description.contains(key))
-        XCTAssertTrue(description.contains("on-launch"),
-                      "the message must point at the server product list")
+        XCTAssertTrue(description.contains(key),
+                      "the developer needs to know which product failed to route")
         XCTAssertFalse(description.contains("App Store Connect"),
-                       "naming App Store Connect is what sent the last investigation the wrong way")
+                       "pointing at App Store Connect is the misdiagnosis this error exists to prevent")
     }
 }

--- a/Tests/helium-swiftTests/PaymentProcessorRoutingTests.swift
+++ b/Tests/helium-swiftTests/PaymentProcessorRoutingTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import Helium
+
+final class PaymentProcessorRoutingTests: XCTestCase {
+
+    // MARK: - Composite keys that must not reach StoreKit
+
+    func testPaddleCompositeKeyIsRecognised() {
+        XCTAssertTrue(HeliumPaymentProcessor.isWebProcessorCompositeKey(
+            "pro_01krypc7fqwabtc3hcxsg54qfw:pri_01kxv658enrjcre5b3sr78j72p"))
+    }
+
+    func testStripeCompositeKeyIsRecognised() {
+        XCTAssertTrue(HeliumPaymentProcessor.isWebProcessorCompositeKey(
+            "prod_ABC123:price_XYZ789"))
+    }
+
+    // MARK: - StoreKit identifiers that must still route to StoreKit
+
+    func testBareStoreKitIdentifierIsNotACompositeKey() {
+        XCTAssertFalse(HeliumPaymentProcessor.isWebProcessorCompositeKey("com.example.app.pro_yearly"))
+    }
+
+    func testStoreKitIdentifierContainingAColonIsNotACompositeKey() {
+        // Both halves have to match a provider's prefix pair, so an identifier
+        // that merely contains a colon keeps its StoreKit routing.
+        XCTAssertFalse(HeliumPaymentProcessor.isWebProcessorCompositeKey("com.example.app:yearly"))
+    }
+
+    func testAndroidStyleBasePlanKeyIsNotACompositeKey() {
+        XCTAssertFalse(HeliumPaymentProcessor.isWebProcessorCompositeKey("premium_sub:monthly-base"))
+    }
+
+    // MARK: - Half-matches
+
+    func testPaddleProductWithStripePricePrefixIsNotACompositeKey() {
+        // Mixing one provider's product prefix with another's price prefix is
+        // not a shape either provider emits.
+        XCTAssertFalse(HeliumPaymentProcessor.isWebProcessorCompositeKey("pro_abc:price_xyz"))
+    }
+
+    func testProductPrefixWithoutPricePrefixIsNotACompositeKey() {
+        XCTAssertFalse(HeliumPaymentProcessor.isWebProcessorCompositeKey("pro_abc:something"))
+    }
+
+    func testTrailingColonIsNotACompositeKey() {
+        XCTAssertFalse(HeliumPaymentProcessor.isWebProcessorCompositeKey("pro_abc:"))
+    }
+
+    func testMultipleColonsAreNotACompositeKey() {
+        XCTAssertFalse(HeliumPaymentProcessor.isWebProcessorCompositeKey("pro_abc:pri_xyz:extra"))
+    }
+
+    func testEmptyKeyIsNotACompositeKey() {
+        XCTAssertFalse(HeliumPaymentProcessor.isWebProcessorCompositeKey(""))
+    }
+
+    // MARK: - Error surface
+
+    func testUnregisteredWebProductKeyErrorNamesTheProductAndTheRealCause() throws {
+        let key = "pro_01krypc7fqwabtc3hcxsg54qfw:pri_01kxv658enrjcre5b3sr78j72p"
+        let description = try XCTUnwrap(
+            HeliumPaymentRoutingError.unregisteredWebProductKey(key).errorDescription)
+
+        XCTAssertTrue(description.contains(key))
+        XCTAssertTrue(description.contains("on-launch"),
+                      "the message must point at the server product list, not App Store Connect")
+    }
+}


### PR DESCRIPTION
## Problem

`HeliumPaymentProcessor.resolve` returns `.appStore` for any key absent from both server price maps, and `handlePurchase` hands that straight to the StoreKit delegate:

```swift
static func resolve(for productKey: String) -> HeliumPaymentProcessor {
    if stripeProducts[productKey] != nil { return .stripe }
    if paddleProducts[productKey] != nil { return .paddle }
    return .appStore
}
```

For a bare StoreKit identifier that is correct. For a `<productId>:<priceId>` composite it is not. App Store Connect has no product under `pro_01kry…:pri_01kxv…`, so `Product.products(for:)` misses and the customer gets:

> Could not find product ... in App Store Connect

That error names the wrong system. The real cause is that the paywall rang up a price the on-launch response never registered in `paddleProducts` / `stripeProducts`, which is a server or paywall configuration problem. This is not hypothetical: it is how a recent Paddle incident was initially diagnosed, and it cost real time before anyone suspected the server.

## Change

Detect the composite shape at the dispatch site and fail with an error pointing at the on-launch product list instead of App Store Connect.

The purchase failed either way. This only changes which error the developer reads, so there is no behavioural risk to a working flow.

## Why both halves are checked

`isWebProcessorCompositeKey` requires the product **and** price side to match one provider's prefix pair:

- Paddle `pro_…:pri_…`
- Stripe `prod_…:price_…`

A StoreKit identifier that merely contains a colon, or matches only one half, still routes to StoreKit exactly as before. Note `"prod_x".hasPrefix("pro_")` is false, so the two providers cannot cross-match.

## Tests

`PaymentProcessorRoutingTests` covers both provider shapes, bare and colon-containing StoreKit identifiers, an Android-style `sub:base-plan` key, half-matches, trailing colon, multiple colons, empty string, and that the error message names the product and points at the on-launch list.

## Verification

Not compiled locally. This repo is iOS-only and the machine has Command Line Tools without full Xcode, so `swift build` fails on `no such module 'UIKit'` and there is no simulator runtime. CI (`run-tests.yml`, SwiftPM tests on an iOS Simulator with Thread Sanitizer) is the first real compile. Symbols were checked by hand: `HeliumLogger` is a public enum already used in this file, `Foundation` is imported in `PaywallEvents.swift`, and `.failed` takes any `Error`.

## Related

Server-side counterpart is cloudcaptainai/bandit-server-lite-phoenix#118, which stops the two bugs that produced these unregistered keys in the first place. This PR is defence in depth for the next time it happens.

Generated with Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow guard on misconfigured web keys only; successful StoreKit, Stripe, and Paddle paths are unchanged, with unit tests for edge cases.
> 
> **Overview**
> When a Paddle or Stripe `productId:priceId` key is missing from the on-launch price maps, `HeliumPaymentProcessor.resolve` still returns `.appStore`, so purchases used to hit StoreKit and surface misleading “not in App Store Connect” errors.
> 
> This PR adds **`isWebProcessorCompositeKey`** (Paddle `pro_…:pri_…` or Stripe `prod_…:price_…`, both halves required) and a **`HeliumPaymentRoutingError.unregisteredWebProductKey`** message that points at paywall/dashboard configuration. In **`handlePurchase`**, if routing is `.appStore` but the key matches that composite shape, the flow fails immediately with that error instead of calling **`makePurchase`**. Bare StoreKit IDs and colon-containing keys that are not web composites still go to StoreKit unchanged.
> 
> **`PaymentProcessorRoutingTests`** covers recognition, false positives, and the error copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25d7376e5ee23697bc0ce1e9bf8ac1e81faf1758. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid Paddle/Stripe “web processor” composite product keys (including App Store web processor keys) now stop the purchase flow and return a clear routing failure instead of falling through.

* **Error Handling**
  * Added detection for composite key formats (`<productId>:<priceId>`) and improved the failure message when the key isn’t found in the loaded paywall products.

* **Tests**
  * Added routing tests covering valid, malformed, and unsupported key formats, plus validation of the error message content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->