### PR TITLE
Derive web-checkout intro-offer eligibility from any offered price, not all

### DIFF
--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -183,12 +183,10 @@ public class ExternalWebCheckoutManager: NSObject {
         return try await openEnrichedCheckoutURL(enrichedURL, productKey: productKey, paywallSession: paywallSession)
     }
 
-    /// Whether this customer is intro-offer eligible, for the web bundle to
-    /// decide whether to select each bucket's trial slot.
+    /// Whether this customer is deemed intro-offer eligible for the web paywall.
     ///
     /// Prefers the server's per-customer signal from `/check-entitlement` when
-    /// available — the local price map can go stale (e.g., host app sets
-    /// userId after Helium initialized, so eligibility could change).
+    /// available — the local price map can go stale.
     private func isIntroOfferEligibleForWebCheckout(paywallInfo: HeliumPaywallInfo?) async -> Bool {
         guard let paywallInfo,
               let products = provider.getOfferedProducts(paywallInfo, false),
@@ -198,27 +196,21 @@ public class ExternalWebCheckoutManager: NSObject {
         if let serverValue = await entitlementsSource.introOfferEligible() {
             return serverValue
         }
-        return Self.introOfferEligible(
+        return Self.blanketIntroOfferEligibility(
             products: products,
             priceMap: provider.getProductsPriceMap() ?? [:]
         )
     }
 
-    /// Derives the per-customer intro-offer signal from the server price map,
-    /// for when `/check-entitlement` returns no eligibility value.
+    /// Derives the intro-offer signal from the price map when
+    /// `/check-entitlement` returns no eligibility value. Matches the contract
+    /// of CML's `computeIntroOfferEligibleForAll`.
     ///
-    /// Mirrors the coarse-prop contract CML's `computeIntroOfferEligibleForAll`
-    /// already ships: only offer-bearing products count, every one of them must
-    /// be eligible, and no offer-bearing products at all means false.
-    ///
-    /// Offer-bearing is keyed on `introOffers`, not on `introOfferEligible`.
-    /// That boolean folds two facts into one: the price carries a trial, AND
-    /// this customer has not consumed an intro offer. It is therefore false
-    /// both for a price with no trial and for a trial this customer cannot
-    /// have, and reading it alone cannot tell those apart. Testing every
-    /// offered product against it let a plain monthly plan sitting beside a
-    /// yearly trial report the customer permanently ineligible.
-    static func introOfferEligible(
+    /// Only offer-bearing prices count. A price's `introOfferEligible` is false
+    /// both when it carries no trial and when the customer already consumed
+    /// one, so requiring it of every offered product let a plain monthly plan
+    /// sitting beside a yearly trial report the customer ineligible.
+    static func blanketIntroOfferEligibility(
         products: [String],
         priceMap: [String: ServerProductPrice]
     ) -> Bool {

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -183,7 +183,9 @@ public class ExternalWebCheckoutManager: NSObject {
         return try await openEnrichedCheckoutURL(enrichedURL, productKey: productKey, paywallSession: paywallSession)
     }
 
-    /// True if every offered product is intro-offer eligible.
+    /// Whether this customer is intro-offer eligible, for the web bundle to
+    /// decide whether to select each bucket's trial slot.
+    ///
     /// Prefers the server's per-customer signal from `/check-entitlement` when
     /// available — the local price map can go stale (e.g., host app sets
     /// userId after Helium initialized, so eligibility could change).
@@ -196,8 +198,33 @@ public class ExternalWebCheckoutManager: NSObject {
         if let serverValue = await entitlementsSource.introOfferEligible() {
             return serverValue
         }
-        let priceMap = provider.getProductsPriceMap() ?? [:]
-        return products.allSatisfy { priceMap[$0]?.subscription?.introOfferEligible == true }
+        return Self.introOfferEligible(
+            products: products,
+            priceMap: provider.getProductsPriceMap() ?? [:]
+        )
+    }
+
+    /// Fallback derivation of the per-customer intro-offer signal from the
+    /// server price map, used when `/check-entitlement` has no answer yet.
+    ///
+    /// A price's `subscription.introOfferEligible` already folds two things
+    /// together: the price carries a trial period, AND this customer has not
+    /// consumed an intro offer. A product with no trial therefore reports false
+    /// for everyone. Requiring EVERY offered product to report true let a
+    /// single no-trial product — a monthly plan sitting next to a yearly trial,
+    /// say — mask an eligible customer and suppress trials across the whole web
+    /// paywall.
+    ///
+    /// One product reporting true is sufficient. Eligibility is a property of
+    /// the customer, not of the product set, and the server applies that one
+    /// customer bit to every trial-bearing price. So a single true means the
+    /// customer is eligible, and an ineligible customer yields false on every
+    /// entry regardless of how many trials the paywall offers.
+    static func introOfferEligible(
+        products: [String],
+        priceMap: [String: ServerProductPrice]
+    ) -> Bool {
+        products.contains { priceMap[$0]?.subscription?.introOfferEligible == true }
     }
 
     /// Builds the enriched checkout URL: existing query items are preserved,

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -203,8 +203,7 @@ public class ExternalWebCheckoutManager: NSObject {
     }
 
     /// Derives the intro-offer signal from the price map when
-    /// `/check-entitlement` returns no eligibility value. Matches the contract
-    /// of CML's `computeIntroOfferEligibleForAll`.
+    /// `/check-entitlement` returns no eligibility value.
     ///
     /// Only offer-bearing prices count. A price's `introOfferEligible` is false
     /// both when it carries no trial and when the customer already consumed

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -207,24 +207,26 @@ public class ExternalWebCheckoutManager: NSObject {
     /// Derives the per-customer intro-offer signal from the server price map,
     /// for when `/check-entitlement` returns no eligibility value.
     ///
-    /// A price's `subscription.introOfferEligible` already folds two things
-    /// together: the price carries a trial period, AND this customer has not
-    /// consumed an intro offer. A product with no trial therefore reports false
-    /// for everyone. Requiring EVERY offered product to report true let a
-    /// single no-trial product — a monthly plan sitting next to a yearly trial,
-    /// say — mask an eligible customer and suppress trials across the whole web
-    /// paywall.
+    /// Mirrors the coarse-prop contract CML's `computeIntroOfferEligibleForAll`
+    /// already ships: only offer-bearing products count, every one of them must
+    /// be eligible, and no offer-bearing products at all means false.
     ///
-    /// One product reporting true is sufficient. Eligibility is a property of
-    /// the customer, not of the product set, and the server applies that one
-    /// customer bit to every trial-bearing price. So a single true means the
-    /// customer is eligible, and an ineligible customer yields false on every
-    /// entry regardless of how many trials the paywall offers.
+    /// Offer-bearing is keyed on `introOffers`, not on `introOfferEligible`.
+    /// That boolean folds two facts into one: the price carries a trial, AND
+    /// this customer has not consumed an intro offer. It is therefore false
+    /// both for a price with no trial and for a trial this customer cannot
+    /// have, and reading it alone cannot tell those apart. Testing every
+    /// offered product against it let a plain monthly plan sitting beside a
+    /// yearly trial report the customer permanently ineligible.
     static func introOfferEligible(
         products: [String],
         priceMap: [String: ServerProductPrice]
     ) -> Bool {
-        products.contains { priceMap[$0]?.subscription?.introOfferEligible == true }
+        let offerBearing = products
+            .compactMap { priceMap[$0]?.subscription }
+            .filter { !($0.introOffers ?? []).isEmpty }
+        guard !offerBearing.isEmpty else { return false }
+        return offerBearing.allSatisfy { $0.introOfferEligible == true }
     }
 
     /// Builds the enriched checkout URL: existing query items are preserved,

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -204,8 +204,8 @@ public class ExternalWebCheckoutManager: NSObject {
         )
     }
 
-    /// Fallback derivation of the per-customer intro-offer signal from the
-    /// server price map, used when `/check-entitlement` has no answer yet.
+    /// Derives the per-customer intro-offer signal from the server price map,
+    /// for when `/check-entitlement` returns no eligibility value.
     ///
     /// A price's `subscription.introOfferEligible` already folds two things
     /// together: the price carries a trial period, AND this customer has not

--- a/Tests/helium-swiftTests/WebCheckoutIntroOfferEligibilityTests.swift
+++ b/Tests/helium-swiftTests/WebCheckoutIntroOfferEligibilityTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import Helium
+
+/// Covers the fallback derivation used when `/check-entitlement` has not
+/// answered yet. Fixtures are decoded from the on-launch wire shape rather than
+/// hand-constructed, so a rename on the server side surfaces here.
+final class WebCheckoutIntroOfferEligibilityTests: XCTestCase {
+
+    private func price(_ productKey: String, introOfferEligible: Bool?) throws -> ServerProductPrice {
+        let parts = productKey.split(separator: ":")
+        var json: [String: Any] = [
+            "id": String(parts[0]),
+            "priceId": String(parts[1]),
+            "formattedPrice": "$29.99",
+            "currency": "USD",
+            "productType": "subscription",
+        ]
+        if let introOfferEligible {
+            json["subscription"] = [
+                "period": "P1Y",
+                "periodUnit": "year",
+                "periodValue": 1,
+                "introOfferEligible": introOfferEligible,
+            ]
+        }
+        let data = try JSONSerialization.data(withJSONObject: json)
+        return try JSONDecoder().decode(ServerProductPrice.self, from: data)
+    }
+
+    private func map(_ entries: [(String, Bool?)]) throws -> [String: ServerProductPrice] {
+        var result: [String: ServerProductPrice] = [:]
+        for (key, eligible) in entries {
+            result[key] = try price(key, introOfferEligible: eligible)
+        }
+        return result
+    }
+
+    private let yearlyTrial = "pro_yearly:pri_trial_7d"
+    private let monthlyNoTrial = "pro_monthly:pri_main_monthly"
+
+    // MARK: - The reported defect
+
+    func testNoTrialProductDoesNotMaskAnEligibleCustomer() throws {
+        // A web paywall offering a yearly trial alongside a monthly plan with no
+        // trial. The monthly entry is false for every customer because it has no
+        // trial period at all, and must not veto the yearly signal.
+        let priceMap = try map([(yearlyTrial, true), (monthlyNoTrial, false)])
+
+        XCTAssertTrue(ExternalWebCheckoutManager.introOfferEligible(
+            products: [monthlyNoTrial, yearlyTrial], priceMap: priceMap))
+    }
+
+    func testOrderOfOfferedProductsDoesNotMatter() throws {
+        let priceMap = try map([(yearlyTrial, true), (monthlyNoTrial, false)])
+
+        XCTAssertTrue(ExternalWebCheckoutManager.introOfferEligible(
+            products: [yearlyTrial, monthlyNoTrial], priceMap: priceMap))
+    }
+
+    // MARK: - Cases that must stay false
+
+    func testIneligibleCustomerIsFalseEvenWithSeveralTrialProducts() throws {
+        // The server applies one customer-level bit to every trial-bearing
+        // price, so an ineligible customer is false everywhere.
+        let priceMap = try map([(yearlyTrial, false), ("pro_yearly:pri_trial_14d", false)])
+
+        XCTAssertFalse(ExternalWebCheckoutManager.introOfferEligible(
+            products: [yearlyTrial, "pro_yearly:pri_trial_14d"], priceMap: priceMap))
+    }
+
+    func testPaywallWithNoTrialsAtAllIsFalse() throws {
+        let priceMap = try map([(monthlyNoTrial, false)])
+
+        XCTAssertFalse(ExternalWebCheckoutManager.introOfferEligible(
+            products: [monthlyNoTrial], priceMap: priceMap))
+    }
+
+    func testEmptyProductListIsFalse() throws {
+        let priceMap = try map([(yearlyTrial, true)])
+
+        XCTAssertFalse(ExternalWebCheckoutManager.introOfferEligible(
+            products: [], priceMap: priceMap))
+    }
+
+    func testProductMissingFromPriceMapIsFalse() throws {
+        XCTAssertFalse(ExternalWebCheckoutManager.introOfferEligible(
+            products: [yearlyTrial], priceMap: [:]))
+    }
+
+    func testEntryWithoutASubscriptionBlockIsFalse() throws {
+        // One-time products carry no subscription detail.
+        let priceMap = try map([(monthlyNoTrial, nil)])
+
+        XCTAssertFalse(ExternalWebCheckoutManager.introOfferEligible(
+            products: [monthlyNoTrial], priceMap: priceMap))
+    }
+
+    func testUnknownProductAlongsideAnEligibleOneIsStillTrue() throws {
+        let priceMap = try map([(yearlyTrial, true)])
+
+        XCTAssertTrue(ExternalWebCheckoutManager.introOfferEligible(
+            products: ["pro_ghost:pri_missing", yearlyTrial], priceMap: priceMap))
+    }
+}

--- a/Tests/helium-swiftTests/WebCheckoutIntroOfferEligibilityTests.swift
+++ b/Tests/helium-swiftTests/WebCheckoutIntroOfferEligibilityTests.swift
@@ -2,23 +2,26 @@ import XCTest
 @testable import Helium
 
 /// Covers the price-map derivation used when `/check-entitlement` returns no
-/// eligibility value. Fixtures are decoded from the on-launch wire shape rather
-/// than hand-constructed, so a rename on the server side surfaces here.
+/// eligibility value. Fixtures are decoded from JSON rather than hand-built, so
+/// a field rename surfaces here.
 final class WebCheckoutIntroOfferEligibilityTests: XCTestCase {
 
-    /// The shapes bandit emits for a price.
+    /// Price fixtures, named for what they represent and defined by the fields
+    /// they carry.
     private enum Shape {
-        /// Trial configured and this customer may have it: flag true, offer present.
+        /// `introOfferEligible: true`, `introOffers` non-empty.
         case eligibleTrial
-        /// Trial configured but already consumed: flag false, offer omitted.
+        /// `introOfferEligible: false`, `introOffers` omitted — a trial the
+        /// customer has already consumed.
         case consumedTrial
-        /// No trial on the price at all: flag false, offer omitted. Identical on
-        /// the wire to `consumedTrial`, which is why offer-bearing is the test.
+        /// `introOfferEligible: false`, `introOffers` omitted — a price with no
+        /// trial at all. Identical on the wire to `consumedTrial`, which is why
+        /// offer-bearing is keyed on `introOffers`.
         case noTrial
-        /// One-time product: no subscription block.
+        /// No `subscription` block.
         case oneTime
-        /// Not a shape bandit emits today. Pins that an offer-bearing price
-        /// reporting ineligible still fails the check.
+        /// `introOfferEligible: false`, `introOffers` non-empty. Pins that an
+        /// offer-bearing price reporting ineligible still fails the check.
         case offerButIneligible
     }
 
@@ -90,8 +93,8 @@ final class WebCheckoutIntroOfferEligibilityTests: XCTestCase {
     // MARK: - Cases that must stay false
 
     func testConsumedTrialIsFalse() throws {
-        // Bandit omits introOffers once the customer has used their intro offer,
-        // so nothing is offer-bearing and the answer is false.
+        // A consumed trial arrives with no introOffers, so no price on the
+        // paywall is offer-bearing.
         let priceMap = try map([(yearlyTrial, .consumedTrial), (monthlyNoTrial, .noTrial)])
 
         XCTAssertFalse(ExternalWebCheckoutManager.blanketIntroOfferEligibility(
@@ -127,10 +130,9 @@ final class WebCheckoutIntroOfferEligibilityTests: XCTestCase {
     // MARK: - Every offer-bearing product must agree
 
     func testOfferBearingButIneligibleFailsTheCheck() throws {
-        // Not a shape bandit emits today: it sets the flag and the offer array
-        // together. Pinned so the contract stays "every offer-bearing product is
-        // eligible" rather than degrading to "any product is eligible" if the
-        // server ever starts sending offers to ineligible customers.
+        // Pins the contract as "every offer-bearing product is eligible" rather
+        // than "any product is eligible", should a price ever arrive carrying an
+        // offer the customer is not eligible for.
         let priceMap = try map([
             (yearlyTrial, .eligibleTrial),
             ("pro_yearly:pri_trial_14d", .offerButIneligible),

--- a/Tests/helium-swiftTests/WebCheckoutIntroOfferEligibilityTests.swift
+++ b/Tests/helium-swiftTests/WebCheckoutIntroOfferEligibilityTests.swift
@@ -2,81 +2,111 @@ import XCTest
 @testable import Helium
 
 /// Covers the price-map derivation used when `/check-entitlement` returns no
-/// eligibility value. Fixtures are decoded from the on-launch wire shape rather than
-/// hand-constructed, so a rename on the server side surfaces here.
+/// eligibility value. Fixtures are decoded from the on-launch wire shape rather
+/// than hand-constructed, so a rename on the server side surfaces here.
 final class WebCheckoutIntroOfferEligibilityTests: XCTestCase {
 
-    private func price(_ productKey: String, introOfferEligible: Bool?) throws -> ServerProductPrice {
+    /// The shapes bandit emits for a price.
+    private enum Shape {
+        /// Trial configured and this customer may have it: flag true, offer present.
+        case eligibleTrial
+        /// Trial configured but already consumed: flag false, offer omitted.
+        case consumedTrial
+        /// No trial on the price at all: flag false, offer omitted. Identical on
+        /// the wire to `consumedTrial`, which is why offer-bearing is the test.
+        case noTrial
+        /// One-time product: no subscription block.
+        case oneTime
+        /// Not a shape bandit emits today. Pins that an offer-bearing price
+        /// reporting ineligible still fails the check.
+        case offerButIneligible
+    }
+
+    private func price(_ productKey: String, _ shape: Shape) throws -> ServerProductPrice {
         let parts = productKey.split(separator: ":")
         var json: [String: Any] = [
             "id": String(parts[0]),
             "priceId": String(parts[1]),
             "formattedPrice": "$29.99",
             "currency": "USD",
-            "productType": "subscription",
+            "productType": shape == .oneTime ? "one_time" : "subscription",
         ]
-        if let introOfferEligible {
-            json["subscription"] = [
-                "period": "P1Y",
-                "periodUnit": "year",
-                "periodValue": 1,
-                "introOfferEligible": introOfferEligible,
+        if shape != .oneTime {
+            var sub: [String: Any] = [
+                "period": "P1Y", "periodUnit": "year", "periodValue": 1,
+                "introOfferEligible": shape == .eligibleTrial,
             ]
+            if shape == .eligibleTrial || shape == .offerButIneligible {
+                sub["introOffers"] = [[
+                    "type": "IntroOffer", "displayPrice": "Free",
+                    "periodUnit": "day", "periodValue": 7, "periodCount": 1,
+                    "paymentMode": "FreeTrial",
+                ]]
+            }
+            json["subscription"] = sub
         }
         let data = try JSONSerialization.data(withJSONObject: json)
         return try JSONDecoder().decode(ServerProductPrice.self, from: data)
     }
 
-    private func map(_ entries: [(String, Bool?)]) throws -> [String: ServerProductPrice] {
+    private func map(_ entries: [(String, Shape)]) throws -> [String: ServerProductPrice] {
         var result: [String: ServerProductPrice] = [:]
-        for (key, eligible) in entries {
-            result[key] = try price(key, introOfferEligible: eligible)
+        for (key, shape) in entries {
+            result[key] = try price(key, shape)
         }
         return result
     }
 
     private let yearlyTrial = "pro_yearly:pri_trial_7d"
     private let monthlyNoTrial = "pro_monthly:pri_main_monthly"
+    private let lifetime = "pro_lifetime:pri_one_time"
 
     // MARK: - The reported defect
 
     func testNoTrialProductDoesNotMaskAnEligibleCustomer() throws {
-        // A web paywall offering a yearly trial alongside a monthly plan with no
+        // A web paywall offering a yearly trial next to a monthly plan with no
         // trial. The monthly entry is false for every customer because it has no
-        // trial period at all, and must not veto the yearly signal.
-        let priceMap = try map([(yearlyTrial, true), (monthlyNoTrial, false)])
+        // trial at all, so it is not offer-bearing and must not be counted.
+        let priceMap = try map([(yearlyTrial, .eligibleTrial), (monthlyNoTrial, .noTrial)])
 
         XCTAssertTrue(ExternalWebCheckoutManager.introOfferEligible(
             products: [monthlyNoTrial, yearlyTrial], priceMap: priceMap))
     }
 
     func testOrderOfOfferedProductsDoesNotMatter() throws {
-        let priceMap = try map([(yearlyTrial, true), (monthlyNoTrial, false)])
+        let priceMap = try map([(yearlyTrial, .eligibleTrial), (monthlyNoTrial, .noTrial)])
 
         XCTAssertTrue(ExternalWebCheckoutManager.introOfferEligible(
             products: [yearlyTrial, monthlyNoTrial], priceMap: priceMap))
     }
 
+    func testOneTimeProductDoesNotMaskAnEligibleCustomer() throws {
+        let priceMap = try map([(yearlyTrial, .eligibleTrial), (lifetime, .oneTime)])
+
+        XCTAssertTrue(ExternalWebCheckoutManager.introOfferEligible(
+            products: [lifetime, yearlyTrial], priceMap: priceMap))
+    }
+
     // MARK: - Cases that must stay false
 
-    func testIneligibleCustomerIsFalseEvenWithSeveralTrialProducts() throws {
-        // The server applies one customer-level bit to every trial-bearing
-        // price, so an ineligible customer is false everywhere.
-        let priceMap = try map([(yearlyTrial, false), ("pro_yearly:pri_trial_14d", false)])
+    func testConsumedTrialIsFalse() throws {
+        // Bandit omits introOffers once the customer has used their intro offer,
+        // so nothing is offer-bearing and the answer is false.
+        let priceMap = try map([(yearlyTrial, .consumedTrial), (monthlyNoTrial, .noTrial)])
 
         XCTAssertFalse(ExternalWebCheckoutManager.introOfferEligible(
-            products: [yearlyTrial, "pro_yearly:pri_trial_14d"], priceMap: priceMap))
+            products: [yearlyTrial, monthlyNoTrial], priceMap: priceMap))
     }
 
     func testPaywallWithNoTrialsAtAllIsFalse() throws {
-        let priceMap = try map([(monthlyNoTrial, false)])
+        let priceMap = try map([(monthlyNoTrial, .noTrial)])
 
         XCTAssertFalse(ExternalWebCheckoutManager.introOfferEligible(
             products: [monthlyNoTrial], priceMap: priceMap))
     }
 
     func testEmptyProductListIsFalse() throws {
-        let priceMap = try map([(yearlyTrial, true)])
+        let priceMap = try map([(yearlyTrial, .eligibleTrial)])
 
         XCTAssertFalse(ExternalWebCheckoutManager.introOfferEligible(
             products: [], priceMap: priceMap))
@@ -87,16 +117,31 @@ final class WebCheckoutIntroOfferEligibilityTests: XCTestCase {
             products: [yearlyTrial], priceMap: [:]))
     }
 
-    func testEntryWithoutASubscriptionBlockIsFalse() throws {
-        // One-time products carry no subscription detail.
-        let priceMap = try map([(monthlyNoTrial, nil)])
+    func testOnlyOneTimeProductsIsFalse() throws {
+        let priceMap = try map([(lifetime, .oneTime)])
 
         XCTAssertFalse(ExternalWebCheckoutManager.introOfferEligible(
-            products: [monthlyNoTrial], priceMap: priceMap))
+            products: [lifetime], priceMap: priceMap))
+    }
+
+    // MARK: - Every offer-bearing product must agree
+
+    func testOfferBearingButIneligibleFailsTheCheck() throws {
+        // Not a shape bandit emits today: it sets the flag and the offer array
+        // together. Pinned so the contract stays "every offer-bearing product is
+        // eligible" rather than degrading to "any product is eligible" if the
+        // server ever starts sending offers to ineligible customers.
+        let priceMap = try map([
+            (yearlyTrial, .eligibleTrial),
+            ("pro_yearly:pri_trial_14d", .offerButIneligible),
+        ])
+
+        XCTAssertFalse(ExternalWebCheckoutManager.introOfferEligible(
+            products: [yearlyTrial, "pro_yearly:pri_trial_14d"], priceMap: priceMap))
     }
 
     func testUnknownProductAlongsideAnEligibleOneIsStillTrue() throws {
-        let priceMap = try map([(yearlyTrial, true)])
+        let priceMap = try map([(yearlyTrial, .eligibleTrial)])
 
         XCTAssertTrue(ExternalWebCheckoutManager.introOfferEligible(
             products: ["pro_ghost:pri_missing", yearlyTrial], priceMap: priceMap))

--- a/Tests/helium-swiftTests/WebCheckoutIntroOfferEligibilityTests.swift
+++ b/Tests/helium-swiftTests/WebCheckoutIntroOfferEligibilityTests.swift
@@ -1,8 +1,8 @@
 import XCTest
 @testable import Helium
 
-/// Covers the fallback derivation used when `/check-entitlement` has not
-/// answered yet. Fixtures are decoded from the on-launch wire shape rather than
+/// Covers the price-map derivation used when `/check-entitlement` returns no
+/// eligibility value. Fixtures are decoded from the on-launch wire shape rather than
 /// hand-constructed, so a rename on the server side surfaces here.
 final class WebCheckoutIntroOfferEligibilityTests: XCTestCase {
 

--- a/Tests/helium-swiftTests/WebCheckoutIntroOfferEligibilityTests.swift
+++ b/Tests/helium-swiftTests/WebCheckoutIntroOfferEligibilityTests.swift
@@ -69,21 +69,21 @@ final class WebCheckoutIntroOfferEligibilityTests: XCTestCase {
         // trial at all, so it is not offer-bearing and must not be counted.
         let priceMap = try map([(yearlyTrial, .eligibleTrial), (monthlyNoTrial, .noTrial)])
 
-        XCTAssertTrue(ExternalWebCheckoutManager.introOfferEligible(
+        XCTAssertTrue(ExternalWebCheckoutManager.blanketIntroOfferEligibility(
             products: [monthlyNoTrial, yearlyTrial], priceMap: priceMap))
     }
 
     func testOrderOfOfferedProductsDoesNotMatter() throws {
         let priceMap = try map([(yearlyTrial, .eligibleTrial), (monthlyNoTrial, .noTrial)])
 
-        XCTAssertTrue(ExternalWebCheckoutManager.introOfferEligible(
+        XCTAssertTrue(ExternalWebCheckoutManager.blanketIntroOfferEligibility(
             products: [yearlyTrial, monthlyNoTrial], priceMap: priceMap))
     }
 
     func testOneTimeProductDoesNotMaskAnEligibleCustomer() throws {
         let priceMap = try map([(yearlyTrial, .eligibleTrial), (lifetime, .oneTime)])
 
-        XCTAssertTrue(ExternalWebCheckoutManager.introOfferEligible(
+        XCTAssertTrue(ExternalWebCheckoutManager.blanketIntroOfferEligibility(
             products: [lifetime, yearlyTrial], priceMap: priceMap))
     }
 
@@ -94,33 +94,33 @@ final class WebCheckoutIntroOfferEligibilityTests: XCTestCase {
         // so nothing is offer-bearing and the answer is false.
         let priceMap = try map([(yearlyTrial, .consumedTrial), (monthlyNoTrial, .noTrial)])
 
-        XCTAssertFalse(ExternalWebCheckoutManager.introOfferEligible(
+        XCTAssertFalse(ExternalWebCheckoutManager.blanketIntroOfferEligibility(
             products: [yearlyTrial, monthlyNoTrial], priceMap: priceMap))
     }
 
     func testPaywallWithNoTrialsAtAllIsFalse() throws {
         let priceMap = try map([(monthlyNoTrial, .noTrial)])
 
-        XCTAssertFalse(ExternalWebCheckoutManager.introOfferEligible(
+        XCTAssertFalse(ExternalWebCheckoutManager.blanketIntroOfferEligibility(
             products: [monthlyNoTrial], priceMap: priceMap))
     }
 
     func testEmptyProductListIsFalse() throws {
         let priceMap = try map([(yearlyTrial, .eligibleTrial)])
 
-        XCTAssertFalse(ExternalWebCheckoutManager.introOfferEligible(
+        XCTAssertFalse(ExternalWebCheckoutManager.blanketIntroOfferEligibility(
             products: [], priceMap: priceMap))
     }
 
     func testProductMissingFromPriceMapIsFalse() throws {
-        XCTAssertFalse(ExternalWebCheckoutManager.introOfferEligible(
+        XCTAssertFalse(ExternalWebCheckoutManager.blanketIntroOfferEligibility(
             products: [yearlyTrial], priceMap: [:]))
     }
 
     func testOnlyOneTimeProductsIsFalse() throws {
         let priceMap = try map([(lifetime, .oneTime)])
 
-        XCTAssertFalse(ExternalWebCheckoutManager.introOfferEligible(
+        XCTAssertFalse(ExternalWebCheckoutManager.blanketIntroOfferEligibility(
             products: [lifetime], priceMap: priceMap))
     }
 
@@ -136,14 +136,14 @@ final class WebCheckoutIntroOfferEligibilityTests: XCTestCase {
             ("pro_yearly:pri_trial_14d", .offerButIneligible),
         ])
 
-        XCTAssertFalse(ExternalWebCheckoutManager.introOfferEligible(
+        XCTAssertFalse(ExternalWebCheckoutManager.blanketIntroOfferEligibility(
             products: [yearlyTrial, "pro_yearly:pri_trial_14d"], priceMap: priceMap))
     }
 
     func testUnknownProductAlongsideAnEligibleOneIsStillTrue() throws {
         let priceMap = try map([(yearlyTrial, .eligibleTrial)])
 
-        XCTAssertTrue(ExternalWebCheckoutManager.introOfferEligible(
+        XCTAssertTrue(ExternalWebCheckoutManager.blanketIntroOfferEligibility(
             products: ["pro_ghost:pri_missing", yearlyTrial], priceMap: priceMap))
     }
 }


### PR DESCRIPTION
## Problem

`isIntroOfferEligibleForWebCheckout` produces the boolean the app2web handoff writes into `ctx.introOfferEligible`, which the web bundle reads as `__heliumPaddleIntroOfferEligible` and uses to decide whether to select each bucket's trial slot.

When `/check-entitlement` returns no eligibility value, it was derived from the product set with `allSatisfy` over `subscription?.introOfferEligible`. That boolean folds two facts into one, server-side:

```go
if price.TrialPeriod != nil && price.TrialPeriod.Frequency > 0 && introEligible {
    subscription.IntroOfferEligible = true
}
```

So a price with no trial reports `false` for every customer, always, and one such product vetoed the whole signal. A web paywall offering a monthly plan alongside a yearly trial reported **every customer ineligible, permanently**, and the bundle showed no trial. Wayk's web paywalls (org `b91f1d9d`) all have that shape: every one includes the monthly no-trial bucket `0a6a685f`.

## Change

Follow the contract CML already ships as `computeIntroOfferEligibleForAll` (content-manager-lite#1170): only offer-bearing products count, every one of them must be eligible, and none offer-bearing means false.

```swift
let offerBearing = products
    .compactMap { priceMap[$0]?.subscription }
    .filter { !($0.introOffers ?? []).isEmpty }
guard !offerBearing.isEmpty else { return false }
return offerBearing.allSatisfy { $0.introOfferEligible == true }
```

Offer-bearing keys on `introOffers`, not on `introOfferEligible`. That field is not overloaded: bandit emits it only alongside `introOfferEligible: true`, and omits it both for prices with no trial and for trials the customer has consumed.

| situation | before | after | correct |
|---|---|---|---|
| eligible, all products have trials | true | true | true |
| eligible, one product has no trial | **false** | true | true |
| eligible, one product is one-time | **false** | true | true |
| customer consumed their intro offer | false | false | false |
| no product has a trial | false | false | false |

## Why not `introOfferEligible != false`

Suggested in review, and it does not fix the case. The Go field is a non-pointer bool with no `omitempty`, so a no-trial **subscription** price serialises an explicit `false` rather than omitting it. The committed golden shows `pri_paired_main` with `"introOfferEligible": false` and no `introOffers`. `!= false` only skips when the whole `subscription` block is nil, which happens for one-time products, so the monthly-plan case survives.

## Same code for both providers

Stripe eligibility is per product (`!eligibility.ProductsWithUsedTrial[productID]`), unlike Paddle's single global bit, so two trial-bearing Stripe prices can legitimately disagree. An earlier revision of this PR used `contains`, which was unsafe there. Under the offer-bearing contract a product the customer already trialed arrives with no `introOffers` and is skipped, exactly as CML treats it, so no provider branch is needed.

## Scope, and what is not established

This affects only the path taken when `entitlementsSource.introOfferEligible()` returns nil, which happens when the entitlements fetch produced no snapshot or the server omitted the field. The user-visible consequence is a missing trial on the web paywall, not a purchase failure.

**How often that path is taken has not been measured.** One case worth checking before sizing this: an unidentified user on first launch, before any `/check-entitlement` result exists. That is precisely the population that should be seeing trials.

This does not touch in-app paywall eligibility, which comes per-product from `paddleProducts`. It is also independent of cloudcaptainai/bandit-server-lite-phoenix#118, which changes only the in-app offered lists and leaves `webProductsOfferedPaddle` byte-identical.

## Tests

`WebCheckoutIntroOfferEligibilityTests` decodes fixtures from the on-launch wire shape rather than hand-constructing them, covering all five shapes: eligible trial, consumed trial, no trial, one-time, and offer-bearing-but-ineligible. The last is not something bandit emits today; it pins the contract as "every offer-bearing product is eligible" so it cannot quietly degrade to "any product is eligible" if that changes.

Generated with Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall trial signaling on the entitlements fallback path, which can affect conversion, but server eligibility is unchanged and behavior is covered by new unit tests.
> 
> **Overview**
> Fixes **web checkout** reporting every customer as intro-offer ineligible when the paywall mixes a trial plan with a **no-trial monthly** (or one-time) product, but only on the **fallback** path where `/check-entitlement` does not supply `introOfferEligible`.
> 
> The local price-map logic no longer requires `introOfferEligible == true` on **every** offered product. It now matches the CML contract via new **`blanketIntroOfferEligibility`**: consider only subscriptions with non-empty **`introOffers`**, require all of those to be eligible, and return false when none are offer-bearing. That value still flows into checkout **`ctx.introOfferEligible`** for the web bundle to pick trial slots.
> 
> Adds **`WebCheckoutIntroOfferEligibilityTests`** with JSON-decoded fixtures for the defect case, consumed trials, one-time products, and mixed eligibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b1cad5c9c30d2d7774c702ad5a2a86a98094d1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved intro-offer eligibility handling during web checkout.
  * Eligibility now correctly evaluates products that include intro offers, including mixed product types, missing data, consumed offers, and unknown products.
  * Correctly reports ineligibility when no offered product has an available intro offer.

* **Tests**
  * Added comprehensive coverage for eligible, ineligible, absent, and one-time intro-offer scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->