### PR TITLE
[HEL-6107] | Paywall fallback preview from control panel

### DIFF
--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
@@ -57,13 +57,14 @@ enum HeliumControlPanelState {
 
 /// What the control panel is currently doing to launch a preview. Launching mutates the shared
 /// preview-trigger config and hands presentation to a deferred main-actor job, so every preview
-/// tap target must stay disabled from the tap until the presenter reports an outcome (opened or
-/// not shown). Releasing sooner would let a second tap rewrite the preview-trigger config out
-/// from under a presentation that has not resolved it yet.
+/// tap target stays disabled from the tap until the preview closes or reports that it could not
+/// be shown. Releasing while a presentation is pending would let a second tap rewrite the
+/// preview-trigger config out from under it; releasing while a preview is on screen would let a
+/// second tap stack another preview over it.
 enum HeliumControlPanelActivity: Equatable {
     case idle
     /// A paywall version's bundle is downloading; the id drives that version row's spinner.
     case loadingVersion(id: String)
-    /// A preview has been handed to the presenter and no outcome has fired yet.
+    /// A preview is in the presenter's hands: presentation pending, on screen, or closing.
     case presentingPaywall
 }

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
@@ -54,3 +54,16 @@ enum HeliumControlPanelState {
         return false
     }
 }
+
+/// What the control panel is currently doing to launch a preview. Launching mutates the shared
+/// preview-trigger config and hands presentation to a deferred main-actor job, so every preview
+/// tap target must stay disabled from the tap until the presenter reports an outcome (opened or
+/// not shown). Releasing sooner would let a second tap rewrite the preview-trigger config out
+/// from under a presentation that has not resolved it yet.
+enum HeliumControlPanelActivity: Equatable {
+    case idle
+    /// A paywall version's bundle is downloading; the id drives that version row's spinner.
+    case loadingVersion(id: String)
+    /// A preview has been handed to the presenter and no outcome has fired yet.
+    case presentingPaywall
+}

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
@@ -383,13 +383,15 @@ struct HeliumControlPanelView: View {
         )
     }
 
-    /// Context for presenting a preview from the panel. The activity lock is released only by an
-    /// actual presentation outcome, so both the opened and the not-shown signal must re-enable
-    /// the panel; every presenter path ends in exactly one of the two.
+    /// Context for presenting a preview from the panel. The activity lock is released only when
+    /// the preview closes or reports it could not be shown, so both signals must re-enable the
+    /// panel; every presenter path ends in exactly one of the two. Releasing at close rather than
+    /// open keeps the panel inert the whole time a preview is on screen, so no tap can stack a
+    /// second preview over it.
     private func previewPresentationContext() -> PaywallPresentationContext {
         PaywallPresentationContext(
             config: PaywallPresentationConfig(dontShowIfAlreadyEntitled: false),
-            eventHandlers: PaywallEventHandlers().onOpen { _ in activity = .idle },
+            eventHandlers: PaywallEventHandlers().onClose { _ in activity = .idle },
             onEntitled: nil,
             onPaywallNotShown: { _ in activity = .idle }
         )

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
@@ -18,52 +18,13 @@ struct HeliumControlPanelView: View {
                 })
                 .ignoresSafeArea()
 
-                switch state {
-                case .loading:
-                    ProgressView("Loading paywalls...")
-                case .loaded(let response):
-                    ScrollView {
-                        VStack(spacing: 16) {
-                            descriptionHeader
-
-                            if response.paywalls.isEmpty {
-                                Text("No paywalls found.")
-                                    .foregroundColor(.secondary)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .padding(.top, 20)
-                            } else {
-                                let filtered = response.paywalls.filter {
-                                    searchText.isEmpty || $0.paywallName.localizedCaseInsensitiveContains(searchText)
-                                }
-                                if filtered.isEmpty {
-                                    Text("No paywalls match \"\(searchText)\".")
-                                        .foregroundColor(.secondary)
-                                        .multilineTextAlignment(.leading)
-                                        .frame(maxWidth: .infinity, alignment: .leading)
-                                        .padding(.top, 20)
-                                } else {
-                                    LazyVStack(spacing: 16) {
-                                        ForEach(filtered) { paywall in
-                                            paywallCard(paywall)
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        .padding()
-                    }
-                case .error(let message):
+                ScrollView {
                     VStack(spacing: 16) {
-                        Text(message)
-                            .foregroundColor(.secondary)
-                            .multilineTextAlignment(.center)
-                            .padding(.horizontal)
-                        Button("Retry") {
-                            state = .loading
-                            fetchTask?.cancel()
-                            fetchTask = Task { await fetchPaywalls() }
-                        }
+                        descriptionHeader
+                        fallbackPreviewCard
+                        stateContent
                     }
+                    .padding()
                 }
             }
             .navigationTitle("Paywall Previews")
@@ -114,6 +75,94 @@ struct HeliumControlPanelView: View {
         .onDisappear {
             fetchTask?.cancel()
             previewTask?.cancel()
+        }
+    }
+
+    @ViewBuilder
+    private var stateContent: some View {
+        switch state {
+        case .loading:
+            ProgressView("Loading paywalls...")
+                .frame(maxWidth: .infinity)
+                .padding(.top, 40)
+        case .loaded(let response):
+            if response.paywalls.isEmpty {
+                Text("No paywalls found.")
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.top, 20)
+            } else {
+                let filtered = response.paywalls.filter {
+                    searchText.isEmpty || $0.paywallName.localizedCaseInsensitiveContains(searchText)
+                }
+                if filtered.isEmpty {
+                    Text("No paywalls match \"\(searchText)\".")
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.top, 20)
+                } else {
+                    LazyVStack(spacing: 16) {
+                        ForEach(filtered) { paywall in
+                            paywallCard(paywall)
+                        }
+                    }
+                }
+            }
+        case .error(let message):
+            VStack(spacing: 16) {
+                Text(message)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+                Button("Retry") {
+                    state = .loading
+                    fetchTask?.cancel()
+                    fetchTask = Task { await fetchPaywalls() }
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.top, 40)
+        }
+    }
+
+    @ViewBuilder
+    private var fallbackPreviewCard: some View {
+        let configured = HeliumFetchedConfigManager.shared.hasConfiguredFallbackPreview()
+        let card = VStack(alignment: .leading, spacing: 2) {
+            Text("Default Fallback Paywall")
+                .font(.system(.headline, design: .rounded))
+                .foregroundColor(.primary)
+            if configured {
+                Text("Tap to preview on this device")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            } else {
+                Text("No fallback configured. [Set up a fallback paywall](https://docs.tryhelium.com/guides/fallback-bundle).")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .tint(.accentColor)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 14)
+        .background(Color(UIColor { traitCollection in
+            traitCollection.userInterfaceStyle == .dark ? .systemGroupedBackground : .white
+        }))
+        .cornerRadius(12)
+
+        if configured {
+            card
+                .contentShape(Rectangle())
+                .onTapGesture { presentFallbackPreview() }
+                .opacity(loadingVersionId == nil ? 1.0 : 0.4)
+                .accessibilityElement(children: .combine)
+                .accessibilityAddTraits(.isButton)
+                .accessibilityAction { presentFallbackPreview() }
+        } else {
+            // Inert: the setup link inside the text must stay the only tap target.
+            card
         }
     }
 
@@ -320,5 +369,23 @@ struct HeliumControlPanelView: View {
                 }
             }
         }
+    }
+
+    private func presentFallbackPreview() {
+        guard loadingVersionId == nil else { return }
+        guard HeliumFetchedConfigManager.shared.setFallbackPreviewTrigger() else {
+            paywallLoadError = "No fallback paywall configured"
+            return
+        }
+        HeliumLogger.log(.debug, category: .ui, "[HeliumControlPanel] Selected fallback paywall preview")
+        HeliumPaywallPresenter.shared.presentUpsell(
+            trigger: HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER,
+            presentationContext: PaywallPresentationContext(
+                config: PaywallPresentationConfig(dontShowIfAlreadyEntitled: false),
+                eventHandlers: nil,
+                onEntitled: nil,
+                onPaywallNotShown: nil
+            )
+        )
     }
 }

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct HeliumControlPanelView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var state: HeliumControlPanelState = .loading
-    @State private var loadingVersionId: String? = nil
+    @State private var activity: HeliumControlPanelActivity = .idle
     @State private var fetchTask: Task<Void, Never>?
     @State private var previewTask: Task<Void, Never>?
     @State private var searchText: String = ""
@@ -36,13 +36,13 @@ struct HeliumControlPanelView: View {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button {
                         state = .loading
-                        loadingVersionId = nil
+                        activity = .idle
                         fetchTask?.cancel()
                         fetchTask = Task { await fetchPaywalls() }
                     } label: {
                         Image(systemName: "arrow.clockwise")
                     }
-                    .disabled(state.isLoading || loadingVersionId != nil)
+                    .disabled(state.isLoading || activity != .idle)
                 }
             }
         }
@@ -156,7 +156,7 @@ struct HeliumControlPanelView: View {
             card
                 .contentShape(Rectangle())
                 .onTapGesture { presentFallbackPreview() }
-                .opacity(loadingVersionId == nil ? 1.0 : 0.4)
+                .opacity(activity == .idle ? 1.0 : 0.4)
                 .accessibilityElement(children: .combine)
                 .accessibilityAddTraits(.isButton)
                 .accessibilityAction { presentFallbackPreview() }
@@ -219,8 +219,8 @@ struct HeliumControlPanelView: View {
 
                 // Version rows
                 ForEach(Array(paywall.versions.enumerated()), id: \.element.id) { index, version in
-                    let isEnabled = version.bundleUrl != nil && loadingVersionId == nil
-                    let isLoading = loadingVersionId == version.id
+                    let isEnabled = version.bundleUrl != nil && activity == .idle
+                    let isLoading = activity == .loadingVersion(id: version.id)
 
                     if index > 0 {
                         Rectangle()
@@ -315,7 +315,7 @@ struct HeliumControlPanelView: View {
     }
 
     private func selectVersion(_ version: HeliumPaywallPreviewVersion, paywall: HeliumPaywallPreviewEntry) {
-        guard loadingVersionId == nil else { return }
+        guard activity == .idle else { return }
         guard let bundleUrl = version.bundleUrl else { return }
 
         // Web paywalls aren't renderable in-app — preview them in the browser
@@ -331,7 +331,7 @@ struct HeliumControlPanelView: View {
             return
         }
 
-        loadingVersionId = version.id
+        activity = .loadingVersion(id: version.id)
         HeliumLogger.log(.debug, category: .ui, "[HeliumControlPanel] Selected paywall: \(paywall.paywallName) version: \(version.versionId)")
 
         previewTask?.cancel()
@@ -351,20 +351,18 @@ struct HeliumControlPanelView: View {
                     webPaywallBundleUrl: version.webPaywallBundleUrl
                 )
 
-                await MainActor.run { loadingVersionId = nil }
-                guard !Task.isCancelled else { return }
+                guard !Task.isCancelled else {
+                    await MainActor.run { activity = .idle }
+                    return
+                }
+                await MainActor.run { activity = .presentingPaywall }
                 HeliumPaywallPresenter.shared.presentUpsell(
                     trigger: HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER,
-                    presentationContext: PaywallPresentationContext(
-                        config: PaywallPresentationConfig(dontShowIfAlreadyEntitled: false),
-                        eventHandlers: nil,
-                        onEntitled: nil,
-                        onPaywallNotShown: nil
-                    )
+                    presentationContext: previewPresentationContext()
                 )
             } catch {
                 await MainActor.run {
-                    loadingVersionId = nil
+                    activity = .idle
                     paywallLoadError = "Failed to load paywall: \(error.localizedDescription)"
                 }
             }
@@ -372,20 +370,28 @@ struct HeliumControlPanelView: View {
     }
 
     private func presentFallbackPreview() {
-        guard loadingVersionId == nil else { return }
+        guard activity == .idle else { return }
         guard HeliumFetchedConfigManager.shared.setFallbackPreviewTrigger() else {
             paywallLoadError = "No fallback paywall configured"
             return
         }
+        activity = .presentingPaywall
         HeliumLogger.log(.debug, category: .ui, "[HeliumControlPanel] Selected fallback paywall preview")
         HeliumPaywallPresenter.shared.presentUpsell(
             trigger: HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER,
-            presentationContext: PaywallPresentationContext(
-                config: PaywallPresentationConfig(dontShowIfAlreadyEntitled: false),
-                eventHandlers: nil,
-                onEntitled: nil,
-                onPaywallNotShown: nil
-            )
+            presentationContext: previewPresentationContext()
+        )
+    }
+
+    /// Context for presenting a preview from the panel. The activity lock is released only by an
+    /// actual presentation outcome, so both the opened and the not-shown signal must re-enable
+    /// the panel; every presenter path ends in exactly one of the two.
+    private func previewPresentationContext() -> PaywallPresentationContext {
+        PaywallPresentationContext(
+            config: PaywallPresentationConfig(dontShowIfAlreadyEntitled: false),
+            eventHandlers: PaywallEventHandlers().onOpen { _ in activity = .idle },
+            onEntitled: nil,
+            onPaywallNotShown: { _ in activity = .idle }
         )
     }
 }

--- a/Sources/Helium/HeliumCore/Diagnostic/Mapper/DiagnosticContentMapper.swift
+++ b/Sources/Helium/HeliumCore/Diagnostic/Mapper/DiagnosticContentMapper.swift
@@ -198,11 +198,14 @@ struct DiagnosticContentMapper {
         DiagnosticContent(
             category: .expected,
             title: "Previewing your fallback paywall",
-            body: "You opened this from the control panel, so Helium rendered the fallback "
-                + "paywall bundled with your app instead of fetching a remote one. Nothing "
-                + "about your live paywalls or triggers changed.",
-            usersWillSee: "Nothing. This preview is local to this device; real users only see "
-                + "this fallback when a live paywall cannot be fetched.",
+            body: "You asked the control panel to render the fallback paywall bundled with your "
+                + "app instead of fetching a remote one. Nothing about your live paywalls or "
+                + "triggers changed.",
+            // The outcome renders only when nothing was shown, so it describes a preview whose
+            // fallback failed to render.
+            usersWillSee: "The bundled fallback could not be rendered, so this preview showed "
+                + "nothing. Real users would hit the same failure whenever Helium needs this "
+                + "fallback.",
             usersWillSeeLink: nil,
             cta: .openUrl(label: "Fallback Docs", url: Url.fallbackGuide),
             reasonCode: code

--- a/Sources/Helium/HeliumCore/Diagnostic/Mapper/DiagnosticContentMapper.swift
+++ b/Sources/Helium/HeliumCore/Diagnostic/Mapper/DiagnosticContentMapper.swift
@@ -107,7 +107,9 @@ struct DiagnosticContentMapper {
         case .alreadyPresented:
             return alreadyPresented(code)
         case .forceShowFallback:
-            return forceShowFallback(code)
+            return context.trigger == HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER
+                ? fallbackPreview(code)
+                : forceShowFallback(code)
         }
     }
 
@@ -185,6 +187,24 @@ struct DiagnosticContentMapper {
             usersWillSee: "The bundled fallback could not be rendered, so this user saw nothing.",
             usersWillSeeLink: nil,
             cta: .openUrl(label: "View Docs", url: Url.quickstart),
+            reasonCode: code
+        )
+    }
+
+    /// forceShowFallback on the preview trigger means the developer asked the control panel to
+    /// render the bundled fallback, so the copy describes the preview rather than any trigger
+    /// configuration.
+    private func fallbackPreview(_ code: String) -> DiagnosticContent {
+        DiagnosticContent(
+            category: .expected,
+            title: "Previewing your fallback paywall",
+            body: "You opened this from the control panel, so Helium rendered the fallback "
+                + "paywall bundled with your app instead of fetching a remote one. Nothing "
+                + "about your live paywalls or triggers changed.",
+            usersWillSee: "Nothing. This preview is local to this device; real users only see "
+                + "this fallback when a live paywall cannot be fetched.",
+            usersWillSeeLink: nil,
+            cta: .openUrl(label: "Fallback Docs", url: Url.fallbackGuide),
             reasonCode: code
         )
     }

--- a/Sources/Helium/HeliumCore/HeliumFallbackViewManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumFallbackViewManager.swift
@@ -14,6 +14,12 @@ public class HeliumFallbackViewManager {
         shared.loadedConfig = nil
         shared.loadedConfigJSON = nil
     }
+
+    /// Inject fallback config for testing purposes only. Accessible via @testable import.
+    func injectFallbackConfigForTesting(_ config: HeliumFetchedConfig, json: JSON? = nil) {
+        loadedConfig = config
+        loadedConfigJSON = json
+    }
     
     // **MARK: - Properties**
     private let defaultFallbacksName = "helium-fallbacks"

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -992,7 +992,12 @@ public class HeliumFetchedConfigManager {
     }
     
     public func getProductIDsForTrigger(_ trigger: String) -> [String]? {
-        fetchedConfig?.triggerToPaywalls[trigger]?.productIds
+        // While a fallback preview is armed, the paywall under the preview trigger is the
+        // bundled fallback entry, which only the fallback manager knows about.
+        if trigger == Self.HELIUM_PREVIEW_TRIGGER, isFallbackPreviewArmed {
+            return HeliumFallbackViewManager.shared.getFallbackInfo(trigger: trigger)?.productIds
+        }
+        return fetchedConfig?.triggerToPaywalls[trigger]?.productIds
     }
     
     public func getFetchedTriggerNames() -> [String] {
@@ -1032,8 +1037,8 @@ public class HeliumFetchedConfigManager {
     /// network. Returns false when no default fallback is configured.
     func setFallbackPreviewTrigger() -> Bool {
         guard hasConfiguredFallbackPreview() else { return false }
-        // An entry left by an earlier paywall version preview would otherwise feed this
-        // trigger's analytics enrichment and injected prices while the fallback renders.
+        // An entry left by an earlier paywall version preview would otherwise feed its
+        // experiment and model IDs into this trigger's analytics while the fallback renders.
         _fetchedConfig.withValue {
             $0?.triggerToPaywalls.removeValue(forKey: Self.HELIUM_PREVIEW_TRIGGER)
         }

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -1026,10 +1026,12 @@ public class HeliumFetchedConfigManager {
     static let HELIUM_PREVIEW_TRIGGER = "helium_preview_trigger"
 
     /// True when a bundled default fallback paywall is available to preview on this device.
+    /// Requires the same resolvable bundle path presentation requires, so a default entry that
+    /// exists but cannot render never offers a preview.
     func hasConfiguredFallbackPreview() -> Bool {
         HeliumFallbackViewManager.shared.getFallbackInfo(
             trigger: HeliumFallbackViewManager.defaultFallbackTrigger
-        ) != nil
+        )?.localBundlePath != nil
     }
 
     /// Arms the preview trigger to render the bundled default fallback. The fallback bundle and
@@ -1037,10 +1039,16 @@ public class HeliumFetchedConfigManager {
     /// network. Returns false when no default fallback is configured.
     func setFallbackPreviewTrigger() -> Bool {
         guard hasConfiguredFallbackPreview() else { return false }
-        // An entry left by an earlier paywall version preview would otherwise feed its
-        // experiment and model IDs into this trigger's analytics while the fallback renders.
+        // An entry left by an earlier paywall version preview would feed its experiment and
+        // model IDs into this trigger's analytics while the fallback renders, so drop it from
+        // the typed config and keep the JSON mirror agreeing that no entry exists.
         _fetchedConfig.withValue {
             $0?.triggerToPaywalls.removeValue(forKey: Self.HELIUM_PREVIEW_TRIGGER)
+        }
+        _fetchedConfigJSON.withValue { json in
+            guard var triggers = json?["triggerToPaywalls"].dictionaryObject,
+                  triggers.removeValue(forKey: Self.HELIUM_PREVIEW_TRIGGER) != nil else { return }
+            json?["triggerToPaywalls"].dictionaryObject = triggers
         }
         isFallbackPreviewArmed = true
         return true

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -211,6 +211,7 @@ public class HeliumFetchedConfigManager {
         shared.fetchedConfigJSON = nil
         shared.triggersWithSkippedBundleAndReason = []
         shared.localizedPriceMap = [:]
+        shared.isFallbackPreviewArmed = false
     }
 
     /// Inject config for testing purposes only. Accessible via @testable import.
@@ -235,6 +236,7 @@ public class HeliumFetchedConfigManager {
     @HeliumAtomic private(set) var fetchedConfigJSON: JSON?
     @HeliumAtomic private(set) var triggersWithSkippedBundleAndReason: [(trigger: String, reason: PaywallUnavailableReason)] = []
     @HeliumAtomic private var localizedPriceMap: [String: LocalizedPrice] = [:]
+    @HeliumAtomic private(set) var isFallbackPreviewArmed: Bool = false
     
     func fetchConfig(
         endpoint: String,
@@ -1018,6 +1020,27 @@ public class HeliumFetchedConfigManager {
 
     static let HELIUM_PREVIEW_TRIGGER = "helium_preview_trigger"
 
+    /// True when a bundled default fallback paywall is available to preview on this device.
+    func hasConfiguredFallbackPreview() -> Bool {
+        HeliumFallbackViewManager.shared.getFallbackInfo(
+            trigger: HeliumFallbackViewManager.defaultFallbackTrigger
+        ) != nil
+    }
+
+    /// Arms the preview trigger to render the bundled default fallback. The fallback bundle and
+    /// its resolved config are loaded at initialize, so arming needs no fetched config or
+    /// network. Returns false when no default fallback is configured.
+    func setFallbackPreviewTrigger() -> Bool {
+        guard hasConfiguredFallbackPreview() else { return false }
+        // An entry left by an earlier paywall version preview would otherwise feed this
+        // trigger's analytics enrichment and injected prices while the fallback renders.
+        _fetchedConfig.withValue {
+            $0?.triggerToPaywalls.removeValue(forKey: Self.HELIUM_PREVIEW_TRIGGER)
+        }
+        isFallbackPreviewArmed = true
+        return true
+    }
+
     /// Sets up a preview trigger configuration for the control panel.
     /// Clones an existing trigger's config and updates it to use the specified bundle.
     func setPreviewTriggerConfig(
@@ -1057,6 +1080,8 @@ public class HeliumFetchedConfigManager {
             guard let configJSON = json else { return }
             json = Self.withPreviewTrigger(configJSON, clonedFrom: sourceTrigger, bundleUrl: bundleUrl)
         }
+
+        isFallbackPreviewArmed = false
     }
 
     /// Returns the trigger the preview was cloned from: the JSON mirror has to clone the same

--- a/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
+++ b/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
@@ -556,7 +556,17 @@ extension HeliumPaywallPresenter {
             HeliumLogger.log(.warn, category: .core, "Helium not initialized when presenting paywall")
             return PaywallViewResult(viewAndSession: nil, fallbackReason: .notInitialized)
         }
-        
+
+        // The control panel arms this to preview the bundled default fallback. Resolution reads
+        // only the fallback manager, never the fetched config, so the preview works offline and
+        // before any config download completes. A developer forcing the fallback render gets
+        // forceShowFallback, and with it the same banner, diagnostic copy, and analytics
+        // labeling as a trigger configured to force its fallback.
+        if trigger == HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER,
+           HeliumFetchedConfigManager.shared.isFallbackPreviewArmed {
+            return fallbackBundleViewFor(trigger: trigger, fallbackReason: .forceShowFallback, presentationContext: presentationContext)
+        }
+
         let paywallInfo = HeliumFetchedConfigManager.shared.getPaywallInfoForTrigger(trigger)
         if Helium.shared.paywallsLoaded() {
             guard let templatePaywallInfo = paywallInfo else {
@@ -637,12 +647,15 @@ extension HeliumPaywallPresenter {
     
     private func fallbackViewFor(trigger: String, paywallInfo: HeliumPaywallInfo?, fallbackReason: PaywallUnavailableReason, presentationContext: PaywallPresentationContext) -> PaywallViewResult {
         
-        // Do not show fallback for a paywall preview
+        // A failed preview must surface its failure, never silently render a fallback in its place.
         if trigger == HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER {
             return PaywallViewResult(viewAndSession: nil, fallbackReason: fallbackReason)
         }
-        
-        // Check existing fallback mechanisms
+
+        return fallbackBundleViewFor(trigger: trigger, fallbackReason: fallbackReason, presentationContext: presentationContext)
+    }
+
+    private func fallbackBundleViewFor(trigger: String, fallbackReason: PaywallUnavailableReason, presentationContext: PaywallPresentationContext) -> PaywallViewResult {
         if let fallbackPaywallInfo = HeliumFallbackViewManager.shared.getFallbackInfo(trigger: trigger),
            let filePath = fallbackPaywallInfo.localBundlePath {
             do {

--- a/Tests/helium-swiftTests/DiagnosticContentMapperTests.swift
+++ b/Tests/helium-swiftTests/DiagnosticContentMapperTests.swift
@@ -15,12 +15,21 @@ final class DiagnosticContentMapperTests: XCTestCase {
         mapper.mapUnavailable(reason, context: context())
     }
 
+    /// The forceShowFallback record branches on the trigger, so the preview variant is its own
+    /// authored record and must be covered by the matrix invariants like any other.
+    private func previewFallbackContent() -> DiagnosticContent {
+        mapper.mapUnavailable(
+            .forceShowFallback,
+            context: DiagnosticContext(trigger: HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER)
+        )
+    }
+
     /// Every authored record: both skip reasons, every unavailable reason, the nil path, and the
-    /// preview-only second try record.
+    /// preview-only records (second try, fallback preview).
     private func allContent() -> [DiagnosticContent] {
         PaywallSkippedReason.allCases.map { mapper.mapSkip($0) }
             + PaywallUnavailableReason.allCases.map { content(for: $0) }
-            + [content(for: nil), mapper.mapSecondTryInPreview()]
+            + [content(for: nil), mapper.mapSecondTryInPreview(), previewFallbackContent()]
     }
 
     // MARK: - Forward compat: no raw codes leak into displayed prose
@@ -205,6 +214,22 @@ final class DiagnosticContentMapperTests: XCTestCase {
         XCTAssertEqual(content.title, "Fallback paywall forced for this trigger")
         XCTAssertTrue(content.body.contains("configured to force the bundled fallback"))
         XCTAssertTrue(content.usersWillSee.contains("could not be rendered"))
+    }
+
+    /// On the preview trigger, forceShowFallback is the developer's own control panel tap, so
+    /// the copy describes the preview and reassures that nothing about live config changed.
+    func testPreviewTriggerForceShowFallbackDescribesThePreview() {
+        let content = previewFallbackContent()
+
+        XCTAssertEqual(content.category, .expected)
+        XCTAssertEqual(content.title, "Previewing your fallback paywall")
+        XCTAssertTrue(content.body.contains("You opened this from the control panel"))
+        XCTAssertTrue(content.usersWillSee.contains("local to this device"))
+        XCTAssertEqual(
+            content.cta,
+            .openUrl(label: "Fallback Docs", url: fallbackGuideUrl)
+        )
+        XCTAssertEqual(content.reasonCode, "forceShowFallback")
     }
 
     // MARK: - Context enrichment

--- a/Tests/helium-swiftTests/DiagnosticContentMapperTests.swift
+++ b/Tests/helium-swiftTests/DiagnosticContentMapperTests.swift
@@ -216,15 +216,18 @@ final class DiagnosticContentMapperTests: XCTestCase {
         XCTAssertTrue(content.usersWillSee.contains("could not be rendered"))
     }
 
-    /// On the preview trigger, forceShowFallback is the developer's own control panel tap, so
-    /// the copy describes the preview and reassures that nothing about live config changed.
+    /// On the preview trigger, forceShowFallback is the developer's own control panel tap. The
+    /// body states only the cause, so it stays true when the preview fails to render, and the
+    /// outcome line the modal shows in that failure describes the failed render.
     func testPreviewTriggerForceShowFallbackDescribesThePreview() {
         let content = previewFallbackContent()
 
         XCTAssertEqual(content.category, .expected)
         XCTAssertEqual(content.title, "Previewing your fallback paywall")
-        XCTAssertTrue(content.body.contains("You opened this from the control panel"))
-        XCTAssertTrue(content.usersWillSee.contains("local to this device"))
+        XCTAssertTrue(content.body.contains("asked the control panel to render"))
+        XCTAssertFalse(content.body.contains("rendered the fallback"), "body must not claim an outcome")
+        XCTAssertTrue(content.usersWillSee.contains("could not be rendered"))
+        XCTAssertTrue(content.usersWillSee.contains("Real users would hit the same failure"))
         XCTAssertEqual(
             content.cta,
             .openUrl(label: "Fallback Docs", url: fallbackGuideUrl)

--- a/Tests/helium-swiftTests/FallbackPreviewTests.swift
+++ b/Tests/helium-swiftTests/FallbackPreviewTests.swift
@@ -135,6 +135,24 @@ final class FallbackPreviewTests: XCTestCase {
         XCTAssertEqual(result.viewAndSession?.paywallSession.fallbackType, .fallbackBundle)
     }
 
+    /// The webview's injected context and price map resolve products by trigger name, and no
+    /// fetched-config entry exists under the preview trigger while armed, so the lookup must
+    /// serve the fallback entry's own products.
+    func testArmedPreviewServesFallbackProductContext() throws {
+        try injectFallbackConfig()
+        XCTAssertTrue(HeliumFetchedConfigManager.shared.setFallbackPreviewTrigger())
+
+        XCTAssertEqual(
+            HeliumFetchedConfigManager.shared.getProductIDsForTrigger(previewTrigger),
+            ["fallback.product"]
+        )
+        let context = createHeliumContext(triggerName: previewTrigger)
+        XCTAssertEqual(
+            context["products"]["productIds"].arrayValue.map(\.stringValue),
+            ["fallback.product"]
+        )
+    }
+
     // MARK: - Mutual exclusion with dashboard previews
 
     func testDashboardPreviewDisarmsFallbackPreview() throws {
@@ -144,6 +162,10 @@ final class FallbackPreviewTests: XCTestCase {
         try installDashboardPreview()
 
         XCTAssertFalse(HeliumFetchedConfigManager.shared.isFallbackPreviewArmed)
+        XCTAssertEqual(
+            HeliumFetchedConfigManager.shared.getProductIDsForTrigger(previewTrigger),
+            ["preview.product"]
+        )
     }
 
     func testFallbackPreviewArmWinsOverEarlierDashboardPreview() throws {
@@ -155,6 +177,10 @@ final class FallbackPreviewTests: XCTestCase {
         XCTAssertTrue(HeliumFetchedConfigManager.shared.setFallbackPreviewTrigger())
 
         XCTAssertNil(HeliumFetchedConfigManager.shared.fetchedConfig?.triggerToPaywalls[previewTrigger])
+        XCTAssertEqual(
+            HeliumFetchedConfigManager.shared.getProductIDsForTrigger(previewTrigger),
+            ["fallback.product"]
+        )
         let result = upsellResult(trigger: previewTrigger)
         XCTAssertEqual(result.fallbackReason, .forceShowFallback)
         XCTAssertEqual(result.viewAndSession?.paywallSession.fallbackType, .fallbackBundle)

--- a/Tests/helium-swiftTests/FallbackPreviewTests.swift
+++ b/Tests/helium-swiftTests/FallbackPreviewTests.swift
@@ -1,0 +1,185 @@
+import XCTest
+@testable import Helium
+
+/// Tests for previewing the bundled default fallback paywall from the control panel:
+/// `setFallbackPreviewTrigger` arms the preview trigger to render the fallback, independent
+/// of any fetched config.
+final class FallbackPreviewTests: XCTestCase {
+
+    private let previewTrigger = HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER
+    private let fallbackBundleUrl = "https://cdn.example.com/bundles/bundle_flbk123.html"
+
+    override func setUp() {
+        super.setUp()
+        HeliumAnalyticsManager.shared.disableAnalyticsForTesting()
+        Helium.resetHelium()
+    }
+
+    override func tearDown() {
+        Helium.resetHelium()
+        super.tearDown()
+    }
+
+    private func makeFallbackEntry() -> HeliumPaywallInfo {
+        var info = makeTestPaywallInfo(paywallName: "default_fallback_paywall", products: ["fallback.product"])
+        info.resolvedConfig = AnyCodable([
+            "baseStack": [
+                "componentProps": [
+                    "bundleURL": fallbackBundleUrl
+                ]
+            ]
+        ] as [String: Any])
+        return info
+    }
+
+    /// Loads a renderable default fallback entry into the fallback manager, including the JSON
+    /// mirror that resolution and rendering read for `resolvedConfig`.
+    @discardableResult
+    private func injectFallbackConfig() throws -> HeliumPaywallInfo {
+        let entry = makeFallbackEntry()
+        let config = makeTestConfig(
+            triggers: [HeliumFallbackViewManager.defaultFallbackTrigger: entry],
+            bundles: ["flbk123": "<html>fallback</html>"]
+        )
+        let json = try JSON(data: JSONEncoder().encode(config))
+        HeliumFallbackViewManager.shared.injectFallbackConfigForTesting(config, json: json)
+        return entry
+    }
+
+    private func installDashboardPreview() throws {
+        var donor = makeTestPaywallInfo(paywallName: "donor_paywall", products: ["donor.product"])
+        donor.resolvedConfig = AnyCodable([
+            "baseStack": [
+                "componentProps": [
+                    "bundleURL": "https://cdn.example.com/bundles/bundle_donor123.html"
+                ]
+            ]
+        ] as [String: Any])
+        injectConfig(makeTestConfig(triggers: ["a_trigger": donor]))
+
+        try HeliumFetchedConfigManager.shared.setPreviewTriggerConfig(
+            bundleId: "preview456",
+            bundleUrl: "https://cdn.example.com/bundles/bundle_preview456.html",
+            bundleHtml: "<html>preview</html>",
+            productIds: ["preview.product"],
+            productIdsStripe: [],
+            productIdsPaddle: [],
+            productIdsPaddleWeb: [],
+            productIdsStripeWeb: []
+        )
+    }
+
+    private func upsellResult(trigger: String) -> PaywallViewResult {
+        HeliumPaywallPresenter.shared.upsellViewResultFor(
+            trigger: trigger,
+            presentationContext: PaywallPresentationContext.empty
+        )
+    }
+
+    // MARK: - Arming
+
+    func testSetFallbackPreviewTriggerArmsWhenFallbackConfigured() throws {
+        try injectFallbackConfig()
+
+        XCTAssertTrue(HeliumFetchedConfigManager.shared.hasConfiguredFallbackPreview())
+        XCTAssertTrue(HeliumFetchedConfigManager.shared.setFallbackPreviewTrigger())
+        XCTAssertTrue(HeliumFetchedConfigManager.shared.isFallbackPreviewArmed)
+    }
+
+    func testSetFallbackPreviewTriggerReturnsFalseWithNoFallbackLoaded() {
+        XCTAssertFalse(HeliumFetchedConfigManager.shared.hasConfiguredFallbackPreview())
+        XCTAssertFalse(HeliumFetchedConfigManager.shared.setFallbackPreviewTrigger())
+        XCTAssertFalse(HeliumFetchedConfigManager.shared.isFallbackPreviewArmed)
+    }
+
+    // MARK: - Resolution
+
+    /// The core offline guarantee: an armed fallback preview renders with no fetched config at
+    /// all, serving the default fallback entry's own bundle under the preview trigger.
+    func testFallbackPreviewRendersWithNilFetchedConfig() throws {
+        Helium.shared.markInitializedForTesting()
+        let entry = try injectFallbackConfig()
+        XCTAssertTrue(HeliumFetchedConfigManager.shared.setFallbackPreviewTrigger())
+        XCTAssertNil(HeliumFetchedConfigManager.shared.fetchedConfig)
+
+        let result = upsellResult(trigger: previewTrigger)
+
+        XCTAssertNotNil(result.viewAndSession)
+        XCTAssertEqual(result.fallbackReason, .forceShowFallback)
+        let session = result.viewAndSession?.paywallSession
+        XCTAssertEqual(session?.trigger, previewTrigger)
+        XCTAssertEqual(session?.fallbackType, .fallbackBundle)
+        XCTAssertEqual(session?.paywallInfoWithBackups?.paywallTemplateName, entry.paywallTemplateName)
+    }
+
+    func testUnarmedPreviewTriggerNeverRendersTheFallback() throws {
+        Helium.shared.markInitializedForTesting()
+        try injectFallbackConfig()
+
+        let result = upsellResult(trigger: previewTrigger)
+
+        XCTAssertNil(result.viewAndSession)
+        XCTAssertEqual(result.fallbackReason, .paywallsNotDownloaded)
+    }
+
+    /// A real trigger served by the fallback keeps its own unavailable reason; only the armed
+    /// preview is labeled forceShowFallback.
+    func testRealTriggerFallbackIsNotLabeledForceShowFallback() throws {
+        Helium.shared.markInitializedForTesting()
+        try injectFallbackConfig()
+
+        let result = upsellResult(trigger: "real_trigger")
+
+        XCTAssertNotNil(result.viewAndSession)
+        XCTAssertEqual(result.fallbackReason, .paywallsNotDownloaded)
+        XCTAssertEqual(result.viewAndSession?.paywallSession.fallbackType, .fallbackBundle)
+    }
+
+    // MARK: - Mutual exclusion with dashboard previews
+
+    func testDashboardPreviewDisarmsFallbackPreview() throws {
+        try injectFallbackConfig()
+        XCTAssertTrue(HeliumFetchedConfigManager.shared.setFallbackPreviewTrigger())
+
+        try installDashboardPreview()
+
+        XCTAssertFalse(HeliumFetchedConfigManager.shared.isFallbackPreviewArmed)
+    }
+
+    func testFallbackPreviewArmWinsOverEarlierDashboardPreview() throws {
+        Helium.shared.markInitializedForTesting()
+        try injectFallbackConfig()
+        try installDashboardPreview()
+        XCTAssertNotNil(HeliumFetchedConfigManager.shared.fetchedConfig?.triggerToPaywalls[previewTrigger])
+
+        XCTAssertTrue(HeliumFetchedConfigManager.shared.setFallbackPreviewTrigger())
+
+        XCTAssertNil(HeliumFetchedConfigManager.shared.fetchedConfig?.triggerToPaywalls[previewTrigger])
+        let result = upsellResult(trigger: previewTrigger)
+        XCTAssertEqual(result.fallbackReason, .forceShowFallback)
+        XCTAssertEqual(result.viewAndSession?.paywallSession.fallbackType, .fallbackBundle)
+    }
+
+    func testResetClearsFallbackPreviewArm() throws {
+        try injectFallbackConfig()
+        XCTAssertTrue(HeliumFetchedConfigManager.shared.setFallbackPreviewTrigger())
+
+        HeliumFetchedConfigManager.reset()
+
+        XCTAssertFalse(HeliumFetchedConfigManager.shared.isFallbackPreviewArmed)
+    }
+
+    // MARK: - Wire format parity with Android
+
+    func testForceShowFallbackWireFormat() {
+        XCTAssertEqual(PaywallUnavailableReason.forceShowFallback.rawValue, "forceShowFallback")
+
+        let event = PaywallOpenEvent(
+            triggerName: previewTrigger,
+            paywallName: "default_fallback_paywall",
+            viewType: .presented,
+            paywallUnavailableReason: .forceShowFallback
+        )
+        XCTAssertEqual(event.toDictionary()["paywallUnavailableReason"] as? String, "forceShowFallback")
+    }
+}

--- a/Tests/helium-swiftTests/FallbackPreviewTests.swift
+++ b/Tests/helium-swiftTests/FallbackPreviewTests.swift
@@ -55,7 +55,8 @@ final class FallbackPreviewTests: XCTestCase {
                 ]
             ]
         ] as [String: Any])
-        injectConfig(makeTestConfig(triggers: ["a_trigger": donor]))
+        let config = makeTestConfig(triggers: ["a_trigger": donor])
+        injectConfig(config, json: try JSON(data: JSONEncoder().encode(config)))
 
         try HeliumFetchedConfigManager.shared.setPreviewTriggerConfig(
             bundleId: "preview456",
@@ -87,6 +88,26 @@ final class FallbackPreviewTests: XCTestCase {
     }
 
     func testSetFallbackPreviewTriggerReturnsFalseWithNoFallbackLoaded() {
+        XCTAssertFalse(HeliumFetchedConfigManager.shared.hasConfiguredFallbackPreview())
+        XCTAssertFalse(HeliumFetchedConfigManager.shared.setFallbackPreviewTrigger())
+        XCTAssertFalse(HeliumFetchedConfigManager.shared.isFallbackPreviewArmed)
+    }
+
+    /// A default entry can exist while missing the bundle URL presentation resolves its local
+    /// file from; such an entry must not offer a preview it cannot render.
+    func testFallbackEntryWithoutBundlePathIsNotPreviewable() {
+        let entryWithoutBundleUrl = makeTestPaywallInfo(
+            paywallName: "default_fallback_paywall",
+            products: ["fallback.product"]
+        )
+        let config = makeTestConfig(
+            triggers: [HeliumFallbackViewManager.defaultFallbackTrigger: entryWithoutBundleUrl]
+        )
+        HeliumFallbackViewManager.shared.injectFallbackConfigForTesting(config)
+
+        XCTAssertNil(HeliumFallbackViewManager.shared.getFallbackInfo(
+            trigger: HeliumFallbackViewManager.defaultFallbackTrigger
+        )?.localBundlePath)
         XCTAssertFalse(HeliumFetchedConfigManager.shared.hasConfiguredFallbackPreview())
         XCTAssertFalse(HeliumFetchedConfigManager.shared.setFallbackPreviewTrigger())
         XCTAssertFalse(HeliumFetchedConfigManager.shared.isFallbackPreviewArmed)
@@ -177,6 +198,47 @@ final class FallbackPreviewTests: XCTestCase {
         XCTAssertTrue(HeliumFetchedConfigManager.shared.setFallbackPreviewTrigger())
 
         XCTAssertNil(HeliumFetchedConfigManager.shared.fetchedConfig?.triggerToPaywalls[previewTrigger])
+        XCTAssertEqual(
+            HeliumFetchedConfigManager.shared.getProductIDsForTrigger(previewTrigger),
+            ["fallback.product"]
+        )
+        let result = upsellResult(trigger: previewTrigger)
+        XCTAssertEqual(result.fallbackReason, .forceShowFallback)
+        XCTAssertEqual(result.viewAndSession?.paywallSession.fallbackType, .fallbackBundle)
+    }
+
+    /// Arming must leave no trace of a dashboard preview in either config store: the typed
+    /// entry feeds analytics enrichment, and the JSON mirror serves resolved-config readers,
+    /// so the two must agree that no entry exists under the preview trigger.
+    func testArmingClearsDashboardPreviewFromBothConfigStores() throws {
+        try injectFallbackConfig()
+        try installDashboardPreview()
+        XCTAssertEqual(
+            HeliumFetchedConfigManager.shared.getResolvedConfigJSONForTrigger(previewTrigger)?.exists(),
+            true
+        )
+
+        XCTAssertTrue(HeliumFetchedConfigManager.shared.setFallbackPreviewTrigger())
+
+        XCTAssertNil(HeliumFetchedConfigManager.shared.fetchedConfig?.triggerToPaywalls[previewTrigger])
+        XCTAssertNotEqual(
+            HeliumFetchedConfigManager.shared.getResolvedConfigJSONForTrigger(previewTrigger)?.exists(),
+            true
+        )
+    }
+
+    /// A config fetch landing after arming replaces both stores wholesale, and server responses
+    /// never contain the internal preview trigger; the armed preview must render the fallback
+    /// exactly as before the fetch.
+    func testConfigFetchAfterArmKeepsFallbackPreviewIntact() throws {
+        Helium.shared.markInitializedForTesting()
+        try injectFallbackConfig()
+        XCTAssertTrue(HeliumFetchedConfigManager.shared.setFallbackPreviewTrigger())
+
+        let freshConfig = makeTestConfig(triggers: ["a_trigger": makeTestPaywallInfo(paywallName: "fresh_paywall")])
+        injectConfig(freshConfig, json: try JSON(data: JSONEncoder().encode(freshConfig)))
+
+        XCTAssertTrue(HeliumFetchedConfigManager.shared.isFallbackPreviewArmed)
         XCTAssertEqual(
             HeliumFetchedConfigManager.shared.getProductIDsForTrigger(previewTrigger),
             ["fallback.product"]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches paywall presentation, preview-trigger config, and fallback resolution paths used only in debug/control-panel flows, but incorrect locking or arming could affect preview reliability or analytics on the internal preview trigger.
> 
> **Overview**
> Adds a **Default Fallback Paywall** card at the top of the paywall previews control panel so developers can tap to preview the app-bundled fallback on device (with docs link when none is configured).
> 
> Preview launching is coordinated through **`HeliumControlPanelActivity`** (replacing per-row `loadingVersionId`): taps stay disabled from bundle download through presentation close or paywall-not-shown, avoiding stacked previews or conflicting preview-trigger config writes.
> 
> **`setFallbackPreviewTrigger()`** arms an internal preview trigger to resolve the default fallback via `HeliumFallbackViewManager` (works offline / without fetched config), clears any dashboard preview entry from typed + JSON config, and **`getProductIDsForTrigger`** serves fallback products while armed. Dashboard version previews disarm this path and vice versa.
> 
> **`HeliumPaywallPresenter`** routes the armed preview through the fallback bundle with `forceShowFallback` labeling; other failed preview triggers still surface failure instead of substituting a fallback. Diagnostics use preview-specific copy for that case on the preview trigger.
> 
> Tests cover arming, rendering, mutual exclusion, and diagnostic mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ee31e17c003db40c0cd4a0f8deb1e2df76883f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a control-panel “Tap to preview” option for the configured fallback paywall, including preview load/progress handling.
  * Improved fallback preview states (loading, error, and guidance when no fallback is available).
  * Added preview-specific diagnostics and CTA deep-linking to fallback setup guidance.
* **Bug Fixes**
  * Ensured dashboard and fallback previews are mutually exclusive, with safe state reset and clearer preview failure behavior.
* **Tests**
  * Expanded diagnostic mapping and added a dedicated fallback preview test suite covering arming, rendering, selection, and state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->