### PR TITLE
[HEL-6233] | Open web paywall previews in browser from control panel

### DIFF
--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
@@ -8,8 +8,12 @@ struct HeliumControlPanelResponse: Codable {
 struct HeliumPaywallPreviewEntry: Codable, Identifiable {
     let paywallUuid: String
     let paywallName: String
+    let isWeb: Bool?
     let versions: [HeliumPaywallPreviewVersion]
     var id: String { paywallUuid }
+
+    /// Web paywalls render in a browser, not in-app; previews open them there.
+    var isWebPaywall: Bool { isWeb == true }
 }
 
 struct HeliumPaywallPreviewVersion: Codable, Identifiable {

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
@@ -8,6 +8,7 @@ struct HeliumControlPanelView: View {
     @State private var previewTask: Task<Void, Never>?
     @State private var searchText: String = ""
     @State private var paywallLoadError: String? = nil
+    @State private var pendingWebPreviewURL: URL? = nil
 
     var body: some View {
         NavigationView {
@@ -92,6 +93,20 @@ struct HeliumControlPanelView: View {
         } message: {
             Text(paywallLoadError ?? "")
         }
+        .alert("Open Web Paywall?", isPresented: Binding(
+            get: { pendingWebPreviewURL != nil },
+            set: { if !$0 { pendingWebPreviewURL = nil } }
+        )) {
+            Button("Cancel", role: .cancel) { }
+            Button("Open in Browser") {
+                if let url = pendingWebPreviewURL {
+                    UIApplication.shared.open(url)
+                }
+                pendingWebPreviewURL = nil
+            }
+        } message: {
+            Text("Web paywalls open in your default browser for a display-only preview. Purchases won't work from this preview.")
+        }
         .onAppear {
             fetchTask = Task { await fetchPaywalls() }
         }
@@ -129,13 +144,23 @@ struct HeliumControlPanelView: View {
             // Right side: header + version rows
             VStack(alignment: .leading, spacing: 0) {
                 // Paywall name header
-                Text(paywall.paywallName)
-                    .font(.system(.headline, design: .rounded))
-                    .foregroundColor(.primary)
-                    .lineLimit(1)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 14)
+                HStack(spacing: 6) {
+                    Text(paywall.paywallName)
+                        .font(.system(.headline, design: .rounded))
+                        .foregroundColor(.primary)
+                        .lineLimit(1)
+                    if paywall.isWebPaywall {
+                        Text("Web")
+                            .font(.caption2.weight(.semibold))
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Capsule().fill(Color(UIColor.tertiarySystemFill)))
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 14)
                 
                 Rectangle()
                     .fill(Color.gray.opacity(0.5))
@@ -175,7 +200,7 @@ struct HeliumControlPanelView: View {
                         if isLoading {
                             ProgressView()
                         } else if version.bundleUrl != nil {
-                            Image(systemName: "magnifyingglass")
+                            Image(systemName: paywall.isWebPaywall ? "safari" : "magnifyingglass")
                                 .font(.subheadline)
                                 .foregroundColor(.accentColor)
                         }
@@ -242,6 +267,16 @@ struct HeliumControlPanelView: View {
     private func selectVersion(_ version: HeliumPaywallPreviewVersion, paywall: HeliumPaywallPreviewEntry) {
         guard loadingVersionId == nil else { return }
         guard let bundleUrl = version.bundleUrl else { return }
+
+        // Web paywalls aren't renderable in-app — preview them in the browser
+        // after the user confirms, since payments won't work from a preview.
+        if paywall.isWebPaywall {
+            guard let url = URL(string: bundleUrl) else { return }
+            HeliumLogger.log(.debug, category: .ui, "[HeliumControlPanel] Selected web paywall: \(paywall.paywallName) version: \(version.versionId)")
+            pendingWebPreviewURL = url
+            return
+        }
+
         loadingVersionId = version.id
         HeliumLogger.log(.debug, category: .ui, "[HeliumControlPanel] Selected paywall: \(paywall.paywallName) version: \(version.versionId)")
 

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
@@ -96,15 +96,16 @@ struct HeliumControlPanelView: View {
         .alert("Open Web Paywall?", isPresented: Binding(
             get: { pendingWebPreviewURL != nil },
             set: { if !$0 { pendingWebPreviewURL = nil } }
-        )) {
+        ), presenting: pendingWebPreviewURL) { url in
             Button("Cancel", role: .cancel) { }
             Button("Open in Browser") {
-                if let url = pendingWebPreviewURL {
-                    UIApplication.shared.open(url)
+                UIApplication.shared.open(url, options: [:]) { opened in
+                    if !opened {
+                        paywallLoadError = "Failed to open web preview."
+                    }
                 }
-                pendingWebPreviewURL = nil
             }
-        } message: {
+        } message: { _ in
             Text("Web paywalls open in your default browser for a display-only preview. Purchases won't work from this preview.")
         }
         .onAppear {
@@ -271,7 +272,11 @@ struct HeliumControlPanelView: View {
         // Web paywalls aren't renderable in-app — preview them in the browser
         // after the user confirms, since payments won't work from a preview.
         if paywall.isWebPaywall {
-            guard let url = URL(string: bundleUrl) else { return }
+            guard HeliumFetchedConfigManager.shared.isValidURL(bundleUrl),
+                  let url = URL(string: bundleUrl) else {
+                paywallLoadError = "Invalid web paywall URL."
+                return
+            }
             HeliumLogger.log(.debug, category: .ui, "[HeliumControlPanel] Selected web paywall: \(paywall.paywallName) version: \(version.versionId)")
             pendingWebPreviewURL = url
             return

--- a/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
+++ b/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
@@ -297,5 +297,53 @@ final class PreviewTriggerConfigTests: XCTestCase {
 
         XCTAssertNil(response.paywalls[0].versions[0].webPaywallBundleUrl)
         XCTAssertNil(response.paywalls[0].versions[0].paddleProductIds)
+        XCTAssertFalse(response.paywalls[0].isWebPaywall)
+    }
+
+    func testDecodesWebPaywallEntry() throws {
+        let json = """
+        {
+          "productIds": [],
+          "paywalls": [
+            {
+              "paywallUuid": "0b7f5c1a-1111-4222-8333-444455556666",
+              "paywallName": "Web Checkout Paywall",
+              "isWeb": true,
+              "versions": [
+                {
+                  "versionId": "9d8c7b6a-aaaa-4bbb-8ccc-dddeeefff000",
+                  "versionStatus": "published",
+                  "versionNumber": 3,
+                  "bundleUrl": "https://bundles-staging.clickthrough.to/x/bundle_1778610753360.html",
+                  "previewUrl": null,
+                  "productIds": [],
+                  "stripeProductIds": [],
+                  "paddleProductIds": ["pro_web:pri_web"],
+                  "webPaddleProductIds": [],
+                  "webPaywallBundleUrl": null,
+                  "lastSavedAt": null
+                }
+              ]
+            },
+            {
+              "paywallUuid": "1c8d6e2b-7777-4888-9999-000011112222",
+              "paywallName": "Native Paywall",
+              "isWeb": false,
+              "versions": []
+            }
+          ]
+        }
+        """
+        let response = try JSONDecoder().decode(
+            HeliumControlPanelResponse.self,
+            from: Data(json.utf8)
+        )
+
+        XCTAssertTrue(response.paywalls[0].isWebPaywall)
+        XCTAssertEqual(
+            response.paywalls[0].versions[0].bundleUrl,
+            "https://bundles-staging.clickthrough.to/x/bundle_1778610753360.html"
+        )
+        XCTAssertFalse(response.paywalls[1].isWebPaywall)
     }
 }


### PR DESCRIPTION
## What

Web paywalls in the paywall previews list (triple-tap control panel) now open in the default browser instead of attempting to render in-app. They're marked with a "Web" badge and a Safari icon, and tapping one shows a dialog explaining it's a display-only preview where purchases won't work.

## Why

Web paywalls can't render in the app's paywall view — their bundle is a web page meant for the browser. The previews list had no way to tell web paywalls apart from native ones, so they either previewed broken or couldn't be previewed at all. Per discussion on the ticket, the direction is to keep them in the list but open them in the browser for an authentic display preview (wiring up a real checkout ctx so purchases work is a follow-up).

## Fix

- Added optional `isWeb` to `HeliumPaywallPreviewEntry`. A missing field decodes as native, so older server responses behave exactly as before.
- Web entries show a "Web" badge next to the paywall name and a Safari icon on tappable version rows.
- Tapping a web version shows a confirmation alert, then opens the version's `bundleUrl` in the default browser. Native paywalls keep the existing in-app preview flow.

Depends on the `/paywall-previews` endpoint adding `isWeb` to each paywall entry (bandit-server-lite-phoenix already reads `is_web` from the DB but doesn't surface it in the response). Until that ships, this change is a safe no-op.

## Tests

- New `testDecodesWebPaywallEntry` covering `isWeb: true/false` decoding, plus an assertion that the legacy response shape (no `isWeb`) decodes as non-web.
- Full unit suite passes locally: 325 tests, 0 failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Debug/TestFlight-only control panel UI with backward-compatible optional API field; no change to production paywall presentation for native paywalls.
> 
> **Overview**
> The paywall previews control panel now distinguishes **web paywalls** from native ones and routes their previews to the system browser instead of the in-app paywall flow.
> 
> Preview entries decode an optional **`isWeb`** flag (missing/`false` stays native). Web paywalls show a **Web** badge and a Safari icon on version rows. Tapping a web version shows a confirmation alert, then opens the version **`bundleUrl`** externally with URL validation; native selection is unchanged.
> 
> Tests cover **`isWeb`** decoding and legacy responses without the field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44f2a3c27ab038a239dc043600ae3a0e9d971e7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for identifying web-based paywalls in the preview panel.
  * Web paywalls are clearly labeled, and users can open them in an external browser for preview.
  * Added a confirmation prompt before launching the web paywall externally.
* **Bug Fixes**
  * Improved validation and handling of web paywall preview URLs.
* **Tests**
  * Added unit test coverage to verify web paywall detection and the correct associated version link data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->