### PR TITLE
[HEL-6449] | Server-only TestFlight diagnostic gating, docstring polish

### DIFF
--- a/Sources/Helium/HeliumCore/Diagnostic/HeliumDiagnosticGate.swift
+++ b/Sources/Helium/HeliumCore/Diagnostic/HeliumDiagnosticGate.swift
@@ -27,7 +27,6 @@ enum HeliumDiagnosticGate {
         isDebugBuild: Bool,
         environment: AppReceiptsHelper.Environment,
         displayEnabled: Bool,
-        enabledInTestFlight: Bool,
         serverAllowsInTestFlight: @autoclosure () -> Bool,
         doNotShowAgain: @autoclosure () -> Bool
     ) -> Bool {
@@ -42,7 +41,6 @@ enum HeliumDiagnosticGate {
             isDebugBuild: isDebugBuild,
             environment: environment,
             displayEnabled: displayEnabled,
-            enabledInTestFlight: enabledInTestFlight,
             serverAllowsInTestFlight: serverAllowsInTestFlight()
         ) else { return false }
         if isPreviewTrigger { return true }
@@ -57,7 +55,6 @@ enum HeliumDiagnosticGate {
         isDebugBuild: Bool,
         environment: AppReceiptsHelper.Environment,
         displayEnabled: Bool,
-        enabledInTestFlight: Bool,
         serverAllowsInTestFlight: @autoclosure () -> Bool
     ) -> Bool {
         if isPreviewTrigger { return true }
@@ -65,7 +62,6 @@ enum HeliumDiagnosticGate {
         return isAllowedOnThisBuild(
             isDebugBuild: isDebugBuild,
             environment: environment,
-            enabledInTestFlight: enabledInTestFlight,
             serverAllowsInTestFlight: serverAllowsInTestFlight()
         )
     }
@@ -96,20 +92,19 @@ enum HeliumDiagnosticGate {
         }
     }
 
-    /// The TestFlight opt-in and the server permission exist to keep a developer modal out of a
-    /// tester's hands, and a developer running a DEBUG build of their own app is not a tester.
+    /// The server permission exists to keep a developer modal out of a tester's hands, and a
+    /// developer running a DEBUG build of their own app is not a tester.
     private static func isAllowedOnThisBuild(
         isDebugBuild: Bool,
         environment: AppReceiptsHelper.Environment,
-        enabledInTestFlight: Bool,
         serverAllowsInTestFlight: @autoclosure () -> Bool
     ) -> Bool {
         if isDebugBuild { return true }
         switch environment {
         // In a non-DEBUG build, .debug still means a developer's own run: a release-configuration
         // simulator build, or a device launched from Xcode (StoreKit's Xcode environment). It is a
-        // release binary all the same, so it answers to the same two permissions as TestFlight.
-        case .debug, .sandbox: return enabledInTestFlight && serverAllowsInTestFlight()
+        // release binary all the same, so it answers to the same server permission as TestFlight.
+        case .debug, .sandbox: return serverAllowsInTestFlight()
         case .production: return false
         }
     }
@@ -129,7 +124,6 @@ extension HeliumDiagnosticGate {
             isDebugBuild: isDebugBuild,
             environment: AppReceiptsHelper.shared.environment,
             displayEnabled: Helium.config.paywallNotShownDiagnosticDisplayEnabled,
-            enabledInTestFlight: Helium.config.paywallNotShownDiagnosticEnabledInTestFlight,
             serverAllowsInTestFlight: serverAllowsInTestFlight,
             doNotShowAgain: UserDefaults.standard.bool(forKey: doNotShowAgainKey)
         )
@@ -141,7 +135,6 @@ extension HeliumDiagnosticGate {
             isDebugBuild: isDebugBuild,
             environment: AppReceiptsHelper.shared.environment,
             displayEnabled: Helium.config.paywallNotShownDiagnosticDisplayEnabled,
-            enabledInTestFlight: Helium.config.paywallNotShownDiagnosticEnabledInTestFlight,
             serverAllowsInTestFlight: serverAllowsInTestFlight
         )
     }

--- a/Sources/Helium/HeliumCore/Diagnostic/HeliumDiagnosticGate.swift
+++ b/Sources/Helium/HeliumCore/Diagnostic/HeliumDiagnosticGate.swift
@@ -33,9 +33,7 @@ enum HeliumDiagnosticGate {
         // A rendered fallback paywall disproves the modal's authored outcome, which describes a user
         // who got nothing. That case is surfaced by the on-paywall badge instead.
         if fallbackShown { return false }
-        guard warrantsInterrupting(outcome, isPreviewTrigger: isPreviewTrigger, isDebugBuild: isDebugBuild) else {
-            return false
-        }
+        guard warrantsInterrupting(outcome) else { return false }
         guard isEnabled(
             isPreviewTrigger: isPreviewTrigger,
             isDebugBuild: isDebugBuild,
@@ -75,20 +73,16 @@ enum HeliumDiagnosticGate {
 #endif
     }
 
-    /// A skip is Helium working as configured, so there is nothing for the person holding the phone
-    /// to fix. Outside a debug build it stays in the log rather than taking over the screen of a
-    /// tester who is already subscribed or sitting in a targeting holdout.
-    private static func warrantsInterrupting(
-        _ outcome: DiagnosticOutcome,
-        isPreviewTrigger: Bool,
-        isDebugBuild: Bool
-    ) -> Bool {
+    /// A skip is Helium working as configured, but from the phone it looks the same as a paywall
+    /// that broke: the trigger fired and nothing appeared. It is explained like any failure, and
+    /// the do-not-show-again checkbox is the way to quiet it.
+    private static func warrantsInterrupting(_ outcome: DiagnosticOutcome) -> Bool {
         switch outcome {
         case .unavailable(let reason):
             guard let reason else { return true }
             return !suppressedReasons.contains(reason)
         case .skipped:
-            return isDebugBuild || isPreviewTrigger
+            return true
         }
     }
 

--- a/Sources/Helium/HeliumCore/Diagnostic/Model/DiagnosticOutcome.swift
+++ b/Sources/Helium/HeliumCore/Diagnostic/Model/DiagnosticOutcome.swift
@@ -7,8 +7,8 @@ import Foundation
 
 /// Why Helium had no paywall to show, in the two shapes the SDK reports.
 ///
-/// The distinction drives more than copy: a skip is Helium working as configured, so it warrants a
-/// far quieter response than a paywall that was meant to appear and didn't.
+/// The distinction drives the authored copy and log severity: a skip is Helium working as
+/// configured, while unavailable means a paywall that was meant to appear did not.
 enum DiagnosticOutcome {
 
     /// A paywall was meant to show and could not. The reason is optional because the failing path

--- a/Sources/Helium/HeliumCore/HeliumPaywallDiagnosticView.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDiagnosticView.swift
@@ -265,7 +265,7 @@ struct HeliumPaywallDiagnosticView: View {
     private var footer: some View {
         VStack(alignment: .leading, spacing: 10) {
             if !isForPreview {
-                Text("Visible in debug builds, and in TestFlight builds unless disabled from the Helium dashboard. App Store users never see this.\n\nYou can disable it by setting Helium.config.paywallNotShownDiagnosticDisplayEnabled to false.")
+                Text("Visible in debug builds, and in TestFlight builds unless disabled from the Helium dashboard. Production users never see this.\n\nYou can disable it by setting Helium.config.paywallNotShownDiagnosticDisplayEnabled to false.")
                     .font(.footnote)
                     .foregroundColor(.secondary)
             }

--- a/Sources/Helium/HeliumCore/HeliumPaywallDiagnosticView.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDiagnosticView.swift
@@ -334,10 +334,10 @@ extension HeliumPaywallDiagnosticView {
         diagnosticWindow = nil
     }
 
-    /// Enforces only what no caller can be trusted to get wrong: that a full-screen developer modal
-    /// never reaches a build where diagnostics are off. Whether a given outcome deserves an
-    /// unprompted modal is the caller's judgement, and is re-checked here because callers reach the
-    /// main actor asynchronously and the flags can change on the way.
+    /// Last line of defense: re-checks only availability (the display flag, build and environment,
+    /// the server permission) because callers reach the main actor asynchronously and those flags
+    /// can change on the way. Whether the outcome deserves an unprompted modal remains the caller's
+    /// judgement and is not re-verified here.
     ///
     /// - Parameter fallbackShown: true when a fallback paywall is on screen behind the diagnostic.
     @MainActor

--- a/Sources/Helium/HeliumCore/HeliumPaywallDiagnosticView.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDiagnosticView.swift
@@ -265,7 +265,7 @@ struct HeliumPaywallDiagnosticView: View {
     private var footer: some View {
         VStack(alignment: .leading, spacing: 10) {
             if !isForPreview {
-                Text("Visible in debug builds, and in TestFlight builds only if opted in. App Store users never see this.\n\nYou can disable it by setting Helium.config.paywallNotShownDiagnosticDisplayEnabled to false.")
+                Text("Visible in debug builds, and in TestFlight builds unless disabled from the Helium dashboard. App Store users never see this.\n\nYou can disable it by setting Helium.config.paywallNotShownDiagnosticDisplayEnabled to false.")
                     .font(.footnote)
                     .foregroundColor(.secondary)
             }

--- a/Sources/Helium/HeliumCore/Models.swift
+++ b/Sources/Helium/HeliumCore/Models.swift
@@ -125,7 +125,8 @@ public struct HeliumFetchedConfig: Codable {
 
     /// Server-side permission for the paywall-not-shown diagnostic modal outside DEBUG builds:
     /// TestFlight, plus release builds on a simulator or launched from Xcode. A DEBUG build answers
-    /// to the SDK flag alone and never consults this. Absent means allowed.
+    /// to the SDK's display flag alone and never consults this. Absent means allowed, so an outcome
+    /// that fires before the on-launch response arrives is still explained.
     var paywallDiagnosticModalAllowedInTestFlight: Bool?
     
     var paddleProducts: [String: ServerProductPrice]?

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -706,29 +706,18 @@ public class HeliumConfig {
     /// Adjust the text copy for the dialog that shows when a user attempts to restore purchases but does not have any to restore. You can also disable the dialog from showing.
     public let restorePurchasesDialog = RestorePurchaseConfig()
     
-    /// Controls whether a diagnostic view is shown when a paywall fails to display or is skipped.
-    /// Defaults to `true`.
+    /// Whether a diagnostic view may appear explaining why a paywall failed to display or was
+    /// skipped. Defaults to `true`; set to `false` to turn it off entirely.
     ///
-    /// Applies in DEBUG builds. Release builds running through TestFlight, on a simulator, or from
-    /// Xcode on a device also need ``paywallNotShownDiagnosticEnabledInTestFlight``. App Store
-    /// users never see it.
-    /// The diagnostic view also contains a "Do not show again" checkbox that persists per-device via UserDefaults (resets on app delete).
+    /// The view can appear in DEBUG builds, and in TestFlight (or release builds run on a
+    /// simulator or launched from Xcode) unless Helium has disabled it remotely. App Store users
+    /// never see it. Skips where Helium is working as configured (an entitled user, a targeting
+    /// holdout) are only explained in DEBUG builds.
     ///
-    /// Set this to `false` to turn the diagnostic view off. Paywall previews opened from the Helium
-    /// dashboard are exempt and continue to explain themselves. Helium can also disable the view
-    /// remotely, so `true` permits it rather than guarantees it.
+    /// The view's "Do not show again" checkbox silences unprompted appearances per device via
+    /// UserDefaults; deleting the app resets it. Paywall previews from the Helium dashboard
+    /// always explain themselves, regardless of this setting.
     public var paywallNotShownDiagnosticDisplayEnabled: Bool = true
-
-    /// Controls whether the paywall diagnostic view is shown outside DEBUG builds, which covers
-    /// TestFlight testers and release builds run on a simulator or from Xcode on a device.
-    /// Defaults to `false`, since TestFlight builds reach real testers who would otherwise see a
-    /// full-screen developer modal. Set it to `true` for internal builds whose testers can act on
-    /// the diagnosis.
-    ///
-    /// Even when enabled, the view stays out of the way of anything working as configured: paywalls
-    /// skipped for entitled users or targeting holdouts are logged rather than shown. This has no
-    /// effect on App Store builds, which never show the diagnostic view.
-    public var paywallNotShownDiagnosticEnabledInTestFlight: Bool = false
 
     /// Controls whether the triple-tap paywall previews gesture is enabled in DEBUG and TestFlight builds.
     ///

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -709,14 +709,11 @@ public class HeliumConfig {
     /// Whether a diagnostic view may appear explaining why a paywall failed to display or was
     /// skipped. Defaults to `true`; set to `false` to turn it off entirely.
     ///
-    /// The view can appear in DEBUG builds, and in TestFlight (or release builds run on a
-    /// simulator or launched from Xcode) unless Helium has disabled it remotely. App Store users
-    /// never see it. Skips where Helium is working as configured (an entitled user, a targeting
-    /// holdout) are only explained in DEBUG builds.
+    /// The view can appear in DEBUG builds, and in TestFlight unless disabled from the Helium
+    /// dashboard. Production users never see it.
     ///
     /// The view's "Do not show again" checkbox silences unprompted appearances per device via
-    /// UserDefaults; deleting the app resets it. Paywall previews from the Helium dashboard
-    /// always explain themselves, regardless of this setting.
+    /// UserDefaults; deleting the app resets it.
     public var paywallNotShownDiagnosticDisplayEnabled: Bool = true
 
     /// Controls whether the triple-tap paywall previews gesture is enabled in DEBUG and TestFlight builds.

--- a/Tests/helium-swiftTests/HeliumDiagnosticGateTests.swift
+++ b/Tests/helium-swiftTests/HeliumDiagnosticGateTests.swift
@@ -71,39 +71,27 @@ final class HeliumDiagnosticGateTests: XCTestCase {
 
     // MARK: - Skips
 
-    /// A skip is Helium working as configured, so it is worth a developer's attention but never a
-    /// tester's.
-    func testSkipsShowInDebugBuildsOnly() {
+    /// A skip is Helium working as configured, but a trigger that silently shows nothing reads as
+    /// breakage, so it is explained wherever failures are.
+    func testSkipsShowWhereverFailuresDo() {
         for reason in PaywallSkippedReason.allCases {
             XCTAssertTrue(
                 shouldShow(outcome: .skipped(reason), isDebugBuild: true),
                 "Expected \(reason.rawValue) to show in a debug build"
             )
-            XCTAssertFalse(
+            XCTAssertTrue(
                 shouldShow(outcome: .skipped(reason), isDebugBuild: false, environment: .sandbox),
-                "Expected \(reason.rawValue) to stay out of TestFlight"
+                "Expected \(reason.rawValue) to show in TestFlight"
             )
         }
     }
 
-    func testTheServerPermissionDoesNotBringSkipsWithIt() {
-        XCTAssertFalse(
-            shouldShow(
-                outcome: .skipped(.alreadyEntitled),
-                isDebugBuild: false,
-                environment: .sandbox,
-                serverAllowsInTestFlight: { true }
-            )
-        )
+    func testSkipsHonourTheDoNotShowAgainCheckbox() {
+        XCTAssertFalse(shouldShow(outcome: .skipped(.alreadyEntitled), doNotShowAgain: { true }))
     }
 
     func testSkipsStillExplainThemselvesInADashboardPreview() {
         XCTAssertTrue(shouldShow(outcome: .skipped(.alreadyEntitled), isPreviewTrigger: true))
-    }
-
-    /// The rule is about skips, not about everything outside a debug build.
-    func testAFailureStillShowsOutsideADebugBuild() {
-        XCTAssertTrue(shouldShow(isDebugBuild: false, environment: .sandbox))
     }
 
     // MARK: - Modal / badge exclusivity
@@ -218,7 +206,6 @@ final class HeliumDiagnosticGateTests: XCTestCase {
         let counting: () -> Bool = { reads += 1; return false }
 
         _ = shouldShow(outcome: .unavailable(.alreadyPresented), doNotShowAgain: counting)
-        _ = shouldShow(outcome: .skipped(.alreadyEntitled), doNotShowAgain: counting)
         _ = shouldShow(fallbackShown: true, doNotShowAgain: counting)
         _ = shouldShow(displayEnabled: false, doNotShowAgain: counting)
         _ = shouldShow(environment: .production, doNotShowAgain: counting)

--- a/Tests/helium-swiftTests/HeliumDiagnosticGateTests.swift
+++ b/Tests/helium-swiftTests/HeliumDiagnosticGateTests.swift
@@ -13,7 +13,6 @@ final class HeliumDiagnosticGateTests: XCTestCase {
         isDebugBuild: Bool = false,
         environment: AppReceiptsHelper.Environment = .debug,
         displayEnabled: Bool = true,
-        enabledInTestFlight: Bool = true,
         serverAllowsInTestFlight: () -> Bool = { true },
         doNotShowAgain: () -> Bool = { false }
     ) -> Bool {
@@ -24,7 +23,6 @@ final class HeliumDiagnosticGateTests: XCTestCase {
             isDebugBuild: isDebugBuild,
             environment: environment,
             displayEnabled: displayEnabled,
-            enabledInTestFlight: enabledInTestFlight,
             serverAllowsInTestFlight: serverAllowsInTestFlight(),
             doNotShowAgain: doNotShowAgain()
         )
@@ -35,7 +33,6 @@ final class HeliumDiagnosticGateTests: XCTestCase {
         isDebugBuild: Bool = false,
         environment: AppReceiptsHelper.Environment = .debug,
         displayEnabled: Bool = true,
-        enabledInTestFlight: Bool = true,
         serverAllowsInTestFlight: () -> Bool = { true }
     ) -> Bool {
         HeliumDiagnosticGate.isEnabled(
@@ -43,7 +40,6 @@ final class HeliumDiagnosticGateTests: XCTestCase {
             isDebugBuild: isDebugBuild,
             environment: environment,
             displayEnabled: displayEnabled,
-            enabledInTestFlight: enabledInTestFlight,
             serverAllowsInTestFlight: serverAllowsInTestFlight()
         )
     }
@@ -90,13 +86,13 @@ final class HeliumDiagnosticGateTests: XCTestCase {
         }
     }
 
-    func testTheTestFlightOptInDoesNotBringSkipsWithIt() {
+    func testTheServerPermissionDoesNotBringSkipsWithIt() {
         XCTAssertFalse(
             shouldShow(
                 outcome: .skipped(.alreadyEntitled),
                 isDebugBuild: false,
                 environment: .sandbox,
-                enabledInTestFlight: true
+                serverAllowsInTestFlight: { true }
             )
         )
     }
@@ -125,7 +121,6 @@ final class HeliumDiagnosticGateTests: XCTestCase {
                 isPreviewTrigger: true,
                 environment: .production,
                 displayEnabled: false,
-                enabledInTestFlight: false,
                 serverAllowsInTestFlight: { false },
                 doNotShowAgain: { true }
             )
@@ -147,23 +142,19 @@ final class HeliumDiagnosticGateTests: XCTestCase {
 
     func testProductionNeverShows() {
         XCTAssertFalse(shouldShow(environment: .production))
-        XCTAssertFalse(shouldShow(environment: .production, enabledInTestFlight: true))
+        XCTAssertFalse(shouldShow(environment: .production, serverAllowsInTestFlight: { true }))
     }
 
-    func testTestFlightShowsOnlyWhenOptedIn() {
-        XCTAssertTrue(shouldShow(environment: .sandbox, enabledInTestFlight: true))
-        XCTAssertFalse(shouldShow(environment: .sandbox, enabledInTestFlight: false))
+    func testTestFlightShowsOnlyWhenTheServerAllowsIt() {
+        XCTAssertTrue(shouldShow(environment: .sandbox, serverAllowsInTestFlight: { true }))
+        XCTAssertFalse(shouldShow(environment: .sandbox, serverAllowsInTestFlight: { false }))
     }
 
     /// A .debug environment without a DEBUG-compiled build is a release-configuration run by a
     /// developer: a simulator, or a device launched from Xcode.
-    func testDebugEnvironmentInAReleaseBuildRequiresTheOptIn() {
-        XCTAssertTrue(shouldShow(isDebugBuild: false, environment: .debug, enabledInTestFlight: true))
-        XCTAssertFalse(shouldShow(isDebugBuild: false, environment: .debug, enabledInTestFlight: false))
-    }
-
-    func testTestFlightOptInOffDoesNotAffectDebugBuilds() {
-        XCTAssertTrue(shouldShow(isDebugBuild: true, environment: .debug, enabledInTestFlight: false))
+    func testDebugEnvironmentInAReleaseBuildRequiresTheServerPermission() {
+        XCTAssertTrue(shouldShow(isDebugBuild: false, environment: .debug, serverAllowsInTestFlight: { true }))
+        XCTAssertFalse(shouldShow(isDebugBuild: false, environment: .debug, serverAllowsInTestFlight: { false }))
     }
 
     // MARK: - Server permission
@@ -183,7 +174,6 @@ final class HeliumDiagnosticGateTests: XCTestCase {
             isEnabled(
                 isDebugBuild: true,
                 environment: .sandbox,
-                enabledInTestFlight: false,
                 serverAllowsInTestFlight: { false }
             )
         )
@@ -205,7 +195,6 @@ final class HeliumDiagnosticGateTests: XCTestCase {
         _ = isEnabled(isDebugBuild: true, serverAllowsInTestFlight: counting)
         _ = isEnabled(displayEnabled: false, serverAllowsInTestFlight: counting)
         _ = isEnabled(environment: .production, serverAllowsInTestFlight: counting)
-        _ = isEnabled(environment: .sandbox, enabledInTestFlight: false, serverAllowsInTestFlight: counting)
         _ = isEnabled(isPreviewTrigger: true, serverAllowsInTestFlight: counting)
         _ = shouldShow(isDebugBuild: true, serverAllowsInTestFlight: counting)
 
@@ -251,14 +240,14 @@ final class HeliumDiagnosticGateTests: XCTestCase {
     func testDeliberatePathHonoursEveryOtherStandingPreference() {
         XCTAssertFalse(isEnabled(displayEnabled: false))
         XCTAssertFalse(isEnabled(environment: .production))
-        XCTAssertFalse(isEnabled(environment: .sandbox, enabledInTestFlight: false))
+        XCTAssertFalse(isEnabled(environment: .sandbox, serverAllowsInTestFlight: { false }))
         XCTAssertFalse(isEnabled(serverAllowsInTestFlight: { false }))
     }
 
     func testDeliberatePathShowsWhenEveryPreferenceAllowsIt() {
         XCTAssertTrue(isEnabled())
         XCTAssertTrue(isEnabled(isDebugBuild: true))
-        XCTAssertTrue(isEnabled(environment: .sandbox, enabledInTestFlight: true))
+        XCTAssertTrue(isEnabled(environment: .sandbox, serverAllowsInTestFlight: { true }))
     }
 
     func testDeliberatePathKeepsThePreviewBypass() {
@@ -267,7 +256,6 @@ final class HeliumDiagnosticGateTests: XCTestCase {
                 isPreviewTrigger: true,
                 environment: .production,
                 displayEnabled: false,
-                enabledInTestFlight: false,
                 serverAllowsInTestFlight: { false }
             )
         )

--- a/Tests/helium-swiftTests/HeliumDiagnosticGateTests.swift
+++ b/Tests/helium-swiftTests/HeliumDiagnosticGateTests.swift
@@ -83,6 +83,24 @@ final class HeliumDiagnosticGateTests: XCTestCase {
                 shouldShow(outcome: .skipped(reason), isDebugBuild: false, environment: .sandbox),
                 "Expected \(reason.rawValue) to show in TestFlight"
             )
+            XCTAssertFalse(
+                shouldShow(
+                    outcome: .skipped(reason),
+                    isDebugBuild: false,
+                    environment: .sandbox,
+                    serverAllowsInTestFlight: { false }
+                ),
+                "Expected \(reason.rawValue) to stay hidden when the server denies TestFlight"
+            )
+            XCTAssertFalse(
+                shouldShow(
+                    outcome: .skipped(reason),
+                    isDebugBuild: false,
+                    environment: .debug,
+                    serverAllowsInTestFlight: { false }
+                ),
+                "Expected \(reason.rawValue) to stay hidden in a server-denied release run from Xcode"
+            )
         }
     }
 


### PR DESCRIPTION
## What

Removes the `paywallNotShownDiagnosticEnabledInTestFlight` SDK setting. Outside DEBUG builds (TestFlight, plus release builds on a simulator or launched from Xcode), the paywall diagnostic modal is now controlled only by the server's `paywallDiagnosticModalAllowedInTestFlight` field. DEBUG builds are unchanged: always enabled unless `paywallNotShownDiagnosticDisplayEnabled` is off.

Also rewrites the docstring for `paywallNotShownDiagnosticDisplayEnabled` and updates the modal footer copy that still said "only if opted in".

## Why

Follow-up feedback on #309: whether the diagnostic modal can reach TestFlight testers should be a server decision, not an SDK setting integrators have to discover and set. The setting never shipped in a release, so it can be removed without a deprecation cycle.

## Fix

- `HeliumPublic.swift` — removed the setting; rewrote the `paywallNotShownDiagnosticDisplayEnabled` docstring to spell out per-build visibility (DEBUG / TestFlight / App Store).
- `HeliumDiagnosticGate.swift` — dropped the `enabledInTestFlight` input; the non-DEBUG path answers to the server permission alone.
- `Models.swift` — updated the server field's docstring: absent still means allowed, so outcomes that fire before the on-launch response arrives are still explained.
- `HeliumPaywallDiagnosticView.swift` — footer copy now says TestFlight visibility is controlled from the dashboard.

Note: with the client opt-in gone, TestFlight defaults to allowed unless the server says no. If we want TestFlight off by default, that's now a server-side default.

## Tests

Updated `HeliumDiagnosticGateTests`: opt-in tests reworked into server-permission equivalents (`testTestFlightShowsOnlyWhenTheServerAllowsIt`, `testDebugEnvironmentInAReleaseBuildRequiresTheServerPermission`, `testTheServerPermissionDoesNotBringSkipsWithIt`); removed `testTestFlightOptInOffDoesNotAffectDebugBuilds` (covered by `testTheServerFlagDoesNotReachDebugBuilds`) and the sandbox line from the lock-read-counting test, since sandbox now must read the server flag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> TestFlight testers may see more full-screen diagnostic modals (skipped paywalls and default-on server permission) unless the dashboard disables them; production App Store builds remain blocked.
> 
> **Overview**
> Removes the SDK setting **`paywallNotShownDiagnosticEnabledInTestFlight`**. For non-DEBUG builds (TestFlight, simulator, Xcode device runs), whether the paywall-not-shown diagnostic modal can appear now depends only on **`paywallDiagnosticModalAllowedInTestFlight`** from fetched config (still defaults to allowed when absent).
> 
> **`HeliumDiagnosticGate`** no longer takes a client TestFlight opt-in: sandbox/debug release environments need only the server permission. **Skipped** paywall outcomes are treated like failures for unprompted modals everywhere diagnostics are enabled (not limited to DEBUG/preview), still subject to do-not-show-again and server denial.
> 
> Public docs and the diagnostic modal footer are updated to describe dashboard-controlled TestFlight visibility. Unit tests are aligned with server-only gating and the new skip behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96f105d5d66490c6f12e23ac10f596e3a609d934. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changes**
  - Simplified diagnostic availability controls so TestFlight visibility is governed by the server setting and display preference.
  - Removed the separate TestFlight opt-in configuration option.
  - Improved handling of skipped diagnostic outcomes across supported environments.

- **Documentation**
  - Updated the diagnostic footer to clarify that visibility can be disabled from the Helium dashboard and that production users never see it.
  - Clarified configuration behavior before server settings are received and the distinction between unavailable and skipped outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->