### PR TITLE
[HEL-6454] Forward per-product Stripe offer terms into web-checkout ctx

### DIFF
--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -176,6 +176,7 @@ public class ExternalWebCheckoutManager: NSObject {
             successURL: resolvedSuccessURL,
             cancelURL: resolvedCancelURL,
             introOfferEligible: await isIntroOfferEligibleForWebCheckout(paywallInfo: paywallSession.paywallInfoWithBackups),
+            stripeOfferTerms: buildStripeOfferTerms(paywallInfo: paywallSession.paywallInfoWithBackups),
             paddleBootstraps: paddleBootstrapsDict,
             paddleAlreadyEntitled: paddleAlreadyEntitledDict
         )
@@ -200,35 +201,45 @@ public class ExternalWebCheckoutManager: NSObject {
         return products.allSatisfy { priceMap[$0]?.subscription?.introOfferEligible == true }
     }
 
-    /// Projects the selected Stripe price's subscription detail into the
-    /// web-checkout ctx so the Apple Pay sheet can reflect trial / recurring
-    /// terms rather than charging the full price for a $0-today trial. Keys
-    /// mirror the injected `subscription` price shape.
-    private func buildStripeOfferTerms(productKey: String) -> [String: Any]? {
+    /// Projects every offered Stripe product's subscription detail into a map
+    /// keyed by product key. The standalone paywall is interactive, so the user
+    /// can re-select before authorizing — a single tapped-product block would go
+    /// stale. Keys mirror the injected `subscription` price shape.
+    private func buildStripeOfferTerms(paywallInfo: HeliumPaywallInfo?) -> [String: Any]? {
         guard provider.kind == .stripe,
-              let sub = provider.getProductsPriceMap()?[productKey]?.subscription else {
+              let paywallInfo,
+              let offered = provider.getOfferedProducts(paywallInfo, false),
+              !offered.isEmpty else {
             return nil
         }
+        let priceMap = provider.getProductsPriceMap() ?? [:]
 
-        var terms: [String: Any] = [:]
-        if let unit = sub.periodUnit { terms["periodUnit"] = unit }
-        if let value = sub.periodValue { terms["periodValue"] = value }
-        if let eligible = sub.introOfferEligible { terms["introOfferEligible"] = eligible }
+        var byProductKey: [String: Any] = [:]
+        for productKey in offered {
+            guard let sub = priceMap[productKey]?.subscription else { continue }
 
-        // Stripe emits at most one intro offer.
-        if let offer = sub.introOffers?.first {
-            var offerDict: [String: Any] = [:]
-            if let type = offer.type { offerDict["type"] = type }
-            if let mode = offer.paymentMode { offerDict["paymentMode"] = mode }
-            if let unit = offer.periodUnit { offerDict["periodUnit"] = unit }
-            if let value = offer.periodValue { offerDict["periodValue"] = value }
-            if let periodCount = offer.periodCount { offerDict["periodCount"] = periodCount }
-            if let price = offer.price { offerDict["price"] = NSDecimalNumber(decimal: price).doubleValue }
-            if let displayPrice = offer.displayPrice { offerDict["displayPrice"] = displayPrice }
-            terms["introOffer"] = offerDict
+            var terms: [String: Any] = [:]
+            if let unit = sub.periodUnit { terms["periodUnit"] = unit }
+            if let value = sub.periodValue { terms["periodValue"] = value }
+            if let eligible = sub.introOfferEligible { terms["introOfferEligible"] = eligible }
+
+            // Stripe emits at most one intro offer.
+            if let offer = sub.introOffers?.first {
+                var offerDict: [String: Any] = [:]
+                if let type = offer.type { offerDict["type"] = type }
+                if let mode = offer.paymentMode { offerDict["paymentMode"] = mode }
+                if let unit = offer.periodUnit { offerDict["periodUnit"] = unit }
+                if let value = offer.periodValue { offerDict["periodValue"] = value }
+                if let periodCount = offer.periodCount { offerDict["periodCount"] = periodCount }
+                if let price = offer.price { offerDict["price"] = NSDecimalNumber(decimal: price).doubleValue }
+                if let displayPrice = offer.displayPrice { offerDict["displayPrice"] = displayPrice }
+                terms["introOffer"] = offerDict
+            }
+
+            byProductKey[productKey] = terms
         }
 
-        return terms
+        return byProductKey.isEmpty ? nil : byProductKey
     }
 
     /// Builds the enriched checkout URL: existing query items are preserved,
@@ -241,6 +252,7 @@ public class ExternalWebCheckoutManager: NSObject {
         successURL: String,
         cancelURL: String,
         introOfferEligible: Bool,
+        stripeOfferTerms: [String: Any]? = nil,
         paddleBootstraps: [String: Any]? = nil,
         paddleAlreadyEntitled: [String: Any]? = nil
     ) throws -> URL {
@@ -274,9 +286,7 @@ public class ExternalWebCheckoutManager: NSObject {
         ctx["introOfferEligible"] = introOfferEligible
 
         // Per-price offer terms, additive to the blanket `introOfferEligible` above.
-        if let stripeOfferTerms = buildStripeOfferTerms(productKey: productKey) {
-            ctx["stripeOfferTerms"] = stripeOfferTerms
-        }
+        if let stripeOfferTerms { ctx["stripeOfferTerms"] = stripeOfferTerms }
 
         ctx["iosBundleId"] = Bundle.main.bundleIdentifier ?? "unknown"
 

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -205,6 +205,11 @@ public class ExternalWebCheckoutManager: NSObject {
     /// keyed by product key. The standalone paywall is interactive, so the user
     /// can re-select before authorizing — a single tapped-product block would go
     /// stale. Keys mirror the injected `subscription` price shape.
+    ///
+    /// The per-product `introOfferEligible` here is the on-launch snapshot and
+    /// can lag the live per-customer signal; the authoritative eligibility gate
+    /// is the top-level `introOfferEligible` in ctx. This block carries the
+    /// offer terms, not the gate.
     private func buildStripeOfferTerms(paywallInfo: HeliumPaywallInfo?) -> [String: Any]? {
         guard provider.kind == .stripe,
               let paywallInfo,

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -200,6 +200,37 @@ public class ExternalWebCheckoutManager: NSObject {
         return products.allSatisfy { priceMap[$0]?.subscription?.introOfferEligible == true }
     }
 
+    /// Projects the selected Stripe price's subscription detail into the
+    /// web-checkout ctx so the Apple Pay sheet can reflect trial / recurring
+    /// terms rather than charging the full price for a $0-today trial. Keys
+    /// mirror the injected `subscription` price shape.
+    private func buildStripeOfferTerms(productKey: String) -> [String: Any]? {
+        guard provider.kind == .stripe,
+              let sub = provider.getProductsPriceMap()?[productKey]?.subscription else {
+            return nil
+        }
+
+        var terms: [String: Any] = [:]
+        if let unit = sub.periodUnit { terms["periodUnit"] = unit }
+        if let value = sub.periodValue { terms["periodValue"] = value }
+        if let eligible = sub.introOfferEligible { terms["introOfferEligible"] = eligible }
+
+        // Stripe emits at most one intro offer.
+        if let offer = sub.introOffers?.first {
+            var offerDict: [String: Any] = [:]
+            if let type = offer.type { offerDict["type"] = type }
+            if let mode = offer.paymentMode { offerDict["paymentMode"] = mode }
+            if let unit = offer.periodUnit { offerDict["periodUnit"] = unit }
+            if let value = offer.periodValue { offerDict["periodValue"] = value }
+            if let periodCount = offer.periodCount { offerDict["periodCount"] = periodCount }
+            if let price = offer.price { offerDict["price"] = NSDecimalNumber(decimal: price).doubleValue }
+            if let displayPrice = offer.displayPrice { offerDict["displayPrice"] = displayPrice }
+            terms["introOffer"] = offerDict
+        }
+
+        return terms
+    }
+
     /// Builds the enriched checkout URL: existing query items are preserved,
     /// the compressed `ctx` payload is written to the URL fragment.
     func buildEnrichedCheckoutURL(
@@ -241,6 +272,11 @@ public class ExternalWebCheckoutManager: NSObject {
             ctx["organizationId"] = organizationId
         }
         ctx["introOfferEligible"] = introOfferEligible
+
+        // Per-price offer terms, additive to the blanket `introOfferEligible` above.
+        if let stripeOfferTerms = buildStripeOfferTerms(productKey: productKey) {
+            ctx["stripeOfferTerms"] = stripeOfferTerms
+        }
 
         ctx["iosBundleId"] = Bundle.main.bundleIdentifier ?? "unknown"
 


### PR DESCRIPTION
## What

Adds `buildStripeOfferTerms(paywallInfo:)` to `ExternalWebCheckoutManager` and injects its result into the web-checkout `ctx` as `stripeOfferTerms`. It projects **every offered Stripe product's** subscription detail (billing period, `introOfferEligible`, and the intro offer — `type`, `paymentMode`, period, price, `displayPrice`) from the on-launch price map the SDK already holds, into a **map keyed by product key**.

## Why

On the standalone Stripe web path, the Apple Pay sheet is built with only a `total` set to the full price. When the subscription actually starts a free trial ($0 charged today via `trial_period_days`), the sheet authorizes the full amount while nothing is charged today — a misleading disclosure. Forwarding the real offer terms lets the web checkout reflect the trial / recurring structure and charge the correct amount today.

**Why per-product (not just the tapped product):** the standalone paywall is interactive — the user can re-select a different product before authorizing Apple Pay — so a single block scoped to the originally-tapped product would be stale for whatever they actually buy. The terms are forwarded for every offered product, and the ctx consumer indexes the map by the selected product key.

## Contract

`stripeOfferTerms` is a map keyed by product key. Each value deliberately mirrors the injected `subscription` price shape (`ServerSubscriptionDetail` / `LocalizedPrice.json`) so the consumer reads it the same way it reads in-app price data:

```
stripeOfferTerms: {
  [productKey]: {
    periodUnit, periodValue, introOfferEligible,
    introOffer: { type, paymentMode, periodUnit, periodValue, periodCount, price, displayPrice }
  }
}
```

The map is keyed by the **offered-product key** (`getOfferedProducts`), so the consumer's "selected product" lookup must use that same key namespace. Products with no subscription detail (one-time) are omitted; an all-empty result yields no `stripeOfferTerms` at all.

**Two `introOfferEligible` fields, two meanings.** The top-level `ctx.introOfferEligible` is the authoritative, per-customer eligibility gate — it prefers the live `/check-entitlement` signal and is a blanket AND across all offered products. The `introOfferEligible` *inside* each per-product block is the on-launch price-map snapshot and can lag the live signal, so it exists for descriptive granularity, not gating. Consumers should gate the $0-today / trial display on the top-level value and treat the per-product block as offer terms only.

## Scope / safety

- **Additive and Stripe-only.** Guarded on `provider.kind == .stripe`; returns nil for Paddle and one-time products, so those paths are unchanged. Sits alongside the existing blanket `introOfferEligible` in ctx. Reuses the same offered-products + price-map traversal as `isIntroOfferEligibleForWebCheckout`.
- This is the **SDK half only** — it forwards the terms. The web-checkout consumer that reads `stripeOfferTerms` to build the Apple Pay recurring/trial sheet, and the Tier B `managementURL` work, are separate follow-ups.

## Testing

Builds clean against the iOS simulator (`xcodebuild -scheme helium-swift -destination 'generic/platform=iOS Simulator'`). Note: verified on the initial single-product version; the per-product rework and the doc-comment additions are non-behavioral changes to the same projection and haven't been re-built locally — CI will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Stripe-only ctx field with no change to checkout URLs, entitlement logic, or Paddle paths; web consumer must read the new key.
> 
> **Overview**
> Adds **`stripeOfferTerms`** to the compressed web-checkout **`ctx`** for Stripe so standalone checkout can show correct Apple Pay amounts when trials apply (today $0 vs full price).
> 
> New **`buildStripeOfferTerms`** walks every **offered** product in the on-launch price map and emits billing period, per-product `introOfferEligible`, and intro-offer fields (`type`, `paymentMode`, period, `price`, `displayPrice`) keyed by product key—so terms stay valid if the user switches plans before authorizing. **`buildEnrichedCheckoutURL`** gains an optional `stripeOfferTerms` argument; Paddle and non-subscription products are unchanged (nil / omitted). Top-level **`ctx.introOfferEligible`** remains the eligibility gate; per-product flags are descriptive only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38037137abd6adf545ee175485e7665a7599a8c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Stripe checkout support for subscription billing periods and introductory offer details.
  * Checkout now includes the selected subscription’s introductory offer eligibility and terms while preserving existing eligibility information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->