### PR TITLE
Release 4.6.0

### DIFF
--- a/Sources/Helium/HeliumCore/BuildConstants.swift
+++ b/Sources/Helium/HeliumCore/BuildConstants.swift
@@ -8,5 +8,5 @@
  */
 public struct BuildConstants {
     /// Current SDK version
-    public static let version = "4.5.6"
+    public static let version = "4.6.0"
 }

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -227,7 +227,7 @@ public class HeliumFetchedConfigManager {
     
     @HeliumAtomic private var _downloadStatus: HeliumFetchedConfigStatus = .notDownloadedYet
     public var downloadStatus: HeliumFetchedConfigStatus { _downloadStatus }
-    private(set) var downloadStep: PaywallsDownloadStep = .config
+    @HeliumAtomic private(set) var downloadStep: PaywallsDownloadStep = .config
     
     static let MAX_NUM_CONFIG_ATTEMPTS: Int = 6 // roughly 36 seconds of delays in between attempts
     static let MAX_NUM_BUNDLE_ATTEMPTS: Int = 4 // roughly 7 seconds of delays in between attempts
@@ -1001,10 +1001,10 @@ public class HeliumFetchedConfigManager {
     }
     
     public func getFetchedTriggerNames() -> [String] {
-        if (fetchedConfig == nil || fetchedConfig?.triggerToPaywalls == nil) {
+        guard let config = fetchedConfig else {
             return []
         }
-        return Array(fetchedConfig!.triggerToPaywalls.keys);
+        return Array(config.triggerToPaywalls.keys)
     }
     
     public func getClientName() -> String? {

--- a/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
+++ b/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
@@ -324,9 +324,7 @@ class HeliumPaywallPresenter {
     
     @MainActor
     private func presentPaywall(trigger: String, paywallSession: PaywallSession, fallbackReason: PaywallUnavailableReason?, isSecondTry: Bool = false, contentView: AnyView, isLoading: Bool = false, presentationContext: PaywallPresentationContext) {
-#if DEBUG
         HeliumPaywallDiagnosticView.dismissIfPresented()
-#endif
         HeliumLogger.log(.debug, category: .ui, "Presenting paywall", metadata: [
             "trigger": trigger,
             "isLoading": String(isLoading),


### PR DESCRIPTION
Cuts the 4.6.0 release, plus two concurrency/teardown fixes found while reviewing the diagnostic gating work.

## Changes

**`HeliumFetchedConfig.swift`**
- `getFetchedTriggerNames()` read `fetchedConfig` three times across a nil check and a force unwrap, so a `resetHelium()` landing in between could crash. Now reads once through `guard let`. The `triggerToPaywalls` nil check was already dead — that property is non-optional.
- `downloadStep` is now `@HeliumAtomic`. It was written from inside the concurrent bundle-fetch task and read from the presenter on another thread with no synchronization — the one property in the manager still unwrapped. It only feeds a diagnostic `PaywallUnavailableReason` label, so no logic depended on reading a stale value.

**`HeliumPaywallPresenter.swift`**
- Removed the `#if DEBUG` around `HeliumPaywallDiagnosticView.dismissIfPresented()`. Every path that *presents* the modal is now runtime-gated, so in TestFlight a modal was never dismissed when a paywall appeared over it — leaving `isCurrentlyPresented` true (silently suppressing all later diagnostics) and stranding a window that resurfaced a stale diagnosis once the paywall closed. `dismissIfPresented` already guards on whether anything is presented, so it needs no build gate; gating teardown on the same predicate that authorized creation is what caused the leak, since the two can drift.

**`BuildConstants.swift`** — 4.5.6 → 4.6.0.

## Why minor rather than patch

HEL-6111 and HEL-6449 expanded the documented behavior of the public `paywallNotShownDiagnosticDisplayEnabled` property: it now governs a modal that can appear in TestFlight, not just DEBUG builds.

## For the release notes

The integrator-visible change in this release is the diagnostic gating. TestFlight builds now show the paywall diagnostic modal by default unless disabled from the Helium dashboard, and skip reasons (already-entitled, targeting holdouts) surface there too. App Store builds are unaffected — production is excluded by both `isDebugBuild` and the `.production` environment check, with test coverage in `HeliumDiagnosticGateTests`.

Everything else in 4.6.0 is already merged and reviewed on `main`: HEL-6107, HEL-6233, HEL-6388, HEL-6449, HEL-6454, web-checkout intro-offer eligibility, and Paddle key StoreKit fallthrough.

## Testing

Not built locally — relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches paywall presentation teardown (TestFlight diagnostics) and shared config state under concurrency; changes are small and targeted but affect UI/diagnostic behavior outside DEBUG.
> 
> **Overview**
> **Release 4.6.0** bumps `BuildConstants.version` from **4.5.6** to **4.6.0**.
> 
> In **`HeliumFetchedConfig`**, `getFetchedTriggerNames()` now binds `fetchedConfig` once with `guard let` instead of checking nil and force-unwrapping on a later read, avoiding a crash if config is cleared mid-call. **`downloadStep`** is marked **`@HeliumAtomic`** so updates from the async bundle fetch task and reads from the paywall presenter are synchronized (it only feeds diagnostic unavailable-reason labels).
> 
> In **`HeliumPaywallPresenter`**, **`HeliumPaywallDiagnosticView.dismissIfPresented()`** runs on every paywall presentation, not only in **DEBUG**. That aligns teardown with runtime-gated presentation so TestFlight builds dismiss the diagnostic modal when a paywall opens instead of leaving `isCurrentlyPresented` stuck and suppressing later diagnostics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85c48c464b1f6398bb843dfcd6271f6801c3dc92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the SDK version to 4.6.0.

* **Bug Fixes**
  * Improved configuration access safety during downloads.
  * Ensured paywall diagnostic views are dismissed consistently when presenting a paywall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->