### PR TITLE
[HEL-6295] | Respect paywall scroll-lock setting in triple-tap previews

### DIFF
--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
@@ -28,6 +28,7 @@ struct HeliumPaywallPreviewVersion: Codable, Identifiable {
     let webPaddleProductIds: [String]?
     let webStripeProductIds: [String]?
     let webPaywallBundleUrl: String?
+    let shouldEnableScroll: Bool?
     let lastSavedAt: String?
     var id: String { versionId }
 

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
@@ -348,7 +348,8 @@ struct HeliumControlPanelView: View {
                     productIdsPaddle: version.paddleProductIds ?? [],
                     productIdsPaddleWeb: version.webPaddleProductIds ?? [],
                     productIdsStripeWeb: version.webStripeProductIds ?? [],
-                    webPaywallBundleUrl: version.webPaywallBundleUrl
+                    webPaywallBundleUrl: version.webPaywallBundleUrl,
+                    shouldEnableScroll: version.shouldEnableScroll
                 )
 
                 guard !Task.isCancelled else {

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -1066,6 +1066,7 @@ public class HeliumFetchedConfigManager {
         productIdsPaddleWeb: [String],
         productIdsStripeWeb: [String],
         webPaywallBundleUrl: String? = nil,
+        shouldEnableScroll: Bool? = nil,
     ) throws {
         // Read-modify-write under the lock, so a fetch landing mid-update is not clobbered by the
         // write-back of a copy taken before it.
@@ -1083,7 +1084,8 @@ public class HeliumFetchedConfigManager {
                 productIdsPaddle: productIdsPaddle,
                 productIdsPaddleWeb: productIdsPaddleWeb,
                 productIdsStripeWeb: productIdsStripeWeb,
-                webPaywallBundleUrl: webPaywallBundleUrl
+                webPaywallBundleUrl: webPaywallBundleUrl,
+                shouldEnableScroll: shouldEnableScroll
             )
             stored = config
             return sourceTrigger
@@ -1091,7 +1093,12 @@ public class HeliumFetchedConfigManager {
 
         _fetchedConfigJSON.withValue { json in
             guard let configJSON = json else { return }
-            json = Self.withPreviewTrigger(configJSON, clonedFrom: sourceTrigger, bundleUrl: bundleUrl)
+            json = Self.withPreviewTrigger(
+                configJSON,
+                clonedFrom: sourceTrigger,
+                bundleUrl: bundleUrl,
+                shouldEnableScroll: shouldEnableScroll
+            )
         }
 
         isFallbackPreviewArmed = false
@@ -1109,7 +1116,8 @@ public class HeliumFetchedConfigManager {
         productIdsPaddle: [String],
         productIdsPaddleWeb: [String],
         productIdsStripeWeb: [String],
-        webPaywallBundleUrl: String?
+        webPaywallBundleUrl: String?,
+        shouldEnableScroll: Bool?
     ) throws -> String {
         guard let sourceTrigger = config.triggerToPaywalls.keys
             .filter({ $0 != HELIUM_PREVIEW_TRIGGER })
@@ -1127,6 +1135,10 @@ public class HeliumFetchedConfigManager {
             throw HeliumControlPanelError.invalidResolvedConfig
         }
         componentProps["bundleURL"] = bundleUrl
+        // The donor's scroll setting has no relation to the previewed paywall. Use the
+        // previewed version's own setting; when the preview response doesn't provide one,
+        // use the platform default (scroll enabled) rather than the donor's value.
+        componentProps["shouldEnableScroll"] = shouldEnableScroll ?? true
         baseStack["componentProps"] = componentProps
         resolvedConfigDict["baseStack"] = baseStack
         previewPaywallInfo.resolvedConfig = AnyCodable(resolvedConfigDict)
@@ -1167,11 +1179,13 @@ public class HeliumFetchedConfigManager {
     private static func withPreviewTrigger(
         _ configJSON: JSON,
         clonedFrom sourceTrigger: String,
-        bundleUrl: String
+        bundleUrl: String,
+        shouldEnableScroll: Bool?
     ) -> JSON {
         var configJSON = configJSON
         var sourceJSON = configJSON["triggerToPaywalls"][sourceTrigger]
         sourceJSON["resolvedConfig"]["baseStack"]["componentProps"]["bundleURL"] = JSON(bundleUrl)
+        sourceJSON["resolvedConfig"]["baseStack"]["componentProps"]["shouldEnableScroll"] = JSON(shouldEnableScroll ?? true)
         configJSON["triggerToPaywalls"][HELIUM_PREVIEW_TRIGGER] = sourceJSON
         return configJSON
     }

--- a/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
+++ b/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
@@ -26,7 +26,8 @@ final class PreviewTriggerConfigTests: XCTestCase {
         info.resolvedConfig = AnyCodable([
             "baseStack": [
                 "componentProps": [
-                    "bundleURL": donorBundleUrl
+                    "bundleURL": donorBundleUrl,
+                    "shouldEnableScroll": false
                 ]
             ]
         ] as [String: Any])
@@ -47,7 +48,8 @@ final class PreviewTriggerConfigTests: XCTestCase {
         productIdsPaddle: [String] = [],
         productIdsPaddleWeb: [String] = [],
         productIdsStripeWeb: [String] = [],
-        webPaywallBundleUrl: String? = nil
+        webPaywallBundleUrl: String? = nil,
+        shouldEnableScroll: Bool? = nil
     ) throws {
         try HeliumFetchedConfigManager.shared.setPreviewTriggerConfig(
             bundleId: "preview456",
@@ -58,12 +60,21 @@ final class PreviewTriggerConfigTests: XCTestCase {
             productIdsPaddle: productIdsPaddle,
             productIdsPaddleWeb: productIdsPaddleWeb,
             productIdsStripeWeb: productIdsStripeWeb,
-            webPaywallBundleUrl: webPaywallBundleUrl
+            webPaywallBundleUrl: webPaywallBundleUrl,
+            shouldEnableScroll: shouldEnableScroll
         )
     }
 
     private var previewInfo: HeliumPaywallInfo? {
         HeliumFetchedConfigManager.shared.fetchedConfig?.triggerToPaywalls[previewTrigger]
+    }
+
+    private var previewComponentProps: [String: Any]? {
+        guard let resolved = previewInfo?.resolvedConfig.value as? [String: Any],
+              let baseStack = resolved["baseStack"] as? [String: Any] else {
+            return nil
+        }
+        return baseStack["componentProps"] as? [String: Any]
     }
 
     func testPreviewDoesNotInheritWebCheckoutUrl() throws {
@@ -122,6 +133,34 @@ final class PreviewTriggerConfigTests: XCTestCase {
         )
     }
 
+    func testPreviewDoesNotInheritDonorScrollSetting() throws {
+        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
+
+        try setPreviewConfig()
+
+        XCTAssertEqual(previewComponentProps?["shouldEnableScroll"] as? Bool, true)
+    }
+
+    func testPreviewUsesProvidedScrollSetting() throws {
+        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
+
+        try setPreviewConfig(shouldEnableScroll: false)
+
+        XCTAssertEqual(previewComponentProps?["shouldEnableScroll"] as? Bool, false)
+    }
+
+    func testDonorTriggerKeepsItsScrollSetting() throws {
+        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
+
+        try setPreviewConfig()
+
+        let donorInfo = HeliumFetchedConfigManager.shared.fetchedConfig?.triggerToPaywalls["a_trigger"]
+        let donorResolved = donorInfo?.resolvedConfig.value as? [String: Any]
+        let donorBaseStack = donorResolved?["baseStack"] as? [String: Any]
+        let donorProps = donorBaseStack?["componentProps"] as? [String: Any]
+        XCTAssertEqual(donorProps?["shouldEnableScroll"] as? Bool, false)
+    }
+
     func testPreviewClearsForceShowFallback() throws {
         injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
 
@@ -166,6 +205,32 @@ final class PreviewTriggerConfigTests: XCTestCase {
         XCTAssertEqual(
             HeliumFetchedConfigManager.shared.getResolvedConfigJSONForTrigger(previewTrigger)?["baseStack"]["componentProps"]["bundleURL"].string,
             previewBundleUrl
+        )
+    }
+
+    func testJsonMirrorUpdatesScrollSetting() throws {
+        let config = makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()])
+        let configJSON = try JSON(data: JSONEncoder().encode(config))
+        injectConfig(config, json: configJSON)
+
+        try setPreviewConfig(shouldEnableScroll: false)
+
+        XCTAssertEqual(
+            HeliumFetchedConfigManager.shared.getResolvedConfigJSONForTrigger(previewTrigger)?["baseStack"]["componentProps"]["shouldEnableScroll"].bool,
+            false
+        )
+    }
+
+    func testJsonMirrorDoesNotInheritDonorScrollSetting() throws {
+        let config = makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()])
+        let configJSON = try JSON(data: JSONEncoder().encode(config))
+        injectConfig(config, json: configJSON)
+
+        try setPreviewConfig()
+
+        XCTAssertEqual(
+            HeliumFetchedConfigManager.shared.getResolvedConfigJSONForTrigger(previewTrigger)?["baseStack"]["componentProps"]["shouldEnableScroll"].bool,
+            true
         )
     }
 
@@ -226,6 +291,7 @@ final class PreviewTriggerConfigTests: XCTestCase {
               "paddleProductIds": ["pro_01knraky336brhcn1r0atkk2ac:pri_01knrarqkpxk9kvf785tny0y5e"],
               "webPaddleProductIds": ["pro_01kppzadma4mq2yx61e5spzgxe:pri_01kpsgnvzp69jyatar1znzxtex"],
               "webPaywallBundleUrl": "https://bundles-staging.clickthrough.to/x/bundle_1778610753360.html",
+              "shouldEnableScroll": false,
               "lastSavedAt": "2026-05-12T18:38:24.345+00:00"
             },
             {
@@ -259,7 +325,9 @@ final class PreviewTriggerConfigTests: XCTestCase {
             "https://bundles-staging.clickthrough.to/x/bundle_1778610753360.html"
         )
         XCTAssertEqual(versions[0].webPaddleProductIds, ["pro_01kppzadma4mq2yx61e5spzgxe:pri_01kpsgnvzp69jyatar1znzxtex"])
+        XCTAssertEqual(versions[0].shouldEnableScroll, false)
         XCTAssertNil(versions[1].webPaywallBundleUrl)
+        XCTAssertNil(versions[1].shouldEnableScroll)
     }
 
     func testDecodesLegacyPreviewsResponseWithoutNewFields() throws {
@@ -297,6 +365,7 @@ final class PreviewTriggerConfigTests: XCTestCase {
 
         XCTAssertNil(response.paywalls[0].versions[0].webPaywallBundleUrl)
         XCTAssertNil(response.paywalls[0].versions[0].paddleProductIds)
+        XCTAssertNil(response.paywalls[0].versions[0].shouldEnableScroll)
         XCTAssertFalse(response.paywalls[0].isWebPaywall)
     }
 


### PR DESCRIPTION
## What

Triple-tap paywall previews now respect the previewed paywall's scroll-lock setting instead of scrolling (or not) based on an unrelated paywall's config.

## Why (root cause)

The preview trigger is installed by cloning the alphabetically-first existing trigger's config and swapping in only the bundle URL and products. `shouldEnableScroll` lives in the cloned `componentProps`, so the preview rendered with the donor trigger's scroll setting rather than the previewed paywall's own.

## Fix

- Decode an optional per-version `shouldEnableScroll` from the paywall-previews response.
- `setPreviewTriggerConfig` sets it explicitly on the cloned `componentProps` in both the typed config and the JSON mirror, so the donor's value never leaks. When the response doesn't provide the field, the preview uses the platform default (scroll enabled) — same default the renderer applies to unspecified config.

Note: the previews endpoint doesn't return this field yet; until it does, previews are deterministic (default) rather than donor-dependent, and pick up the real setting as soon as the endpoint sends it.

## Tests

- Preview does not inherit the donor's scroll setting (typed config + JSON mirror).
- Response-provided value is applied; donor keeps its own setting.
- Response decoding with the new field, plus legacy responses without it.
- Full unit suite: 352 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to debug/TestFlight preview trigger setup; no production paywall fetch path changes beyond optional API decoding.
> 
> **Overview**
> Triple-tap **paywall previews** now use the previewed version’s **`shouldEnableScroll`** instead of inheriting scroll-lock from the alphabetically first “donor” trigger when the preview config is cloned.
> 
> The control panel decodes optional **`shouldEnableScroll`** per preview version and passes it into **`setPreviewTriggerConfig`**, which writes **`componentProps.shouldEnableScroll`** on both the typed config and the JSON mirror (default **`true`** when the API omits the field, matching the renderer). Until the previews endpoint sends the field, behavior is deterministic scroll-on rather than donor-dependent.
> 
> Tests cover donor isolation, explicit values, JSON mirror updates, and legacy response decoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f159c55f35ed8f6921acc90cf19bebe5b339f515. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable scrolling for paywall previews.
  - Preview versions can explicitly enable or disable scrolling independently of the source paywall.
  - When no setting is provided, preview scrolling is enabled by default.
- **Bug Fixes**
  - Preview configurations now consistently preserve their own scroll settings without inheriting unintended values from the source paywall.
  - Existing preview responses remain compatible when the new setting is absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->