### PR TITLE
[SDK-43] | Soften default restore dialog wording so no-purchases-found reads as informational

### DIFF
--- a/Sources/Helium/RestorePurchaseConfig.swift
+++ b/Sources/Helium/RestorePurchaseConfig.swift
@@ -10,8 +10,8 @@ public class RestorePurchaseConfig {
     
     // Default values
     private static let defaultShowHeliumDialog = true
-    private static let defaultRestoreFailedTitle = "Restore Failed"
-    private static let defaultRestoreFailedMessage = "We couldn't find any previous purchases to restore."
+    private static let defaultRestoreFailedTitle = "No Purchases Found"
+    private static let defaultRestoreFailedMessage = "We couldn't find any previous purchases to restore. If you've purchased before, make sure you're signed in with the same account you used for the original purchase."
     private static let defaultRestoreFailedCloseButtonText = "OK"
 
     private(set) var showHeliumDialog: Bool = defaultShowHeliumDialog


### PR DESCRIPTION
## What

Changes the default copy of the dialog shown when "Restore Purchases" finds nothing to restore:

- Title: `Restore Failed` → `No Purchases Found`
- Message: `We couldn't find any previous purchases to restore.` → `We couldn't find any previous purchases to restore. If you've purchased before, make sure you're signed in with the same account you used for the original purchase.`

Close button text (`OK`) is unchanged.

## Why

This dialog shows whenever restore completes with no entitlements found — the expected outcome for a user with nothing to restore. The "Restore Failed" title framed that normal result as an error and was being reported as a restore bug. The added sentence gives users the most common actual fix (wrong store account) as a self-service next step.

## Fix

Default string values only, in `RestorePurchaseConfig.swift`. No logic changes; the `setCustomRestoreFailedStrings` override and property names are untouched.

## Tests

None added — string-literal change with no behavior impact; nothing asserts the old defaults.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing default strings only in `RestorePurchaseConfig`; restore flow and customization APIs are untouched.
> 
> **Overview**
> Updates the **default** Helium restore dialog strings in `RestorePurchaseConfig` so an empty restore reads as informational rather than a failure.
> 
> The default title changes from **Restore Failed** to **No Purchases Found**, and the default message adds guidance to sign in with the same store account used for the original purchase. The **OK** close label and all restore/dialog logic (`showHeliumDialog`, `setCustomRestoreFailedStrings`, `reset`) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9827922ee1152df9b156985ce6c09e39fd731c89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->