### PR TITLE
Open paywall navigate links in-app via SDK config

### DIFF
--- a/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
@@ -244,18 +244,13 @@ extension WebViewMessageHandler: WKNavigationDelegate {
         HeliumLogger.log(.trace, category: .ui, "WebView did commit navigation")
     }
     
-    private func shouldOpenExternally(url: URL) -> Bool {
-        // For now, open all urls externally.
-        return true;
-    }
-
     func webView(
         _ webView: WKWebView,
         decidePolicyFor navigationAction: WKNavigationAction,
         decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
     ) {
         if navigationAction.navigationType == .linkActivated,
-           let url = navigationAction.request.url, shouldOpenExternally(url: url) {
+           let url = navigationAction.request.url {
             Task { @MainActor in
                 self.openPaywallLink(url)
             }

--- a/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SafariServices
 import WebKit
 
 
@@ -117,7 +118,7 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
                     respond(["status": "error", "message": "Missing or invalid target"])
                     break
                 }
-                await UIApplication.shared.open(url)
+                self.openPaywallLink(url)
                 respond(["status": "success"])
                 
             case "show-secondary-paywall":
@@ -151,6 +152,22 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
         }
     }
     
+    /// Opens a link tapped in the paywall. When `Helium.config.openPaywallLinksInApp` is enabled,
+    /// http/https links are shown in an in-app browser presented over the paywall; all other
+    /// schemes (and any link when the in-app browser can't be presented) open externally.
+    @MainActor
+    func openPaywallLink(_ url: URL) {
+        if Helium.config.openPaywallLinksInApp,
+           let scheme = url.scheme?.lowercased(),
+           scheme == "http" || scheme == "https",
+           let presenter = UIWindowHelper.findTopMostViewController() {
+            let safariViewController = SFSafariViewController(url: url)
+            presenter.present(safariViewController, animated: true)
+        } else {
+            UIApplication.shared.open(url)
+        }
+    }
+
     /// Converts Objective-C types from JavaScript bridge to native Swift types
     private func convertToSwiftTypes(_ value: Any) -> Any {
         // Handle NSArray -> Swift Array
@@ -209,7 +226,7 @@ extension WebViewMessageHandler: WKNavigationDelegate {
         // For now, open all urls externally.
         return true;
     }
-    
+
     func webView(
         _ webView: WKWebView,
         decidePolicyFor navigationAction: WKNavigationAction,
@@ -217,7 +234,9 @@ extension WebViewMessageHandler: WKNavigationDelegate {
     ) {
         if navigationAction.navigationType == .linkActivated,
            let url = navigationAction.request.url, shouldOpenExternally(url: url) {
-            UIApplication.shared.open(url);
+            Task { @MainActor in
+                self.openPaywallLink(url)
+            }
             decisionHandler(.cancel)
         } else {
             decisionHandler(.allow)

--- a/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
@@ -152,9 +152,9 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
         }
     }
     
-    /// Opens a link tapped in the paywall. When `Helium.config.openPaywallLinksInApp` is enabled,
-    /// http/https links are shown in an in-app browser presented over the paywall; all other
-    /// schemes (and any link when the in-app browser can't be presented) open externally.
+    /// Opens a link tapped in the paywall. When `Helium.config.openPaywallLinksInApp` is enabled
+    /// (the default), http/https links are shown in an in-app browser presented over the paywall;
+    /// all other schemes (and any link when the in-app browser can't be presented) open externally.
     @MainActor
     func openPaywallLink(_ url: URL) {
         let scope = delegateWrapper?.observabilityScope

--- a/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
@@ -115,6 +115,12 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
             case "navigate":
                 guard let target = data["target"] as? String,
                       let url = URL(string: target) else {
+                    // Unopenable targets still count as a failed link open, so broken paywall
+                    // content shows up in the observability pipeline.
+                    HeliumObservabilityManager.shared.track(
+                        PaywallLinkOpenAttempted(openedInApp: false, success: false, scheme: nil, url: nil),
+                        scope: self.delegateWrapper?.observabilityScope
+                    )
                     respond(["status": "error", "message": "Missing or invalid target"])
                     break
                 }
@@ -167,11 +173,13 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
             // As a page sheet the browser slides up over the paywall; SFSafariViewController's
             // default full-screen presentation animates sideways like a navigation push instead.
             safariViewController.modalPresentationStyle = .pageSheet
-            presenter.present(safariViewController, animated: true)
-            HeliumObservabilityManager.shared.track(
-                PaywallLinkOpenAttempted(openedInApp: true, success: true, scheme: scheme, url: reportedURL),
-                scope: scope
-            )
+            presenter.present(safariViewController, animated: true) {
+                let success = safariViewController.presentingViewController != nil
+                HeliumObservabilityManager.shared.track(
+                    PaywallLinkOpenAttempted(openedInApp: true, success: success, scheme: scheme, url: reportedURL),
+                    scope: scope
+                )
+            }
         } else {
             UIApplication.shared.open(url, options: [:]) { opened in
                 HeliumObservabilityManager.shared.track(

--- a/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
@@ -124,7 +124,7 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
                     respond(["status": "error", "message": "Missing or invalid target"])
                     break
                 }
-                self.openPaywallLink(url)
+                self.openPaywallLink(url, allowInApp: true)
                 respond(["status": "success"])
                 
             case "show-secondary-paywall":
@@ -158,15 +158,16 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
         }
     }
     
-    /// Opens a link tapped in the paywall. When `Helium.config.openPaywallLinksInApp` is enabled
-    /// (the default), http/https links are shown in an in-app browser presented over the paywall;
-    /// all other schemes (and any link when the in-app browser can't be presented) open externally.
+    /// Opens a link from the paywall. A link is shown in an in-app browser presented over the
+    /// paywall only when the caller allows it, `Helium.config.openPaywallLinksInApp` is enabled
+    /// (the default), and the URL is http/https; every other link opens externally.
     @MainActor
-    func openPaywallLink(_ url: URL) {
+    func openPaywallLink(_ url: URL, allowInApp: Bool) {
         let scope = delegateWrapper?.observabilityScope
         let scheme = url.scheme?.lowercased()
         let reportedURL = urlForObservability(url)
-        if Helium.config.openPaywallLinksInApp,
+        if allowInApp,
+           Helium.config.openPaywallLinksInApp,
            scheme == "http" || scheme == "https",
            let presenter = UIWindowHelper.findTopMostViewController() {
             let safariViewController = SFSafariViewController(url: url)
@@ -252,7 +253,7 @@ extension WebViewMessageHandler: WKNavigationDelegate {
         if navigationAction.navigationType == .linkActivated,
            let url = navigationAction.request.url {
             Task { @MainActor in
-                self.openPaywallLink(url)
+                self.openPaywallLink(url, allowInApp: false)
             }
             decisionHandler(.cancel)
         } else {

--- a/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
@@ -164,6 +164,9 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
            scheme == "http" || scheme == "https",
            let presenter = UIWindowHelper.findTopMostViewController() {
             let safariViewController = SFSafariViewController(url: url)
+            // As a page sheet the browser slides up over the paywall; SFSafariViewController's
+            // default full-screen presentation animates sideways like a navigation push instead.
+            safariViewController.modalPresentationStyle = .pageSheet
             presenter.present(safariViewController, animated: true)
             HeliumObservabilityManager.shared.track(
                 PaywallLinkOpenAttempted(openedInApp: true, success: true, scheme: scheme, url: reportedURL),

--- a/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
@@ -159,19 +159,20 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
     func openPaywallLink(_ url: URL) {
         let scope = delegateWrapper?.observabilityScope
         let scheme = url.scheme?.lowercased()
+        let reportedURL = urlForObservability(url)
         if Helium.config.openPaywallLinksInApp,
            scheme == "http" || scheme == "https",
            let presenter = UIWindowHelper.findTopMostViewController() {
             let safariViewController = SFSafariViewController(url: url)
             presenter.present(safariViewController, animated: true)
             HeliumObservabilityManager.shared.track(
-                PaywallLinkOpenAttempted(openedInApp: true, success: true, scheme: scheme),
+                PaywallLinkOpenAttempted(openedInApp: true, success: true, scheme: scheme, url: reportedURL),
                 scope: scope
             )
         } else {
             UIApplication.shared.open(url, options: [:]) { opened in
                 HeliumObservabilityManager.shared.track(
-                    PaywallLinkOpenAttempted(openedInApp: false, success: opened, scheme: scheme),
+                    PaywallLinkOpenAttempted(openedInApp: false, success: opened, scheme: scheme, url: reportedURL),
                     scope: scope
                 )
             }

--- a/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
@@ -157,14 +157,24 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
     /// schemes (and any link when the in-app browser can't be presented) open externally.
     @MainActor
     func openPaywallLink(_ url: URL) {
+        let scope = delegateWrapper?.observabilityScope
+        let scheme = url.scheme?.lowercased()
         if Helium.config.openPaywallLinksInApp,
-           let scheme = url.scheme?.lowercased(),
            scheme == "http" || scheme == "https",
            let presenter = UIWindowHelper.findTopMostViewController() {
             let safariViewController = SFSafariViewController(url: url)
             presenter.present(safariViewController, animated: true)
+            HeliumObservabilityManager.shared.track(
+                PaywallLinkOpenAttempted(openedInApp: true, success: true, scheme: scheme),
+                scope: scope
+            )
         } else {
-            UIApplication.shared.open(url)
+            UIApplication.shared.open(url, options: [:]) { opened in
+                HeliumObservabilityManager.shared.track(
+                    PaywallLinkOpenAttempted(openedInApp: false, success: opened, scheme: scheme),
+                    scope: scope
+                )
+            }
         }
     }
 

--- a/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
@@ -118,13 +118,13 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
                     // Unopenable targets still count as a failed link open, so broken paywall
                     // content shows up in the observability pipeline.
                     HeliumObservabilityManager.shared.track(
-                        PaywallLinkOpenAttempted(openedInApp: false, success: false, scheme: nil, url: nil),
+                        PaywallLinkOpenAttempted(source: .navigate, openedInApp: false, success: false, scheme: nil, url: nil),
                         scope: self.delegateWrapper?.observabilityScope
                     )
                     respond(["status": "error", "message": "Missing or invalid target"])
                     break
                 }
-                self.openPaywallLink(url, allowInApp: true)
+                self.openPaywallLink(url, source: .navigate)
                 respond(["status": "success"])
                 
             case "show-secondary-paywall":
@@ -158,15 +158,15 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
         }
     }
     
-    /// Opens a link from the paywall. A link is shown in an in-app browser presented over the
-    /// paywall only when the caller allows it, `Helium.config.openPaywallLinksInApp` is enabled
-    /// (the default), and the URL is http/https; every other link opens externally.
+    /// Opens a link from the paywall. A navigate-sourced link is shown in an in-app browser
+    /// presented over the paywall when `Helium.config.openPaywallLinksInApp` is enabled (the
+    /// default) and the URL is http/https; every other link opens externally.
     @MainActor
-    func openPaywallLink(_ url: URL, allowInApp: Bool) {
+    func openPaywallLink(_ url: URL, source: PaywallLinkSource) {
         let scope = delegateWrapper?.observabilityScope
         let scheme = url.scheme?.lowercased()
         let reportedURL = urlForObservability(url)
-        if allowInApp,
+        if source == .navigate,
            Helium.config.openPaywallLinksInApp,
            scheme == "http" || scheme == "https",
            let presenter = UIWindowHelper.findTopMostViewController() {
@@ -177,14 +177,14 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
             presenter.present(safariViewController, animated: true) {
                 let success = safariViewController.presentingViewController != nil
                 HeliumObservabilityManager.shared.track(
-                    PaywallLinkOpenAttempted(openedInApp: true, success: success, scheme: scheme, url: reportedURL),
+                    PaywallLinkOpenAttempted(source: source, openedInApp: true, success: success, scheme: scheme, url: reportedURL),
                     scope: scope
                 )
             }
         } else {
             UIApplication.shared.open(url, options: [:]) { opened in
                 HeliumObservabilityManager.shared.track(
-                    PaywallLinkOpenAttempted(openedInApp: false, success: opened, scheme: scheme, url: reportedURL),
+                    PaywallLinkOpenAttempted(source: source, openedInApp: false, success: opened, scheme: scheme, url: reportedURL),
                     scope: scope
                 )
             }
@@ -253,7 +253,7 @@ extension WebViewMessageHandler: WKNavigationDelegate {
         if navigationAction.navigationType == .linkActivated,
            let url = navigationAction.request.url {
             Task { @MainActor in
-                self.openPaywallLink(url, allowInApp: false)
+                self.openPaywallLink(url, source: .anchor)
             }
             decisionHandler(.cancel)
         } else {

--- a/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
@@ -43,6 +43,10 @@ class ActionsDelegateWrapper: ObservableObject {
         delegate.paywallInfo.productHapticsEnabled ?? []
     }
 
+    var observabilityScope: PaywallObservabilityScope {
+        delegate.paywallSession.observabilityScope
+    }
+
     func dismiss(dispatchEvent: Bool = true) {
         delegate.dismiss(dispatchEvent: dispatchEvent)
     }

--- a/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
+++ b/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
@@ -14,6 +14,11 @@ func truncatedForObservability(_ s: String?, maxLength: Int = 500) -> String? {
     return String(s.prefix(maxLength)) + "…(truncated)"
 }
 
+/// Cuts a URL at its query/fragment, which can carry user data.
+func urlForObservability(_ url: URL) -> String {
+    String(url.absoluteString.prefix { $0 != "?" && $0 != "#" })
+}
+
 func msSince(_ start: Date) -> Int {
     Int(Date().timeIntervalSince(start) * 1000)
 }
@@ -224,17 +229,19 @@ struct WebCheckoutBrowserOpenAttempted: HeliumObservabilityEvent {
 
 /// A link tapped in paywall content was handed off to a browser — in-app
 /// (`SFSafariViewController`) when `openPaywallLinksInApp` is enabled for a web URL,
-/// external otherwise. Only the scheme is reported; full URLs stay out of the pipeline
-/// since their query strings can carry user data.
+/// external otherwise. The reported URL is cut at its query/fragment, which can carry
+/// user data.
 struct PaywallLinkOpenAttempted: HeliumObservabilityEvent {
     let openedInApp: Bool
     let success: Bool
     let scheme: String?
+    let url: String?
 
     var name: String { "paywall_link_open_attempted" }
     var properties: [String: Any] {
         var p: [String: Any] = ["openedInApp": openedInApp, "success": success]
         if let scheme { p["scheme"] = scheme }
+        if let url { p["url"] = url }
         return p
     }
 }

--- a/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
+++ b/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
@@ -227,10 +227,11 @@ struct WebCheckoutBrowserOpenAttempted: HeliumObservabilityEvent {
     }
 }
 
-/// A link tapped in paywall content was handed off to a browser — in-app
-/// (`SFSafariViewController`) when `openPaywallLinksInApp` is enabled for a web URL,
-/// external otherwise. The reported URL is cut at its query/fragment, which can carry
-/// user data.
+/// A link tapped in paywall content was handed off to an in-app browser
+/// (`SFSafariViewController`) or an external app — in-app when `openPaywallLinksInApp`
+/// is enabled (the default) for a web URL, external otherwise (including non-web schemes
+/// like `mailto:` and `tel:`). The reported URL is cut at its query/fragment, which can
+/// carry user data.
 struct PaywallLinkOpenAttempted: HeliumObservabilityEvent {
     let openedInApp: Bool
     let success: Bool

--- a/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
+++ b/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
@@ -227,12 +227,19 @@ struct WebCheckoutBrowserOpenAttempted: HeliumObservabilityEvent {
     }
 }
 
-/// A link tapped in paywall content was handed off to an in-app browser
-/// (`SFSafariViewController`) or an external app — in-app when `openPaywallLinksInApp`
-/// is enabled (the default) for a web URL, external otherwise (including non-web schemes
-/// like `mailto:` and `tel:`). The reported URL is cut at its query/fragment, which can
-/// carry user data.
+/// How a paywall link was requested: the paywall's explicit navigate action, or a tapped
+/// HTML anchor. Only navigate links may open in-app.
+enum PaywallLinkSource: String {
+    case navigate, anchor
+}
+
+/// A link in paywall content was handed off to an in-app browser
+/// (`SFSafariViewController`) or an external app — in-app when the source is navigate,
+/// `openPaywallLinksInApp` is enabled (the default), and the URL is a web URL; external
+/// otherwise (including non-web schemes like `mailto:` and `tel:`). The reported URL is
+/// cut at its query/fragment, which can carry user data.
 struct PaywallLinkOpenAttempted: HeliumObservabilityEvent {
+    let source: PaywallLinkSource
     let openedInApp: Bool
     let success: Bool
     let scheme: String?
@@ -240,7 +247,7 @@ struct PaywallLinkOpenAttempted: HeliumObservabilityEvent {
 
     var name: String { "paywall_link_open_attempted" }
     var properties: [String: Any] {
-        var p: [String: Any] = ["openedInApp": openedInApp, "success": success]
+        var p: [String: Any] = ["source": source.rawValue, "openedInApp": openedInApp, "success": success]
         if let scheme { p["scheme"] = scheme }
         if let url { p["url"] = url }
         return p

--- a/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
+++ b/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
@@ -222,6 +222,23 @@ struct WebCheckoutBrowserOpenAttempted: HeliumObservabilityEvent {
     }
 }
 
+/// A link tapped in paywall content was handed off to a browser — in-app
+/// (`SFSafariViewController`) when `openPaywallLinksInApp` is enabled for a web URL,
+/// external otherwise. Only the scheme is reported; full URLs stay out of the pipeline
+/// since their query strings can carry user data.
+struct PaywallLinkOpenAttempted: HeliumObservabilityEvent {
+    let openedInApp: Bool
+    let success: Bool
+    let scheme: String?
+
+    var name: String { "paywall_link_open_attempted" }
+    var properties: [String: Any] {
+        var p: [String: Any] = ["openedInApp": openedInApp, "success": success]
+        if let scheme { p["scheme"] = scheme }
+        return p
+    }
+}
+
 struct WebCheckoutRedirectReceived: HeliumObservabilityEvent {
     let provider: String
     let redirectKind: String

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -721,6 +721,14 @@ public class HeliumConfig {
     /// Defaults to `true`.
     public var paywallPreviewsAutoEnabledInDevBuilds: Bool = true
 
+    /// Opens http/https links tapped in paywalls in an in-app browser (`SFSafariViewController`)
+    /// presented over the paywall, instead of leaving the app for the external browser.
+    ///
+    /// Links with other schemes (e.g. `mailto:`, `tel:`, custom app schemes) always open externally.
+    ///
+    /// Defaults to `false` (links open in the external browser).
+    public var openPaywallLinksInApp: Bool = false
+
     // MARK: - External Web Checkout Configuration
 
     /// Which External Web Checkout payment processors are enabled. Empty means disabled.

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -722,7 +722,7 @@ public class HeliumConfig {
     public var paywallPreviewsAutoEnabledInDevBuilds: Bool = true
 
     /// Opens http/https links tapped in paywalls in an in-app browser (`SFSafariViewController`)
-    /// presented over the paywall, instead of leaving the app for the external browser.
+    /// presented over the paywall, instead of in an external browser.
     ///
     /// Links with other schemes (e.g. `mailto:`, `tel:`, custom app schemes) always open externally.
     ///

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -721,12 +721,13 @@ public class HeliumConfig {
     /// Defaults to `true`.
     public var paywallPreviewsAutoEnabledInDevBuilds: Bool = true
 
-    /// Opens http/https links tapped in paywalls in an in-app browser (`SFSafariViewController`)
-    /// presented over the paywall, instead of in an external browser.
+    /// Opens http/https links that paywalls request via their navigate action in an in-app browser
+    /// (`SFSafariViewController`) presented over the paywall, instead of in an external browser.
     ///
-    /// Links with other schemes (e.g. `mailto:`, `tel:`, custom app schemes) always open externally.
+    /// Links with other schemes (e.g. `mailto:`, `tel:`, custom app schemes) always open
+    /// externally, as does direct HTML navigation in paywall content.
     ///
-    /// Defaults to `true`. Set to `false` to open links in the external browser instead.
+    /// Defaults to `true`. Set to `false` to open navigate links in the external browser instead.
     public var openPaywallLinksInApp: Bool = true
 
     // MARK: - External Web Checkout Configuration

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -726,8 +726,8 @@ public class HeliumConfig {
     ///
     /// Links with other schemes (e.g. `mailto:`, `tel:`, custom app schemes) always open externally.
     ///
-    /// Defaults to `false` (links open in the external browser).
-    public var openPaywallLinksInApp: Bool = false
+    /// Defaults to `true`. Set to `false` to open links in the external browser instead.
+    public var openPaywallLinksInApp: Bool = true
 
     // MARK: - External Web Checkout Configuration
 

--- a/Tests/helium-swiftTests/HeliumObservabilityEventsTests.swift
+++ b/Tests/helium-swiftTests/HeliumObservabilityEventsTests.swift
@@ -21,21 +21,34 @@ final class HeliumObservabilityEventsTests: XCTestCase {
 
     // MARK: - PaywallLinkOpenAttempted
 
-    func testPaywallLinkOpenCarriesDestinationSuccessAndScheme() throws {
-        let event = PaywallLinkOpenAttempted(openedInApp: true, success: true, scheme: "https")
+    func testPaywallLinkOpenCarriesDestinationSuccessSchemeAndUrl() throws {
+        let event = PaywallLinkOpenAttempted(
+            openedInApp: true,
+            success: true,
+            scheme: "https",
+            url: "https://tryhelium.com/pricing"
+        )
 
         XCTAssertEqual(event.name, "paywall_link_open_attempted")
         XCTAssertEqual(try wireProperties(for: event), NSDictionary(dictionary: [
             "openedInApp": true,
             "success": true,
             "scheme": "https",
+            "url": "https://tryhelium.com/pricing",
         ]))
     }
 
-    func testPaywallLinkOpenWithoutASchemeOmitsTheKey() throws {
-        let event = PaywallLinkOpenAttempted(openedInApp: false, success: false, scheme: nil)
+    func testPaywallLinkOpenWithoutASchemeOmitsTheOptionalKeys() throws {
+        let event = PaywallLinkOpenAttempted(openedInApp: false, success: false, scheme: nil, url: nil)
 
         XCTAssertNil(try wireProperties(for: event)["scheme"])
+        XCTAssertNil(try wireProperties(for: event)["url"])
+    }
+
+    func testUrlForObservabilityCutsQueryAndFragment() throws {
+        let url = try XCTUnwrap(URL(string: "https://tryhelium.com/pricing?token=abc123#section"))
+
+        XCTAssertEqual(urlForObservability(url), "https://tryhelium.com/pricing")
     }
 
     // MARK: - FallbackPaywallsConfigured

--- a/Tests/helium-swiftTests/HeliumObservabilityEventsTests.swift
+++ b/Tests/helium-swiftTests/HeliumObservabilityEventsTests.swift
@@ -19,6 +19,25 @@ final class HeliumObservabilityEventsTests: XCTestCase {
         return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? NSDictionary)
     }
 
+    // MARK: - PaywallLinkOpenAttempted
+
+    func testPaywallLinkOpenCarriesDestinationSuccessAndScheme() throws {
+        let event = PaywallLinkOpenAttempted(openedInApp: true, success: true, scheme: "https")
+
+        XCTAssertEqual(event.name, "paywall_link_open_attempted")
+        XCTAssertEqual(try wireProperties(for: event), NSDictionary(dictionary: [
+            "openedInApp": true,
+            "success": true,
+            "scheme": "https",
+        ]))
+    }
+
+    func testPaywallLinkOpenWithoutASchemeOmitsTheKey() throws {
+        let event = PaywallLinkOpenAttempted(openedInApp: false, success: false, scheme: nil)
+
+        XCTAssertNil(try wireProperties(for: event)["scheme"])
+    }
+
     // MARK: - FallbackPaywallsConfigured
 
     func testFullyPopulatedBundleCarriesGeneratedAtOrgDefaultUUIDCountAndMap() throws {

--- a/Tests/helium-swiftTests/HeliumObservabilityEventsTests.swift
+++ b/Tests/helium-swiftTests/HeliumObservabilityEventsTests.swift
@@ -21,8 +21,9 @@ final class HeliumObservabilityEventsTests: XCTestCase {
 
     // MARK: - PaywallLinkOpenAttempted
 
-    func testPaywallLinkOpenCarriesDestinationSuccessSchemeAndUrl() throws {
+    func testPaywallLinkOpenCarriesSourceDestinationSuccessSchemeAndUrl() throws {
         let event = PaywallLinkOpenAttempted(
+            source: .navigate,
             openedInApp: true,
             success: true,
             scheme: "https",
@@ -31,6 +32,7 @@ final class HeliumObservabilityEventsTests: XCTestCase {
 
         XCTAssertEqual(event.name, "paywall_link_open_attempted")
         XCTAssertEqual(try wireProperties(for: event), NSDictionary(dictionary: [
+            "source": "navigate",
             "openedInApp": true,
             "success": true,
             "scheme": "https",
@@ -39,9 +41,10 @@ final class HeliumObservabilityEventsTests: XCTestCase {
     }
 
     func testPaywallLinkOpenWithoutASchemeOmitsTheOptionalKeys() throws {
-        let event = PaywallLinkOpenAttempted(openedInApp: false, success: false, scheme: nil, url: nil)
+        let event = PaywallLinkOpenAttempted(source: .anchor, openedInApp: false, success: false, scheme: nil, url: nil)
 
         XCTAssertEqual(try wireProperties(for: event), NSDictionary(dictionary: [
+            "source": "anchor",
             "openedInApp": false,
             "success": false,
         ]))

--- a/Tests/helium-swiftTests/HeliumObservabilityEventsTests.swift
+++ b/Tests/helium-swiftTests/HeliumObservabilityEventsTests.swift
@@ -41,8 +41,10 @@ final class HeliumObservabilityEventsTests: XCTestCase {
     func testPaywallLinkOpenWithoutASchemeOmitsTheOptionalKeys() throws {
         let event = PaywallLinkOpenAttempted(openedInApp: false, success: false, scheme: nil, url: nil)
 
-        XCTAssertNil(try wireProperties(for: event)["scheme"])
-        XCTAssertNil(try wireProperties(for: event)["url"])
+        XCTAssertEqual(try wireProperties(for: event), NSDictionary(dictionary: [
+            "openedInApp": false,
+            "success": false,
+        ]))
     }
 
     func testUrlForObservabilityCutsQueryAndFragment() throws {


### PR DESCRIPTION
Adds `Helium.config.openPaywallLinksInApp` (default `true`). When enabled, http/https links that paywalls request via their **navigate action** open in an `SFSafariViewController` presented as a page sheet sliding up over the paywall, instead of leaving the app. Direct HTML navigation in paywall content and non-web schemes (`mailto:`, `tel:`, custom app schemes) keep opening externally, and the Stripe/Paddle external-checkout flow is untouched.

Also adds a `paywall_link_open_attempted` observability event (`openedInApp` / `success` / `scheme` / `url` cut at its query/fragment, plus paywall session scope), covering completed, failed, and invalid-target opens. Nothing added to the analytics pipeline, so no new ClickHouse columns.

Consolidates the HEL-6221 follow-up work (in-app default, page-sheet presentation, accurate open tracking) that briefly lived on #323 — that PR is closed as a duplicate.

Android counterpart: cloudcaptainai/helium-android#333

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default paywall link UX and modal presentation on top of the paywall; observability and config are additive, but regressions could affect navigation flows or external-only expectations when config is off.
> 
> **Overview**
> Adds **`Helium.config.openPaywallLinksInApp`** (default **`true`**). Paywall **navigate** actions for **http/https** URLs now open in **`SFSafariViewController`** as a **page sheet** over the paywall instead of always leaving the app.
> 
> **Anchor** taps in paywall HTML and non-web schemes still use **`UIApplication.shared.open`**. Invalid navigate targets are tracked as failed opens.
> 
> Link handling is centralized in **`openPaywallLink`**, replacing the navigation delegate’s “always external” behavior. Observability adds **`paywall_link_open_attempted`** (source, in-app vs external, success, scheme, URL without query/fragment) scoped to the paywall session via **`ActionsDelegateWrapper.observabilityScope`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d84331f210214dd2e7ee65f18c96377ca27a94b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Paywall HTTP/HTTPS links can now open in an in-app Safari view.
  - Added a configuration option to use the external browser instead; in-app opening is enabled by default.
  - Non-web links and unsupported navigation continue opening externally.

- **Bug Fixes**
  - Improved handling of invalid or unavailable navigation targets.

- **Observability**
  - Enhanced tracking for link-opening attempts, outcomes, sources, and sanitized URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->