### PR TITLE
Open paywall navigate links in-app

### DIFF
--- a/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SafariServices
 import WebKit
 
 
@@ -117,7 +118,7 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
                     respond(["status": "error", "message": "Missing or invalid target"])
                     break
                 }
-                await UIApplication.shared.open(url)
+                self.openPaywallLink(url)
                 respond(["status": "success"])
                 
             case "show-secondary-paywall":
@@ -151,6 +152,22 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
         }
     }
     
+    /// Opens a link tapped in the paywall. When `Helium.config.openPaywallLinksInApp` is enabled,
+    /// http/https links are shown in an in-app browser presented over the paywall; all other
+    /// schemes (and any link when the in-app browser can't be presented) open externally.
+    @MainActor
+    func openPaywallLink(_ url: URL) {
+        if Helium.config.openPaywallLinksInApp,
+           let scheme = url.scheme?.lowercased(),
+           scheme == "http" || scheme == "https",
+           let presenter = UIWindowHelper.findTopMostViewController() {
+            let safariViewController = SFSafariViewController(url: url)
+            presenter.present(safariViewController, animated: true)
+        } else {
+            UIApplication.shared.open(url)
+        }
+    }
+
     /// Converts Objective-C types from JavaScript bridge to native Swift types
     private func convertToSwiftTypes(_ value: Any) -> Any {
         // Handle NSArray -> Swift Array
@@ -209,7 +226,7 @@ extension WebViewMessageHandler: WKNavigationDelegate {
         // For now, open all urls externally.
         return true;
     }
-    
+
     func webView(
         _ webView: WKWebView,
         decidePolicyFor navigationAction: WKNavigationAction,
@@ -217,7 +234,9 @@ extension WebViewMessageHandler: WKNavigationDelegate {
     ) {
         if navigationAction.navigationType == .linkActivated,
            let url = navigationAction.request.url, shouldOpenExternally(url: url) {
-            UIApplication.shared.open(url);
+            Task { @MainActor in
+                self.openPaywallLink(url)
+            }
             decisionHandler(.cancel)
         } else {
             decisionHandler(.allow)

--- a/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
@@ -152,9 +152,9 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
         }
     }
     
-    /// Opens a link tapped in the paywall. When `Helium.config.openPaywallLinksInApp` is enabled,
-    /// http/https links are shown in an in-app browser presented over the paywall; all other
-    /// schemes (and any link when the in-app browser can't be presented) open externally.
+    /// Opens a link tapped in the paywall. When `Helium.config.openPaywallLinksInApp` is enabled
+    /// (the default), http/https links are shown in an in-app browser presented over the paywall;
+    /// all other schemes (and any link when the in-app browser can't be presented) open externally.
     @MainActor
     func openPaywallLink(_ url: URL) {
         let scope = delegateWrapper?.observabilityScope

--- a/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
@@ -115,6 +115,12 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
             case "navigate":
                 guard let target = data["target"] as? String,
                       let url = URL(string: target) else {
+                    // Unopenable targets still count as a failed link open, so broken paywall
+                    // content shows up in the observability pipeline.
+                    HeliumObservabilityManager.shared.track(
+                        PaywallLinkOpenAttempted(openedInApp: false, success: false, scheme: nil),
+                        scope: self.delegateWrapper?.observabilityScope
+                    )
                     respond(["status": "error", "message": "Missing or invalid target"])
                     break
                 }
@@ -166,11 +172,13 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
             // As a page sheet the browser slides up over the paywall; SFSafariViewController's
             // default full-screen presentation animates sideways like a navigation push instead.
             safariViewController.modalPresentationStyle = .pageSheet
-            presenter.present(safariViewController, animated: true)
-            HeliumObservabilityManager.shared.track(
-                PaywallLinkOpenAttempted(openedInApp: true, success: true, scheme: scheme),
-                scope: scope
-            )
+            presenter.present(safariViewController, animated: true) {
+                let success = safariViewController.presentingViewController != nil
+                HeliumObservabilityManager.shared.track(
+                    PaywallLinkOpenAttempted(openedInApp: true, success: success, scheme: scheme),
+                    scope: scope
+                )
+            }
         } else {
             UIApplication.shared.open(url, options: [:]) { opened in
                 HeliumObservabilityManager.shared.track(

--- a/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
@@ -243,18 +243,13 @@ extension WebViewMessageHandler: WKNavigationDelegate {
         HeliumLogger.log(.trace, category: .ui, "WebView did commit navigation")
     }
     
-    private func shouldOpenExternally(url: URL) -> Bool {
-        // For now, open all urls externally.
-        return true;
-    }
-
     func webView(
         _ webView: WKWebView,
         decidePolicyFor navigationAction: WKNavigationAction,
         decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
     ) {
         if navigationAction.navigationType == .linkActivated,
-           let url = navigationAction.request.url, shouldOpenExternally(url: url) {
+           let url = navigationAction.request.url {
             Task { @MainActor in
                 self.openPaywallLink(url)
             }

--- a/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
@@ -163,6 +163,9 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
            scheme == "http" || scheme == "https",
            let presenter = UIWindowHelper.findTopMostViewController() {
             let safariViewController = SFSafariViewController(url: url)
+            // As a page sheet the browser slides up over the paywall; SFSafariViewController's
+            // default full-screen presentation animates sideways like a navigation push instead.
+            safariViewController.modalPresentationStyle = .pageSheet
             presenter.present(safariViewController, animated: true)
             HeliumObservabilityManager.shared.track(
                 PaywallLinkOpenAttempted(openedInApp: true, success: true, scheme: scheme),

--- a/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
@@ -157,14 +157,24 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
     /// schemes (and any link when the in-app browser can't be presented) open externally.
     @MainActor
     func openPaywallLink(_ url: URL) {
+        let scope = delegateWrapper?.observabilityScope
+        let scheme = url.scheme?.lowercased()
         if Helium.config.openPaywallLinksInApp,
-           let scheme = url.scheme?.lowercased(),
            scheme == "http" || scheme == "https",
            let presenter = UIWindowHelper.findTopMostViewController() {
             let safariViewController = SFSafariViewController(url: url)
             presenter.present(safariViewController, animated: true)
+            HeliumObservabilityManager.shared.track(
+                PaywallLinkOpenAttempted(openedInApp: true, success: true, scheme: scheme),
+                scope: scope
+            )
         } else {
-            UIApplication.shared.open(url)
+            UIApplication.shared.open(url, options: [:]) { opened in
+                HeliumObservabilityManager.shared.track(
+                    PaywallLinkOpenAttempted(openedInApp: false, success: opened, scheme: scheme),
+                    scope: scope
+                )
+            }
         }
     }
 

--- a/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
@@ -43,6 +43,10 @@ class ActionsDelegateWrapper: ObservableObject {
         delegate.paywallInfo.productHapticsEnabled ?? []
     }
 
+    var observabilityScope: PaywallObservabilityScope {
+        delegate.paywallSession.observabilityScope
+    }
+
     func dismiss(dispatchEvent: Bool = true) {
         delegate.dismiss(dispatchEvent: dispatchEvent)
     }

--- a/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
+++ b/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
@@ -222,10 +222,11 @@ struct WebCheckoutBrowserOpenAttempted: HeliumObservabilityEvent {
     }
 }
 
-/// A link tapped in paywall content was handed off to a browser — in-app
-/// (`SFSafariViewController`) when `openPaywallLinksInApp` is enabled for a web URL,
-/// external otherwise. Only the scheme is reported; full URLs stay out of the pipeline
-/// since their query strings can carry user data.
+/// A link tapped in paywall content was handed off to an in-app browser
+/// (`SFSafariViewController`) or an external app — in-app when `openPaywallLinksInApp`
+/// is enabled (the default) for a web URL, external otherwise (including non-web schemes
+/// like `mailto:` and `tel:`). Only the scheme is reported; full URLs stay out of the
+/// pipeline since their query strings can carry user data.
 struct PaywallLinkOpenAttempted: HeliumObservabilityEvent {
     let openedInApp: Bool
     let success: Bool

--- a/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
+++ b/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
@@ -222,6 +222,23 @@ struct WebCheckoutBrowserOpenAttempted: HeliumObservabilityEvent {
     }
 }
 
+/// A link tapped in paywall content was handed off to a browser — in-app
+/// (`SFSafariViewController`) when `openPaywallLinksInApp` is enabled for a web URL,
+/// external otherwise. Only the scheme is reported; full URLs stay out of the pipeline
+/// since their query strings can carry user data.
+struct PaywallLinkOpenAttempted: HeliumObservabilityEvent {
+    let openedInApp: Bool
+    let success: Bool
+    let scheme: String?
+
+    var name: String { "paywall_link_open_attempted" }
+    var properties: [String: Any] {
+        var p: [String: Any] = ["openedInApp": openedInApp, "success": success]
+        if let scheme { p["scheme"] = scheme }
+        return p
+    }
+}
+
 struct WebCheckoutRedirectReceived: HeliumObservabilityEvent {
     let provider: String
     let redirectKind: String

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -721,6 +721,14 @@ public class HeliumConfig {
     /// Defaults to `true`.
     public var paywallPreviewsAutoEnabledInDevBuilds: Bool = true
 
+    /// Opens http/https links tapped in paywalls in an in-app browser (`SFSafariViewController`)
+    /// presented over the paywall, instead of leaving the app for the external browser.
+    ///
+    /// Links with other schemes (e.g. `mailto:`, `tel:`, custom app schemes) always open externally.
+    ///
+    /// Defaults to `false` (links open in the external browser).
+    public var openPaywallLinksInApp: Bool = false
+
     // MARK: - External Web Checkout Configuration
 
     /// Which External Web Checkout payment processors are enabled. Empty means disabled.

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -726,8 +726,8 @@ public class HeliumConfig {
     ///
     /// Links with other schemes (e.g. `mailto:`, `tel:`, custom app schemes) always open externally.
     ///
-    /// Defaults to `false` (links open in the external browser).
-    public var openPaywallLinksInApp: Bool = false
+    /// Defaults to `true`. Set to `false` to open links in the external browser instead.
+    public var openPaywallLinksInApp: Bool = true
 
     // MARK: - External Web Checkout Configuration
 

--- a/Tests/helium-swiftTests/HeliumObservabilityEventsTests.swift
+++ b/Tests/helium-swiftTests/HeliumObservabilityEventsTests.swift
@@ -19,6 +19,25 @@ final class HeliumObservabilityEventsTests: XCTestCase {
         return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? NSDictionary)
     }
 
+    // MARK: - PaywallLinkOpenAttempted
+
+    func testPaywallLinkOpenCarriesDestinationSuccessAndScheme() throws {
+        let event = PaywallLinkOpenAttempted(openedInApp: true, success: true, scheme: "https")
+
+        XCTAssertEqual(event.name, "paywall_link_open_attempted")
+        XCTAssertEqual(try wireProperties(for: event), NSDictionary(dictionary: [
+            "openedInApp": true,
+            "success": true,
+            "scheme": "https",
+        ]))
+    }
+
+    func testPaywallLinkOpenWithoutASchemeOmitsTheKey() throws {
+        let event = PaywallLinkOpenAttempted(openedInApp: false, success: false, scheme: nil)
+
+        XCTAssertNil(try wireProperties(for: event)["scheme"])
+    }
+
     // MARK: - FallbackPaywallsConfigured
 
     func testFullyPopulatedBundleCarriesGeneratedAtOrgDefaultUUIDCountAndMap() throws {

--- a/Tests/helium-swiftTests/HeliumObservabilityEventsTests.swift
+++ b/Tests/helium-swiftTests/HeliumObservabilityEventsTests.swift
@@ -35,7 +35,10 @@ final class HeliumObservabilityEventsTests: XCTestCase {
     func testPaywallLinkOpenWithoutASchemeOmitsTheKey() throws {
         let event = PaywallLinkOpenAttempted(openedInApp: false, success: false, scheme: nil)
 
-        XCTAssertNil(try wireProperties(for: event)["scheme"])
+        XCTAssertEqual(try wireProperties(for: event), NSDictionary(dictionary: [
+            "openedInApp": false,
+            "success": false,
+        ]))
     }
 
     // MARK: - FallbackPaywallsConfigured


### PR DESCRIPTION
Paywall "navigate" links (ToS, privacy, custom links) now open in an in-app browser instead of pulling the user out of the app mid-paywall.

## What changed
- `Helium.config.openPaywallLinksInApp` controls the behavior and now defaults to `true`; set it to `false` to restore the external-browser behavior.
- http/https links open in an `SFSafariViewController` presented as a page sheet, so it slides up over the paywall (the default full-screen presentation animates sideways like a navigation push). Other schemes (`mailto:`, `tel:`, custom app schemes) still open externally.
- Observability: `paywall_link_open_attempted` reports `openedInApp`/`success`/`scheme`; success is read from the presentation completion handler, and blank/malformed targets are reported as failed opens.
- Removed the dead always-`true` `shouldOpenExternally` helper.

## Testing
- Full unit test suite passes; event wire-format tests updated.
- Verified on an iPhone 16 Pro: page sheet slides up over the paywall with the paywall visible behind it, swipe-down dismisses, external path still works when the flag is disabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized paywall navigation and presentation changes with an opt-out config flag; no auth, payment, or entitlement logic touched.
> 
> **Overview**
> Paywall link taps (JS **navigate** messages and in-webview link activations) no longer always jump to the external browser. They route through a shared **`openPaywallLink`** path instead of the removed always-external helper.
> 
> **`Helium.config.openPaywallLinksInApp`** defaults to **`true`**. When enabled, **http/https** URLs open in **`SFSafariViewController`** as a **page sheet** over the paywall; **`mailto:`**, **`tel:`**, custom schemes, and the case when no presenter is found still use **`UIApplication.shared.open`**. Setting the flag to **`false`** restores external-browser behavior for web URLs.
> 
> Observability adds **`paywall_link_open_attempted`** with **`openedInApp`**, **`success`**, and optional **`scheme`** (no full URLs). Invalid navigate targets and failed opens are tracked; **`ActionsDelegateWrapper`** exposes **`observabilityScope`** so events attach to the paywall session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0b2103aee15c34bff785e63c6dc23898571c373. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - HTTP(S) links opened from paywalls now open in an in-app Safari view by default.
  - Added a configuration option to open paywall links in the external browser instead.
  - Non-HTTP(S) links continue opening externally.

- **Bug Fixes**
  - Improved link handling for paywall web views, including invalid or unavailable link targets.

- **Observability**
  - Added tracking for paywall link-opening attempts and outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->