### PR TITLE
[SDK-48] | Combine web checkout success and cancel URLs into a single redirect URL

### DIFF
--- a/HeliumExample/HeliumExample/HeliumExampleApp.swift
+++ b/HeliumExample/HeliumExample/HeliumExampleApp.swift
@@ -34,7 +34,7 @@ struct HeliumExampleApp: App {
             AppConfig.apiKey
         }
         
-        Helium.config.enableExternalWebCheckout(successURL: "heliumexamplestripe://openapp", cancelURL: "heliumexamplestripe://openapp", paymentProcessors: .all)
+        Helium.config.enableExternalWebCheckout(redirectURL: "heliumexamplestripe://openapp", paymentProcessors: .all)
         
         Helium.shared.initialize(
             apiKey: apiKey

--- a/Sources/Helium/HeliumCore/StripeCheckout/WebCheckoutModels.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/WebCheckoutModels.swift
@@ -12,11 +12,14 @@ public enum HeliumCheckoutRedirectType: String {
 enum WebCheckoutRedirect {
     /// Classifies an incoming URL forwarded via `Helium.shared.handleURL(_:)`.
     ///
-    /// When the configured success and cancel URLs have distinct paths, the match
-    /// alone is authoritative. When they're identical, query params appended by
-    /// our checkout flow disambiguate. Returns `nil` if the URL doesn't match, or
-    /// if success/cancel collide and query params aren't conclusive — those go to
-    /// the didBecomeActive observer, which reconciles against real entitlement state.
+    /// With a single configured redirect URL (the standard configuration), query
+    /// params appended by our checkout flow determine the outcome; a matching URL
+    /// with no query params at all means the user abandoned checkout, so it
+    /// classifies as cancel. Legacy configs with distinct success and cancel URLs
+    /// are matched by base URL alone, which is authoritative. Returns `nil` if the
+    /// URL doesn't match, or if query params are present but inconclusive — those
+    /// go to the didBecomeActive observer, which reconciles against real
+    /// entitlement state.
     static func classify(_ url: URL) -> HeliumCheckoutRedirectType? {
         let matchesSuccess = matchesBase(url, configured: Helium.config.checkoutSuccessURL)
         let matchesCancel = matchesBase(url, configured: Helium.config.checkoutCancelURL)
@@ -278,7 +281,7 @@ enum WebCheckoutError: LocalizedError {
         case .cannotPresentCheckout:
             return "Could not present the checkout view"
         case .checkoutURLsNotConfigured:
-            return "Checkout URLs not configured. Call Helium.config.enableExternalWebCheckout() before presenting a paywall."
+            return "Checkout redirect URL not configured. Call Helium.config.enableExternalWebCheckout(redirectURL:paymentProcessors:) before presenting a paywall."
         case .invalidBaseURLForComponents:
             return "Web paywall bundle URL could not be parsed into URLComponents."
         case .failedToCompressCtx:

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -430,8 +430,11 @@ public class Helium {
     /// This is not required, but encouraged for smoother post-purchase experience.
     ///
     /// Safe to call with unrelated URLs — returns `nil` if external web checkout is
-    /// disabled or the URL does not match the URLs configured via
-    /// ``HeliumConfig/enableExternalWebCheckout(successURL:cancelURL:)``.
+    /// disabled, the URL does not match a redirect URL configured via
+    /// ``HeliumConfig/enableExternalWebCheckout(redirectURL:paymentProcessors:)``,
+    /// or the checkout outcome can't be determined from the URL alone. In that last
+    /// case Helium still reconciles the purchase against entitlement state when the
+    /// app returns to the foreground.
     ///
     /// Call this from `.onOpenURL`, `SceneDelegate.scene(_:openURLContexts:)`, or
     /// `AppDelegate.application(_:open:options:)`.
@@ -439,7 +442,7 @@ public class Helium {
     /// ## Example
     /// ```swift
     /// .onOpenURL { url in
-    ///     if !Helium.shared.handleURL(url) {
+    ///     if Helium.shared.handleURL(url) == nil {
     ///         // your own deep link handling
     ///     }
     /// }
@@ -747,13 +750,36 @@ public class HeliumConfig {
     /// Enables External Web Checkout Flow for any Paddle or Stripe products in your paywalls. If not enabled, paywalls with Paddle/Stripe products
     /// will not show. Your fallback paywall/s, if provided, will show instead.
     ///
-    /// You must provide redirect URLs so Helium knows where to send the user after checkout completes or is cancelled.
-    /// It is ok to use the same url for both success and cancel.
+    /// You must provide a redirect URL so Helium knows where to send the user back after checkout,
+    /// whether it succeeded, was cancelled, or failed. The one URL covers all outcomes — the SDK
+    /// determines the outcome from query parameters the checkout flow appends, and otherwise
+    /// reconciles against entitlement state when the app returns to the foreground.
+    ///
+    /// Register the URL as a deep link (custom scheme or universal link) and forward it to
+    /// ``Helium/handleURL(_:)`` from your URL handler.
     ///
     /// - Parameters:
-    ///   - successURL: The URL to redirect to after a successful payment.
-    ///   - cancelURL: The URL the provider redirects to when the user cancels checkout.
+    ///   - redirectURL: The URL checkout redirects back to when the user is done, regardless of outcome.
     ///   - paymentProcessors: Which payment processors to enable. Paddle, Stripe, or both.
+    public func enableExternalWebCheckout(
+        redirectURL: String,
+        paymentProcessors: WebCheckoutProcessors
+    ) {
+        guard let parsed = URL(string: redirectURL), parsed.scheme != nil else {
+            HeliumLogger.log(.error, category: .core, "enableExternalWebCheckout: invalid redirectURL. It must be a valid URL with a scheme (e.g. https://example.com or myapp://path).")
+            return
+        }
+        if parsed.query != nil {
+            HeliumLogger.log(.warn, category: .core, "enableExternalWebCheckout: redirectURL contains query parameters. Checkout outcome detection relies on query parameters appended at redirect time, so prefer a query-free URL.")
+        }
+        setExternalWebCheckout(successURL: redirectURL, cancelURL: redirectURL, paymentProcessors: paymentProcessors)
+    }
+
+    /// Enables External Web Checkout Flow with separate success and cancel URLs.
+    ///
+    /// Prefer ``enableExternalWebCheckout(redirectURL:paymentProcessors:)`` — a single redirect
+    /// URL covers all checkout outcomes.
+    @available(*, deprecated, message: "Use enableExternalWebCheckout(redirectURL:paymentProcessors:) instead. A single redirect URL covers success, cancel, and payment failure; the SDK determines the outcome itself.")
     public func enableExternalWebCheckout(
         successURL: String,
         cancelURL: String,
@@ -764,6 +790,14 @@ public class HeliumConfig {
             HeliumLogger.log(.error, category: .core, "enableExternalWebCheckout: invalid URLs provided. Both successURL and cancelURL must be valid URLs with a scheme (e.g. https://example.com or myapp://path).")
             return
         }
+        setExternalWebCheckout(successURL: successURL, cancelURL: cancelURL, paymentProcessors: paymentProcessors)
+    }
+
+    private func setExternalWebCheckout(
+        successURL: String,
+        cancelURL: String,
+        paymentProcessors: WebCheckoutProcessors
+    ) {
         guard !paymentProcessors.isEmpty else {
             HeliumLogger.log(.error, category: .core, "enableExternalWebCheckout: paymentProcessors must not be empty. Pass .all, .paddle, or .stripe.")
             return

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -430,11 +430,8 @@ public class Helium {
     /// This is not required, but encouraged for smoother post-purchase experience.
     ///
     /// Safe to call with unrelated URLs — returns `nil` if external web checkout is
-    /// disabled, the URL does not match a redirect URL configured via
-    /// ``HeliumConfig/enableExternalWebCheckout(redirectURL:paymentProcessors:)``,
-    /// or the checkout outcome can't be determined from the URL alone. In that last
-    /// case Helium still reconciles the purchase against entitlement state when the
-    /// app returns to the foreground.
+    /// disabled or the URL does not match a redirect URL configured via
+    /// ``HeliumConfig/enableExternalWebCheckout(redirectURL:paymentProcessors:)``.
     ///
     /// Call this from `.onOpenURL`, `SceneDelegate.scene(_:openURLContexts:)`, or
     /// `AppDelegate.application(_:open:options:)`.
@@ -751,15 +748,15 @@ public class HeliumConfig {
     /// will not show. Your fallback paywall/s, if provided, will show instead.
     ///
     /// You must provide a redirect URL so Helium knows where to send the user back after checkout,
-    /// whether it succeeded, was cancelled, or failed. The one URL covers all outcomes — the SDK
-    /// determines the outcome from query parameters the checkout flow appends, and otherwise
-    /// reconciles against entitlement state when the app returns to the foreground.
+    /// whether it succeeded, was cancelled, or failed. If a user returns to the app manually
+    /// without the redirect URL, then the SDK will look at the latest entitlement state to
+    /// determine if a purchase was made.
     ///
     /// Register the URL as a deep link (custom scheme or universal link) and forward it to
     /// ``Helium/handleURL(_:)`` from your URL handler.
     ///
     /// - Parameters:
-    ///   - redirectURL: The URL checkout redirects back to when the user is done, regardless of outcome.
+    ///   - redirectURL: The URL checkout redirects back to when the user is done.
     ///   - paymentProcessors: Which payment processors to enable. Paddle, Stripe, or both.
     public func enableExternalWebCheckout(
         redirectURL: String,
@@ -768,9 +765,6 @@ public class HeliumConfig {
         guard let parsed = URL(string: redirectURL), parsed.scheme != nil else {
             HeliumLogger.log(.error, category: .core, "enableExternalWebCheckout: invalid redirectURL. It must be a valid URL with a scheme (e.g. https://example.com or myapp://path).")
             return
-        }
-        if parsed.query != nil {
-            HeliumLogger.log(.warn, category: .core, "enableExternalWebCheckout: redirectURL contains query parameters. Checkout outcome detection relies on query parameters appended at redirect time, so prefer a query-free URL.")
         }
         setExternalWebCheckout(successURL: redirectURL, cancelURL: redirectURL, paymentProcessors: paymentProcessors)
     }

--- a/Tests/helium-swiftTests/WebCheckoutRedirectTests.swift
+++ b/Tests/helium-swiftTests/WebCheckoutRedirectTests.swift
@@ -132,7 +132,7 @@ final class WebCheckoutRedirectTests: XCTestCase {
         XCTAssertNil(Helium.config.checkoutCancelURL)
     }
 
-    func testEnable_redirectURLWithQuery_isAcceptedWithWarning() {
+    func testEnable_redirectURLWithQuery_isAccepted() {
         Helium.config.enableExternalWebCheckout(redirectURL: "myapp://checkout/return?src=app", paymentProcessors: .all)
         XCTAssertTrue(Helium.config.webCheckoutEnabled)
     }

--- a/Tests/helium-swiftTests/WebCheckoutRedirectTests.swift
+++ b/Tests/helium-swiftTests/WebCheckoutRedirectTests.swift
@@ -1,0 +1,154 @@
+import XCTest
+@testable import Helium
+
+/// `Helium.config` is shared process-wide state, so every test configures it in full
+/// and `tearDown` resets it.
+final class WebCheckoutRedirectTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        Helium.config.disableExternalWebCheckout()
+    }
+
+    override func tearDown() {
+        Helium.config.disableExternalWebCheckout()
+        super.tearDown()
+    }
+
+    private func classify(_ urlString: String) -> HeliumCheckoutRedirectType? {
+        WebCheckoutRedirect.classify(URL(string: urlString)!)
+    }
+
+    // MARK: - Single redirect URL (standard configuration)
+
+    private func enableSingleURL(_ redirectURL: String = "myapp://checkout/return") {
+        Helium.config.enableExternalWebCheckout(redirectURL: redirectURL, paymentProcessors: .all)
+    }
+
+    func testSingleURL_noQueryItems_isCancel() {
+        enableSingleURL()
+        XCTAssertEqual(classify("myapp://checkout/return"), .cancel)
+    }
+
+    func testSingleURL_transactionId_isSuccess() {
+        enableSingleURL()
+        XCTAssertEqual(classify("myapp://checkout/return?transactionId=txn_123"), .success)
+    }
+
+    func testSingleURL_emptyTransactionId_isInconclusive() {
+        enableSingleURL()
+        XCTAssertNil(classify("myapp://checkout/return?transactionId="))
+    }
+
+    func testSingleURL_alreadySubscribedTrue_isSuccess() {
+        enableSingleURL()
+        XCTAssertEqual(classify("myapp://checkout/return?alreadySubscribed=true"), .success)
+    }
+
+    func testSingleURL_alreadySubscribedFalse_isInconclusive() {
+        enableSingleURL()
+        XCTAssertNil(classify("myapp://checkout/return?alreadySubscribed=false"))
+    }
+
+    func testSingleURL_error_isPaymentFailure() {
+        enableSingleURL()
+        XCTAssertEqual(classify("myapp://checkout/return?error=card_declined"), .paymentFailure)
+    }
+
+    func testSingleURL_unrelatedQueryParams_isInconclusive() {
+        enableSingleURL()
+        XCTAssertNil(classify("myapp://checkout/return?utm_source=email"))
+    }
+
+    func testSingleURL_transactionIdWinsOverError() {
+        enableSingleURL()
+        XCTAssertEqual(classify("myapp://checkout/return?transactionId=txn_123&error=oops"), .success)
+    }
+
+    func testSingleURL_nonMatchingURLs_returnNil() {
+        enableSingleURL()
+        XCTAssertNil(classify("otherapp://checkout/return"))
+        XCTAssertNil(classify("myapp://other/return"))
+        XCTAssertNil(classify("myapp://checkout/other"))
+    }
+
+    func testSingleURL_trailingSlashNormalization() {
+        enableSingleURL("https://example.com/return/")
+        XCTAssertEqual(classify("https://example.com/return"), .cancel)
+
+        Helium.config.disableExternalWebCheckout()
+        enableSingleURL("https://example.com/return")
+        XCTAssertEqual(classify("https://example.com/return/"), .cancel)
+    }
+
+    func testSingleURL_emptyPathNormalization() {
+        enableSingleURL("myapp://openapp")
+        XCTAssertEqual(classify("myapp://openapp/"), .cancel)
+        XCTAssertEqual(classify("myapp://openapp?transactionId=txn_1"), .success)
+    }
+
+    func testSingleURL_stripeSessionIdPlaceholder_matchesByPrefix() {
+        enableSingleURL("https://example.com/return/{CHECKOUT_SESSION_ID}")
+        XCTAssertEqual(classify("https://example.com/return/cs_test_abc?transactionId=txn_1"), .success)
+        XCTAssertEqual(classify("https://example.com/return/cs_test_abc"), .cancel)
+    }
+
+    func testNotConfigured_returnsNil() {
+        XCTAssertNil(classify("myapp://checkout/return"))
+    }
+
+    // MARK: - Legacy distinct success/cancel URLs (deprecated configuration)
+
+    private func enableLegacyDistinctURLs() {
+        // Deliberately exercises the deprecated overload with distinct URLs.
+        Helium.config.enableExternalWebCheckout(
+            successURL: "myapp://checkout/success",
+            cancelURL: "myapp://checkout/cancel",
+            paymentProcessors: .all
+        )
+    }
+
+    func testLegacyDistinctURLs_baseMatchIsAuthoritative() {
+        enableLegacyDistinctURLs()
+        XCTAssertEqual(classify("myapp://checkout/success"), .success)
+        XCTAssertEqual(classify("myapp://checkout/cancel"), .cancel)
+        XCTAssertEqual(classify("myapp://checkout/cancel?transactionId=txn_1"), .cancel)
+        XCTAssertNil(classify("myapp://checkout/other"))
+    }
+
+    // MARK: - Configuration validation
+
+    func testEnable_schemelessRedirectURL_staysDisabled() {
+        Helium.config.enableExternalWebCheckout(redirectURL: "no-scheme", paymentProcessors: .all)
+        XCTAssertFalse(Helium.config.webCheckoutEnabled)
+        XCTAssertNil(Helium.config.checkoutSuccessURL)
+        XCTAssertNil(Helium.config.checkoutCancelURL)
+    }
+
+    func testEnable_emptyProcessors_staysDisabled() {
+        Helium.config.enableExternalWebCheckout(redirectURL: "myapp://checkout/return", paymentProcessors: [])
+        XCTAssertFalse(Helium.config.webCheckoutEnabled)
+        XCTAssertNil(Helium.config.checkoutSuccessURL)
+        XCTAssertNil(Helium.config.checkoutCancelURL)
+    }
+
+    func testEnable_redirectURLWithQuery_isAcceptedWithWarning() {
+        Helium.config.enableExternalWebCheckout(redirectURL: "myapp://checkout/return?src=app", paymentProcessors: .all)
+        XCTAssertTrue(Helium.config.webCheckoutEnabled)
+    }
+
+    func testEnable_singleURL_setsBothInternalURLs() {
+        enableSingleURL()
+        XCTAssertTrue(Helium.config.webCheckoutEnabled)
+        XCTAssertEqual(Helium.config.checkoutSuccessURL, "myapp://checkout/return")
+        XCTAssertEqual(Helium.config.checkoutCancelURL, "myapp://checkout/return")
+    }
+
+    func testDisable_clearsConfiguration() {
+        enableSingleURL()
+        Helium.config.disableExternalWebCheckout()
+        XCTAssertFalse(Helium.config.webCheckoutEnabled)
+        XCTAssertNil(Helium.config.checkoutSuccessURL)
+        XCTAssertNil(Helium.config.checkoutCancelURL)
+    }
+}


### PR DESCRIPTION
## What

Replaces the two-URL External Web Checkout setup with a single redirect URL. New API: `enableExternalWebCheckout(redirectURL:paymentProcessors:)`. The existing `successURL:cancelURL:` overload is deprecated but keeps its exact behavior.

## Why

Customers are told to use the same URL for success and cancel anyway (SDK-48). The SDK already distinguishes outcomes itself — query params appended at redirect time (`transactionId`, `alreadySubscribed`, `error`), and entitlement reconciliation on foreground when those are inconclusive — so separate URLs only complicate setup.

## Fix

- Added `enableExternalWebCheckout(redirectURL:paymentProcessors:)`; both public overloads route through a shared private helper. Query-bearing redirect URLs are accepted with a warning log (cancel detection degrades to the foreground observer).
- `WebCheckoutRedirect.classify` logic unchanged — the identical-URL path was already supported; doc comments now describe it as the standard configuration.
- Internal storage still holds two URLs so legacy distinct-URL configs behave as before, and the web bundle keeps receiving all three ctx keys (`successUrl`, `cancelUrl`, `paymentFailureUrl`).
- Fixed the `handleURL` docstring (non-compiling example, stale API reference) and the `checkoutURLsNotConfigured` error message.
- Example app moved to the new API.

## Tests

- New `WebCheckoutRedirectTests` (19 tests): first coverage of `WebCheckoutRedirect.classify` — query-param disambiguation, bare-URL-means-cancel, inconclusive-means-nil, Stripe `{CHECKOUT_SESSION_ID}` prefix matching, slash normalization, legacy distinct-URL matching, and config validation.
- Full unit suite passes on iPhone 17 Pro simulator.

## Related

- Docs (Paddle/Stripe onboarding guides) show the two-arg call; need the one-arg call after release.
- React Native/Flutter wrappers should adopt the single-URL API and mirror the deprecation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches public checkout configuration and deep-link handling on the purchase path, but redirect classification behavior is unchanged and the old API is preserved via deprecation.
> 
> **Overview**
> External web checkout setup is simplified to **one redirect URL** via `Helium.config.enableExternalWebCheckout(redirectURL:paymentProcessors:)`, which stores that URL for both success and cancel internally. The **two-URL overload remains** but is **deprecated**; both paths now share a private `setExternalWebCheckout` helper with the same validation as before.
> 
> **Docs and DX:** `WebCheckoutRedirect.classify` comments now describe the single-URL model as standard (query params for outcome, bare match = cancel). `handleURL` docs fix the `.onOpenURL` example (`== nil` instead of negating a non-Bool) and point at the new API. The misconfiguration error text refers to the redirect URL API. The example app switches from `successURL`/`cancelURL` to `redirectURL`.
> 
> **Tests:** New `WebCheckoutRedirectTests` cover single-URL query disambiguation, legacy distinct URLs, URL normalization, Stripe session placeholder matching, and config validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3630cf35b53fe29b05920c2d1528c719862f4cf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring external web checkout with a single redirect URL for successful, canceled, and failed checkout outcomes.
  * Improved redirect handling, including URL normalization and outcome classification.
  * Added clearer validation and warnings for redirect URL configurations.

* **Deprecations**
  * The separate success and cancellation URL configuration remains available but is now deprecated in favor of the unified redirect URL approach.

* **Documentation**
  * Updated checkout and URL-handling guidance to clarify redirect behavior and entitlement reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->