### PR TITLE
Detect paywall bundle JS crashes and show the fallback paywall

### DIFF
--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -393,6 +393,16 @@ struct DynamicWebView: View {
                 jsCrashProbeActive = false
                 return
             }
+            // The probe delays can outlast the fatal window an edge-arriving error
+            // entered under; the promise that late errors never replace holds here too.
+            guard WebViewRenderGuard.isWithinFatalWindow(
+                isContentLoaded: isContentLoaded,
+                contentLoadedAt: contentLoadedAt
+            ) else {
+                trackOutcome(.benign)
+                jsCrashProbeActive = false
+                return
+            }
             trackOutcome(.fatalBlankScreen)
             webViewLoadFail(reason: "JsRuntimeError", kind: .jsCrash)
         }

--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -378,22 +378,34 @@ struct DynamicWebView: View {
         let probedToken = loadToken
         Task { @MainActor in
             // Give a partially-broken page time to paint before judging it blank.
-            try? await Task.sleep(nanoseconds: 300_000_000)
-            guard probedToken == loadToken, let webView else { return }
-            let result = try? await webView.evaluateJavaScript(WebViewRenderGuard.blankScreenProbeSource)
-            guard probedToken == loadToken else { return }
-            switch result as? String {
-            case "blank":
-                trackOutcome(.fatalBlankScreen)
-                webViewLoadFail(reason: "JsRuntimeError", kind: .jsCrash)
-            case "content":
-                trackOutcome(.benign)
+            guard let first = await probeResult(afterSeconds: 0.3, token: probedToken) else { return }
+            guard first == "blank" else {
+                trackOutcome(first == "content" ? .benign : .probeInconclusive)
                 jsCrashProbeActive = false
-            default:
-                trackOutcome(.probeInconclusive)
-                jsCrashProbeActive = false
+                return
             }
+            guard let second = await probeResult(
+                afterSeconds: WebViewRenderGuard.blankConfirmationDelay,
+                token: probedToken
+            ) else { return }
+            guard second == "blank" else {
+                trackOutcome(second == "content" ? .benign : .probeInconclusive)
+                jsCrashProbeActive = false
+                return
+            }
+            trackOutcome(.fatalBlankScreen)
+            webViewLoadFail(reason: "JsRuntimeError", kind: .jsCrash)
         }
+    }
+
+    /// nil means the load attempt changed while waiting — the result is meaningless.
+    @MainActor
+    private func probeResult(afterSeconds delay: TimeInterval, token: String) async -> String? {
+        try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+        guard token == loadToken, let webView else { return nil }
+        let result = try? await webView.evaluateJavaScript(WebViewRenderGuard.blankScreenProbeSource)
+        guard token == loadToken else { return nil }
+        return result as? String ?? "probe-failed"
     }
 
     private func webViewLoadFail(reason: String, kind: WebViewFailKind = .navigation) {

--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -393,16 +393,8 @@ struct DynamicWebView: View {
                 jsCrashProbeActive = false
                 return
             }
-            // The probe delays can outlast the fatal window an edge-arriving error
-            // entered under; the promise that late errors never replace holds here too.
-            guard WebViewRenderGuard.isWithinFatalWindow(
-                isContentLoaded: isContentLoaded,
-                contentLoadedAt: contentLoadedAt
-            ) else {
-                trackOutcome(.benign)
-                jsCrashProbeActive = false
-                return
-            }
+            // The fatal window gates entry only. Rechecking it here would strand a
+            // confirmed-blank screen — there is no visible paywall left to protect.
             trackOutcome(.fatalBlankScreen)
             webViewLoadFail(reason: "JsRuntimeError", kind: .jsCrash)
         }

--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -192,7 +192,7 @@ struct DynamicWebView: View {
           handlePaywallJSError(info)
       }
       .onReceive(NotificationCenter.default.publisher(for: .webViewProcessTerminated)) { res in
-          guard res.object as? WKNavigationDelegate === webView?.navigationDelegate else { return }
+          guard res.object as? WKWebView === webView else { return }
           HeliumObservabilityManager.shared.track(
               PaywallWebProcessTerminated(
                   loadAttempt: String(describing: fileLoadAttempt),
@@ -295,8 +295,14 @@ struct DynamicWebView: View {
                     delegateWrapper: actionsDelegate,
                     heliumViewController: presentationState.heliumViewController
                 )
-                // A newer load attempt superseded this one during preparation.
-                guard preparingToken == loadToken else { return }
+                // A newer load attempt superseded this one during preparation. Release this
+                // task's holder unless the newer attempt received the same pooled instance.
+                guard preparingToken == loadToken else {
+                    if let preparedWebView, preparedWebView !== webView {
+                        WebViewManager.shared.releaseHolderIfUnused(for: preparedWebView)
+                    }
+                    return
+                }
                 guard let preparedWebView else {
                     HeliumLogger.log(.error, category: .ui, "Failed to retrieve preparedWebView!")
                     webViewLoadFail(reason: "NoPreparedWebView") // logically this should never be possible
@@ -695,6 +701,12 @@ class WebViewManager {
         return webView
     }
     
+    /// Frees a holder claimed by a load attempt that was abandoned before presenting,
+    /// so the pooled webview can be handed out again.
+    fileprivate func releaseHolderIfUnused(for webView: WKWebView) {
+        preparedWebViewHolders.first { $0.preparedWebView === webView }?.heliumViewController = nil
+    }
+
     func preLoad(filePath: String) async {
         let startTime = Date()
         

--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -378,7 +378,11 @@ struct DynamicWebView: View {
         let probedToken = loadToken
         Task { @MainActor in
             // Give a partially-broken page time to paint before judging it blank.
-            guard let first = await probeResult(afterSeconds: 0.3, token: probedToken) else { return }
+            guard let first = await probeResult(afterSeconds: 0.3, token: probedToken) else {
+                trackOutcome(.abandoned)
+                jsCrashProbeActive = false
+                return
+            }
             guard first == "blank" else {
                 trackOutcome(first == "content" ? .benign : .probeInconclusive)
                 jsCrashProbeActive = false
@@ -387,7 +391,11 @@ struct DynamicWebView: View {
             guard let second = await probeResult(
                 afterSeconds: WebViewRenderGuard.blankConfirmationDelay,
                 token: probedToken
-            ) else { return }
+            ) else {
+                trackOutcome(.abandoned)
+                jsCrashProbeActive = false
+                return
+            }
             guard second == "blank" else {
                 trackOutcome(second == "content" ? .benign : .probeInconclusive)
                 jsCrashProbeActive = false

--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -378,9 +378,10 @@ struct DynamicWebView: View {
         let probedToken = loadToken
         Task { @MainActor in
             // Give a partially-broken page time to paint before judging it blank.
+            // A nil probe means the load attempt changed underneath us: the flag now
+            // belongs to the newer attempt (which resets it), so leave it alone.
             guard let first = await probeResult(afterSeconds: 0.3, token: probedToken) else {
                 trackOutcome(.abandoned)
-                jsCrashProbeActive = false
                 return
             }
             guard first == "blank" else {
@@ -393,7 +394,6 @@ struct DynamicWebView: View {
                 token: probedToken
             ) else {
                 trackOutcome(.abandoned)
-                jsCrashProbeActive = false
                 return
             }
             guard second == "blank" else {

--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -350,13 +350,16 @@ struct DynamicWebView: View {
     }
     
     private func handlePaywallJSError(_ info: [String: Any]) {
+        // Captured now so a late outcome (an abandoned probe) still describes the
+        // attempt the error was reported against, not whatever the ladder advanced to.
+        let reportedAttempt = fileLoadAttempt
         let trackOutcome = { (outcome: PaywallJSErrorOutcome) in
             HeliumObservabilityManager.shared.track(
                 PaywallJSErrorDetected(
                     source: info["source"] as? String ?? "unknown",
                     errorMessage: info["message"] as? String,
                     errorStack: info["stack"] as? String,
-                    loadAttempt: String(describing: fileLoadAttempt),
+                    loadAttempt: String(describing: reportedAttempt),
                     outcome: outcome,
                     msSinceLoadStart: viewLoadStartTime.map { msSince($0) }
                 ),

--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -33,6 +33,9 @@ struct DynamicWebView: View {
     let shouldEnableScroll: Bool
     
     @State private var isContentLoaded = false
+    @State private var contentLoadedAt: Date? = nil
+    @State private var jsCrashProbeActive = false
+    @State private var loadToken = UUID().uuidString
     @State private var webView: WKWebView? = nil
     @State private var showControlPanel = false
     @State private var viewLoadStartTime: Date?
@@ -161,6 +164,7 @@ struct DynamicWebView: View {
       .onReceive(NotificationCenter.default.publisher(for: .webViewContentLoaded)) { res in
           if !isContentLoaded && res.object as? WKNavigationDelegate === webView?.navigationDelegate {
               isContentLoaded = true
+              contentLoadedAt = Date()
               if let startTime = viewLoadStartTime {
                   let timeInterval = Date().timeIntervalSince(startTime)
                   let milliseconds = UInt64(timeInterval * 1000)
@@ -180,6 +184,24 @@ struct DynamicWebView: View {
               webViewLoadFail(reason: "Failed to render paywall.")
           }
       }
+      .onReceive(NotificationCenter.default.publisher(for: .webViewJSErrorDetected)) { res in
+          guard res.object as? WKNavigationDelegate === webView?.navigationDelegate,
+                let info = res.userInfo as? [String: Any],
+                info["loadToken"] as? String == loadToken
+          else { return }
+          handlePaywallJSError(info)
+      }
+      .onReceive(NotificationCenter.default.publisher(for: .webViewProcessTerminated)) { res in
+          guard res.object as? WKNavigationDelegate === webView?.navigationDelegate else { return }
+          HeliumObservabilityManager.shared.track(
+              PaywallWebProcessTerminated(
+                  loadAttempt: String(describing: fileLoadAttempt),
+                  wasContentLoaded: isContentLoaded
+              ),
+              scope: actionsDelegate.observabilityScope
+          )
+          webViewLoadFail(reason: "WebContentProcessTerminated", kind: .processTerminated)
+      }
       .onReceive(NotificationCenter.default.publisher(for: .heliumWebCheckoutProcessingChanged)) { notification in
           guard let visible = notification.userInfo?["visible"] as? Bool else { return }
           withAnimation(.easeInOut(duration: 0.15)) { processingVisible = visible }
@@ -190,6 +212,7 @@ struct DynamicWebView: View {
         if webView != nil {
             return
         }
+        loadToken = UUID().uuidString
         HeliumLogger.log(.trace, category: .ui, "WebView loading html - \(fileLoadAttempt)")
         
         guard let filePathToLoad = useBackup ? backupFilePath : filePath else {
@@ -255,7 +278,14 @@ struct DynamicWebView: View {
                 injectionTime: .atDocumentStart,
                 forMainFrameOnly: true
             )
-            
+
+            let errorHookScript = WKUserScript(
+                source: WebViewRenderGuard.errorHookScriptSource(loadToken: loadToken),
+                injectionTime: .atDocumentStart,
+                forMainFrameOnly: true
+            )
+
+            let preparingToken = loadToken
             Task {
                 // WebView creation timing
                 _ = Date()
@@ -265,6 +295,8 @@ struct DynamicWebView: View {
                     delegateWrapper: actionsDelegate,
                     heliumViewController: presentationState.heliumViewController
                 )
+                // A newer load attempt superseded this one during preparation.
+                guard preparingToken == loadToken else { return }
                 guard let preparedWebView else {
                     HeliumLogger.log(.error, category: .ui, "Failed to retrieve preparedWebView!")
                     webViewLoadFail(reason: "NoPreparedWebView") // logically this should never be possible
@@ -274,6 +306,7 @@ struct DynamicWebView: View {
                 _ = Date()
                 preparedWebView.configuration.userContentController.removeAllUserScripts()
                 preparedWebView.configuration.userContentController.addUserScript(combinedScript)
+                preparedWebView.configuration.userContentController.addUserScript(errorHookScript)
                 
                 // File loading timing
                 _ = Date()
@@ -310,19 +343,62 @@ struct DynamicWebView: View {
         }
     }
     
-    private func webViewLoadFail(reason: String) {
-        HeliumLogger.log(.debug, category: .ui, "WebView failed to load - \(reason)")
-        switch fileLoadAttempt {
-        case .initialLoad:
-            advanceFileLoadAttempt(to: .secondLoad, useBackup: false)
+    private func handlePaywallJSError(_ info: [String: Any]) {
+        let trackOutcome = { (outcome: PaywallJSErrorOutcome) in
+            HeliumObservabilityManager.shared.track(
+                PaywallJSErrorDetected(
+                    source: info["source"] as? String ?? "unknown",
+                    errorMessage: info["message"] as? String,
+                    errorStack: info["stack"] as? String,
+                    loadAttempt: String(describing: fileLoadAttempt),
+                    outcome: outcome,
+                    msSinceLoadStart: viewLoadStartTime.map { msSince($0) }
+                ),
+                scope: actionsDelegate.observabilityScope
+            )
+        }
+
+        guard !jsCrashProbeActive,
+              WebViewRenderGuard.isWithinFatalWindow(
+                  isContentLoaded: isContentLoaded,
+                  contentLoadedAt: contentLoadedAt
+              )
+        else {
+            trackOutcome(.benign)
             return
-        case .secondLoad:
-            if backupFilePath != nil {
-                advanceFileLoadAttempt(to: .backupLoad, useBackup: true)
-                return
+        }
+
+        jsCrashProbeActive = true
+        let probedToken = loadToken
+        Task { @MainActor in
+            // Give a partially-broken page time to paint before judging it blank.
+            try? await Task.sleep(nanoseconds: 300_000_000)
+            guard probedToken == loadToken, let webView else { return }
+            let result = try? await webView.evaluateJavaScript(WebViewRenderGuard.blankScreenProbeSource)
+            guard probedToken == loadToken else { return }
+            switch result as? String {
+            case "blank":
+                trackOutcome(.fatalBlankScreen)
+                webViewLoadFail(reason: "JsRuntimeError", kind: .jsCrash)
+            case "content":
+                trackOutcome(.benign)
+                jsCrashProbeActive = false
+            default:
+                trackOutcome(.probeInconclusive)
+                jsCrashProbeActive = false
             }
-        default:
-            break
+        }
+    }
+
+    private func webViewLoadFail(reason: String, kind: WebViewFailKind = .navigation) {
+        HeliumLogger.log(.debug, category: .ui, "WebView failed to load - \(reason)")
+        if let next = WebViewRenderGuard.nextLoadAttempt(
+            after: fileLoadAttempt,
+            kind: kind,
+            hasBackup: backupFilePath != nil
+        ) {
+            advanceFileLoadAttempt(to: next, useBackup: next == .backupLoad)
+            return
         }
         let trigger = triggerName ?? ""
         let paywallName = HeliumFetchedConfigManager.shared.getPaywallInfoForTrigger(trigger)?.paywallTemplateName ?? HeliumFallbackViewManager.shared.getFallbackInfo(trigger: trigger)?.paywallTemplateName ?? "unknown"
@@ -356,6 +432,9 @@ struct DynamicWebView: View {
         Task { @MainActor in
             fileLoadAttempt = attempt
             webView = nil
+            jsCrashProbeActive = false
+            isContentLoaded = false
+            contentLoadedAt = nil
             // give time for SwiftUI to update otherwise any existing webview display might remain
             await Task.yield()
             loadWebView(useBackup: useBackup)

--- a/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
@@ -36,6 +36,17 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
 
 
         if message.name == "logging" {
+            if let dict = message.body as? [String: Any],
+               dict["type"] as? String == "js-error" {
+                HeliumLogger.log(.warn, category: .ui, "Paywall JS error reported", metadata: [
+                    "message": dict["message"] as? String ?? ""
+                ])
+                NotificationCenter.default.post(
+                    name: .webViewJSErrorDetected,
+                    object: self,
+                    userInfo: dict
+                )
+            }
             replyHandler(nil, nil)
             return
         }
@@ -275,11 +286,17 @@ extension WebViewMessageHandler: WKNavigationDelegate {
         HeliumLogger.log(.error, category: .ui, "WebView provisional navigation failed", metadata: ["error": error.localizedDescription])
         NotificationCenter.default.post(name: .webViewContentLoadFail, object: self)
     }
-    
+
+    func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        HeliumLogger.log(.error, category: .ui, "WebView content process terminated")
+        NotificationCenter.default.post(name: .webViewProcessTerminated, object: self)
+    }
+
 }
 
-// Add notification name
 extension Notification.Name {
    static let webViewContentLoaded = Notification.Name("webViewContentLoaded")
    static let webViewContentLoadFail = Notification.Name("webViewContentLoadFail")
+   static let webViewJSErrorDetected = Notification.Name("webViewJSErrorDetected")
+   static let webViewProcessTerminated = Notification.Name("webViewProcessTerminated")
 }

--- a/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
@@ -37,7 +37,7 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
 
         if message.name == "logging" {
             if let dict = message.body as? [String: Any],
-               dict["type"] as? String == "js-error" {
+               dict["type"] as? String == "sdk-detected-js-error" {
                 HeliumLogger.log(.warn, category: .ui, "Paywall JS error reported", metadata: [
                     "message": dict["message"] as? String ?? ""
                 ])

--- a/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
@@ -289,7 +289,7 @@ extension WebViewMessageHandler: WKNavigationDelegate {
 
     func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
         HeliumLogger.log(.error, category: .ui, "WebView content process terminated")
-        NotificationCenter.default.post(name: .webViewProcessTerminated, object: self)
+        NotificationCenter.default.post(name: .webViewProcessTerminated, object: webView)
     }
 
 }

--- a/Sources/Helium/HeliumCore/Components/Web/WebViewRenderGuard.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/WebViewRenderGuard.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+enum WebViewFailKind {
+    case navigation
+    case jsCrash
+    case processTerminated
+}
+
+/// Load-ladder decisions and injected scripts for detecting blank paywall renders.
+enum WebViewRenderGuard {
+
+    static func nextLoadAttempt(
+        after current: FileLoadAttempt,
+        kind: WebViewFailKind,
+        hasBackup: Bool
+    ) -> FileLoadAttempt? {
+        switch current {
+        case .initialLoad:
+            // A JS crash is deterministic — retrying the same bundle would fail identically.
+            if kind == .jsCrash && hasBackup { return .backupLoad }
+            return .secondLoad
+        case .secondLoad:
+            return hasBackup ? .backupLoad : nil
+        case .backupLoad:
+            return nil
+        }
+    }
+
+    /// didFinish fires even when the page's JS crashed, so errors stay fatal for a
+    /// short window after it; later errors never replace a visible paywall.
+    static let postLoadFatalWindow: TimeInterval = 5.0
+
+    static func isWithinFatalWindow(
+        isContentLoaded: Bool,
+        contentLoadedAt: Date?,
+        now: Date = Date()
+    ) -> Bool {
+        if !isContentLoaded { return true }
+        guard let contentLoadedAt else { return true }
+        return now.timeIntervalSince(contentLoadedAt) <= postLoadFatalWindow
+    }
+
+    /// Runs at document start, before any bundle code. Must never affect the page.
+    static func errorHookScriptSource(loadToken: String) -> String {
+        """
+        (function() {
+            try {
+                var reported = 0;
+                var report = function(source, message, stack) {
+                    try {
+                        if (reported >= 5) return;
+                        reported++;
+                        if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.logging) {
+                            window.webkit.messageHandlers.logging.postMessage({
+                                type: 'js-error',
+                                source: source,
+                                message: String(message || '').slice(0, 500),
+                                stack: String(stack || '').slice(0, 2000),
+                                loadToken: '\(loadToken)'
+                            });
+                        }
+                    } catch (e) {}
+                };
+                // No capture phase: resource load errors must not trigger replacement.
+                window.addEventListener('error', function(ev) {
+                    try {
+                        var err = ev && ev.error;
+                        report('error', (err && err.message) || (ev && ev.message), err && err.stack);
+                    } catch (e) {}
+                });
+                window.addEventListener('unhandledrejection', function(ev) {
+                    try {
+                        var r = ev && ev.reason;
+                        report('unhandledrejection', (r && r.message) || String(r), r && r.stack);
+                    } catch (e) {}
+                });
+            } catch (e) {}
+        })();
+        """
+    }
+
+    /// Anything but 'blank' counts as content — when in doubt, never replace a
+    /// possibly-working paywall. Always returns a string: the async
+    /// `evaluateJavaScript` overload traps on nil.
+    static let blankScreenProbeSource = """
+        (function() {
+            try {
+                var b = document.body;
+                if (!b || b.childElementCount === 0) return 'blank';
+                if (b.getBoundingClientRect().height < 10) return 'blank';
+                var els = b.querySelectorAll('*');
+                var limit = Math.min(els.length, 300);
+                for (var i = 0; i < limit; i++) {
+                    var e = els[i];
+                    var r = e.getBoundingClientRect();
+                    if (r.width < 3 || r.height < 3) continue;
+                    var s = window.getComputedStyle(e);
+                    if (s.display === 'none' || s.visibility === 'hidden' || parseFloat(s.opacity) === 0) continue;
+                    var tag = e.tagName;
+                    if (tag === 'IMG' || tag === 'VIDEO' || tag === 'CANVAS' || tag === 'SVG' || tag === 'svg') return 'content';
+                    if (s.backgroundImage && s.backgroundImage !== 'none') return 'content';
+                    if (tag !== 'SCRIPT' && tag !== 'STYLE' && (e.textContent || '').trim().length > 0) return 'content';
+                }
+                return 'blank';
+            } catch (e) { return 'probe-failed'; }
+        })();
+        """
+}

--- a/Sources/Helium/HeliumCore/Components/Web/WebViewRenderGuard.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/WebViewRenderGuard.swift
@@ -17,7 +17,7 @@ enum WebViewRenderGuard {
         switch current {
         case .initialLoad:
             // A JS crash is deterministic — retrying the same bundle would fail identically.
-            if kind == .jsCrash && hasBackup { return .backupLoad }
+            if kind == .jsCrash { return hasBackup ? .backupLoad : nil }
             return .secondLoad
         case .secondLoad:
             return hasBackup ? .backupLoad : nil

--- a/Sources/Helium/HeliumCore/Components/Web/WebViewRenderGuard.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/WebViewRenderGuard.swift
@@ -30,6 +30,10 @@ enum WebViewRenderGuard {
     /// short window after it; later errors never replace a visible paywall.
     static let postLoadFatalWindow: TimeInterval = 5.0
 
+    /// A first blank probe can catch a healthy page moments before its first paint,
+    /// so a blank result must be confirmed by a second probe this much later.
+    static let blankConfirmationDelay: TimeInterval = 1.0
+
     static func isWithinFatalWindow(
         isContentLoaded: Bool,
         contentLoadedAt: Date?,

--- a/Sources/Helium/HeliumCore/Components/Web/WebViewRenderGuard.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/WebViewRenderGuard.swift
@@ -56,7 +56,7 @@ enum WebViewRenderGuard {
                         reported++;
                         if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.logging) {
                             window.webkit.messageHandlers.logging.postMessage({
-                                type: 'js-error',
+                                type: 'sdk-detected-js-error',
                                 source: source,
                                 message: String(message || '').slice(0, 500),
                                 stack: String(stack || '').slice(0, 2000),
@@ -96,7 +96,6 @@ enum WebViewRenderGuard {
                     if (node.nodeType === Node.TEXT_NODE && (node.textContent || '').trim().length > 0) return 'content';
                 }
                 if (b.childElementCount === 0) return 'blank';
-                if (b.getBoundingClientRect().height < 10) return 'blank';
                 var els = b.querySelectorAll('*');
                 var limit = Math.min(els.length, 300);
                 for (var i = 0; i < limit; i++) {

--- a/Sources/Helium/HeliumCore/Components/Web/WebViewRenderGuard.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/WebViewRenderGuard.swift
@@ -86,7 +86,12 @@ enum WebViewRenderGuard {
         (function() {
             try {
                 var b = document.body;
-                if (!b || b.childElementCount === 0) return 'blank';
+                if (!b) return 'blank';
+                for (var n = 0; n < b.childNodes.length; n++) {
+                    var node = b.childNodes[n];
+                    if (node.nodeType === Node.TEXT_NODE && (node.textContent || '').trim().length > 0) return 'content';
+                }
+                if (b.childElementCount === 0) return 'blank';
                 if (b.getBoundingClientRect().height < 10) return 'blank';
                 var els = b.querySelectorAll('*');
                 var limit = Math.min(els.length, 300);

--- a/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
+++ b/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
@@ -325,6 +325,8 @@ enum PaywallJSErrorOutcome: String {
     case benign
     /// Probe failed; treated as content so a working paywall is never replaced.
     case probeInconclusive
+    /// The probe was abandoned mid-flight — the load attempt changed underneath it.
+    case abandoned
 }
 
 /// An uncaught error or unhandled rejection in a paywall bundle. Emitted for

--- a/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
+++ b/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
@@ -316,6 +316,51 @@ struct WebCheckoutPurchaseCheckExhausted: HeliumObservabilityEvent {
     }
 }
 
+// MARK: - Paywall webview render
+
+enum PaywallJSErrorOutcome: String {
+    /// Screen confirmed blank; routed into the load ladder.
+    case fatalBlankScreen
+    /// Content was visible, or the error came too late to act on.
+    case benign
+    /// Probe failed; treated as content so a working paywall is never replaced.
+    case probeInconclusive
+}
+
+/// An uncaught error or unhandled rejection in a paywall bundle. Emitted for
+/// every report so broken bundles are queryable even when nothing went blank.
+struct PaywallJSErrorDetected: HeliumObservabilityEvent {
+    let source: String
+    let errorMessage: String?
+    let errorStack: String?
+    let loadAttempt: String
+    let outcome: PaywallJSErrorOutcome
+    let msSinceLoadStart: Int?
+
+    var name: String { "paywall_js_error_detected" }
+    var properties: [String: Any] {
+        var p: [String: Any] = [
+            "source": source,
+            "loadAttempt": loadAttempt,
+            "outcome": outcome.rawValue,
+        ]
+        if let m = truncatedForObservability(errorMessage) { p["errorMessage"] = m }
+        if let s = truncatedForObservability(errorStack, maxLength: 1000) { p["errorStack"] = s }
+        if let msSinceLoadStart { p["msSinceLoadStart"] = msSinceLoadStart }
+        return p
+    }
+}
+
+struct PaywallWebProcessTerminated: HeliumObservabilityEvent {
+    let loadAttempt: String
+    let wasContentLoaded: Bool
+
+    var name: String { "paywall_web_process_terminated" }
+    var properties: [String: Any] {
+        ["loadAttempt": loadAttempt, "wasContentLoaded": wasContentLoaded]
+    }
+}
+
 /// Reports the fallback bundle an app ships. The event's presence in the stream is
 /// itself the "this app has fallbacks configured" signal, so it is only emitted when
 /// a bundle was found and parsed.

--- a/Tests/helium-swiftTests/WebViewRenderGuardIntegrationTests.swift
+++ b/Tests/helium-swiftTests/WebViewRenderGuardIntegrationTests.swift
@@ -9,6 +9,13 @@ import WebKit
 @MainActor
 final class WebViewRenderGuardIntegrationTests: XCTestCase {
 
+    override func setUp() async throws {
+        // WebKit page loads are unreliably slow under Thread Sanitizer (how CI runs
+        // this suite), timing out the didFinish waits. They run un-sanitized locally.
+        let tsanActive = dlsym(dlopen(nil, RTLD_LAZY), "__tsan_init") != nil
+        try XCTSkipIf(tsanActive, "Skipped under Thread Sanitizer: WebKit loads time out")
+    }
+
     private final class LoggingBridgeStub: NSObject, WKScriptMessageHandlerWithReply {
         var onMessage: ((Any) -> Void)?
         func userContentController(
@@ -50,11 +57,17 @@ final class WebViewRenderGuardIntegrationTests: XCTestCase {
         return webView
     }
 
-    private func loadAndWaitForFinish(_ webView: WKWebView, html: String) async {
+    private enum LoadError: Error { case didFinishTimedOut }
+
+    /// Throws on timeout so a slow load fails here, not as a confusing
+    /// follow-on JS error in the assertion that assumed a loaded page.
+    private func loadAndWaitForFinish(_ webView: WKWebView, html: String) async throws {
         let finished = expectation(description: "didFinish")
         navDelegate.onFinish = { finished.fulfill() }
         webView.loadHTMLString(html, baseURL: nil)
-        await fulfillment(of: [finished], timeout: 10.0)
+        guard await XCTWaiter.fulfillment(of: [finished], timeout: 30.0) == .completed else {
+            throw LoadError.didFinishTimedOut
+        }
     }
 
     func testThrowDuringInitialExecutionReportsJsErrorWithToken() {
@@ -100,7 +113,7 @@ final class WebViewRenderGuardIntegrationTests: XCTestCase {
 
     func testProbeReturnsBlankForCrashedEmptyDocument() async throws {
         let webView = makeWebView(loadToken: "probe-blank-tok")
-        await loadAndWaitForFinish(
+        try await loadAndWaitForFinish(
             webView,
             html: "<html><body><script>window.locale = {}; locale.some(function(l) { return true; });</script></body></html>"
         )
@@ -111,9 +124,20 @@ final class WebViewRenderGuardIntegrationTests: XCTestCase {
 
     func testProbeReturnsContentForVisibleText() async throws {
         let webView = makeWebView(loadToken: "probe-content-tok")
-        await loadAndWaitForFinish(
+        try await loadAndWaitForFinish(
             webView,
             html: "<html><body><div>Start your free trial</div></body></html>"
+        )
+
+        let result = try await webView.evaluateJavaScript(WebViewRenderGuard.blankScreenProbeSource)
+        XCTAssertEqual(result as? String, "content")
+    }
+
+    func testProbeReturnsContentForDirectBodyText() async throws {
+        let webView = makeWebView(loadToken: "probe-body-text-tok")
+        try await loadAndWaitForFinish(
+            webView,
+            html: "<html><body>Paywall ready</body></html>"
         )
 
         let result = try await webView.evaluateJavaScript(WebViewRenderGuard.blankScreenProbeSource)
@@ -126,7 +150,7 @@ final class WebViewRenderGuardIntegrationTests: XCTestCase {
         var reportedError = false
         bridge.onMessage = { _ in reportedError = true }
 
-        await loadAndWaitForFinish(
+        try await loadAndWaitForFinish(
             webView,
             html: "<html><body><div id='root'>Paywall</div><script>document.getElementById('root').textContent = 'Paywall ready';</script></body></html>"
         )

--- a/Tests/helium-swiftTests/WebViewRenderGuardIntegrationTests.swift
+++ b/Tests/helium-swiftTests/WebViewRenderGuardIntegrationTests.swift
@@ -10,8 +10,7 @@ import WebKit
 final class WebViewRenderGuardIntegrationTests: XCTestCase {
 
     override func setUp() async throws {
-        // WebKit page loads are unreliably slow under Thread Sanitizer (how CI runs
-        // this suite), timing out the didFinish waits. They run un-sanitized locally.
+        // WebKit page loads can exceed the didFinish timeout under Thread Sanitizer.
         let tsanActive = dlsym(dlopen(nil, RTLD_LAZY), "__tsan_init") != nil
         try XCTSkipIf(tsanActive, "Skipped under Thread Sanitizer: WebKit loads time out")
     }

--- a/Tests/helium-swiftTests/WebViewRenderGuardIntegrationTests.swift
+++ b/Tests/helium-swiftTests/WebViewRenderGuardIntegrationTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+import WebKit
+@testable import Helium
+
+/// Exercises the injected error hook and blank-screen probe against real
+/// WebKit: a bundle that throws during initial execution must produce a
+/// js-error message on the logging bridge, and the probe must distinguish a
+/// blank document from one with visible content.
+@MainActor
+final class WebViewRenderGuardIntegrationTests: XCTestCase {
+
+    private final class LoggingBridgeStub: NSObject, WKScriptMessageHandlerWithReply {
+        var onMessage: ((Any) -> Void)?
+        func userContentController(
+            _ userContentController: WKUserContentController,
+            didReceive message: WKScriptMessage,
+            replyHandler: @escaping (Any?, String?) -> Void
+        ) {
+            onMessage?(message.body)
+            replyHandler(nil, nil)
+        }
+    }
+
+    private final class NavigationFinishStub: NSObject, WKNavigationDelegate {
+        var onFinish: (() -> Void)?
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            onFinish?()
+        }
+    }
+
+    private var bridge: LoggingBridgeStub!
+    private var navDelegate: NavigationFinishStub!
+
+    private func makeWebView(loadToken: String) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        let contentController = WKUserContentController()
+        bridge = LoggingBridgeStub()
+        contentController.addScriptMessageHandler(bridge, contentWorld: .page, name: "logging")
+        contentController.addUserScript(WKUserScript(
+            source: WebViewRenderGuard.errorHookScriptSource(loadToken: loadToken),
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: true
+        ))
+        config.userContentController = contentController
+        // A zero frame gives the page a zero viewport, which would make every
+        // document probe as blank.
+        let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 390, height: 844), configuration: config)
+        navDelegate = NavigationFinishStub()
+        webView.navigationDelegate = navDelegate
+        return webView
+    }
+
+    private func loadAndWaitForFinish(_ webView: WKWebView, html: String) async {
+        let finished = expectation(description: "didFinish")
+        navDelegate.onFinish = { finished.fulfill() }
+        webView.loadHTMLString(html, baseURL: nil)
+        await fulfillment(of: [finished], timeout: 10.0)
+    }
+
+    func testThrowDuringInitialExecutionReportsJsErrorWithToken() {
+        let webView = makeWebView(loadToken: "integration-tok")
+
+        let reported = expectation(description: "js-error reported")
+        bridge.onMessage = { body in
+            guard let dict = body as? [String: Any],
+                  dict["type"] as? String == "js-error" else { return }
+            XCTAssertEqual(dict["loadToken"] as? String, "integration-tok")
+            XCTAssertEqual(dict["source"] as? String, "error")
+            // loadHTMLString(baseURL: nil) gives the page an opaque origin, so
+            // WebKit may sanitize the message to "Script error." — detection,
+            // not message fidelity, is what's under test.
+            XCTAssertFalse((dict["message"] as? String ?? "").isEmpty)
+            reported.fulfill()
+        }
+
+        webView.loadHTMLString(
+            "<html><body><script>window.locale = {}; locale.some(function(l) { return true; });</script></body></html>",
+            baseURL: nil
+        )
+        wait(for: [reported], timeout: 10.0)
+    }
+
+    func testUnhandledRejectionReportsJsError() {
+        let webView = makeWebView(loadToken: "rejection-tok")
+
+        let reported = expectation(description: "unhandledrejection reported")
+        bridge.onMessage = { body in
+            guard let dict = body as? [String: Any],
+                  dict["type"] as? String == "js-error" else { return }
+            XCTAssertEqual(dict["source"] as? String, "unhandledrejection")
+            reported.fulfill()
+        }
+
+        webView.loadHTMLString(
+            "<html><body><div>visible</div><script>Promise.reject(new Error('async boom'));</script></body></html>",
+            baseURL: nil
+        )
+        wait(for: [reported], timeout: 10.0)
+    }
+
+    func testProbeReturnsBlankForCrashedEmptyDocument() async throws {
+        let webView = makeWebView(loadToken: "probe-blank-tok")
+        await loadAndWaitForFinish(
+            webView,
+            html: "<html><body><script>window.locale = {}; locale.some(function(l) { return true; });</script></body></html>"
+        )
+
+        let result = try await webView.evaluateJavaScript(WebViewRenderGuard.blankScreenProbeSource)
+        XCTAssertEqual(result as? String, "blank")
+    }
+
+    func testProbeReturnsContentForVisibleText() async throws {
+        let webView = makeWebView(loadToken: "probe-content-tok")
+        await loadAndWaitForFinish(
+            webView,
+            html: "<html><body><div>Start your free trial</div></body></html>"
+        )
+
+        let result = try await webView.evaluateJavaScript(WebViewRenderGuard.blankScreenProbeSource)
+        XCTAssertEqual(result as? String, "content")
+    }
+
+    func testHookScriptDoesNotBreakWorkingPage() async throws {
+        let webView = makeWebView(loadToken: "no-interference-tok")
+
+        var reportedError = false
+        bridge.onMessage = { _ in reportedError = true }
+
+        await loadAndWaitForFinish(
+            webView,
+            html: "<html><body><div id='root'>Paywall</div><script>document.getElementById('root').textContent = 'Paywall ready';</script></body></html>"
+        )
+
+        let text = try await webView.evaluateJavaScript("document.getElementById('root').textContent")
+        XCTAssertEqual(text as? String, "Paywall ready")
+        XCTAssertFalse(reportedError)
+    }
+}

--- a/Tests/helium-swiftTests/WebViewRenderGuardIntegrationTests.swift
+++ b/Tests/helium-swiftTests/WebViewRenderGuardIntegrationTests.swift
@@ -75,7 +75,7 @@ final class WebViewRenderGuardIntegrationTests: XCTestCase {
         let reported = expectation(description: "js-error reported")
         bridge.onMessage = { body in
             guard let dict = body as? [String: Any],
-                  dict["type"] as? String == "js-error" else { return }
+                  dict["type"] as? String == "sdk-detected-js-error" else { return }
             XCTAssertEqual(dict["loadToken"] as? String, "integration-tok")
             XCTAssertEqual(dict["source"] as? String, "error")
             // loadHTMLString(baseURL: nil) gives the page an opaque origin, so
@@ -98,7 +98,7 @@ final class WebViewRenderGuardIntegrationTests: XCTestCase {
         let reported = expectation(description: "unhandledrejection reported")
         bridge.onMessage = { body in
             guard let dict = body as? [String: Any],
-                  dict["type"] as? String == "js-error" else { return }
+                  dict["type"] as? String == "sdk-detected-js-error" else { return }
             XCTAssertEqual(dict["source"] as? String, "unhandledrejection")
             reported.fulfill()
         }

--- a/Tests/helium-swiftTests/WebViewRenderGuardTests.swift
+++ b/Tests/helium-swiftTests/WebViewRenderGuardTests.swift
@@ -1,0 +1,222 @@
+import XCTest
+import WebKit
+@testable import Helium
+
+final class WebViewRenderGuardTests: XCTestCase {
+
+    // MARK: - nextLoadAttempt decision table
+
+    func testNavigationFailurePreservesExistingLadder() {
+        XCTAssertEqual(
+            WebViewRenderGuard.nextLoadAttempt(after: .initialLoad, kind: .navigation, hasBackup: true),
+            .secondLoad
+        )
+        XCTAssertEqual(
+            WebViewRenderGuard.nextLoadAttempt(after: .initialLoad, kind: .navigation, hasBackup: false),
+            .secondLoad
+        )
+        XCTAssertEqual(
+            WebViewRenderGuard.nextLoadAttempt(after: .secondLoad, kind: .navigation, hasBackup: true),
+            .backupLoad
+        )
+        XCTAssertNil(
+            WebViewRenderGuard.nextLoadAttempt(after: .secondLoad, kind: .navigation, hasBackup: false)
+        )
+    }
+
+    func testJsCrashSkipsRetryWhenBackupExists() {
+        XCTAssertEqual(
+            WebViewRenderGuard.nextLoadAttempt(after: .initialLoad, kind: .jsCrash, hasBackup: true),
+            .backupLoad
+        )
+    }
+
+    func testJsCrashWithoutBackupStillGetsOneRetry() {
+        XCTAssertEqual(
+            WebViewRenderGuard.nextLoadAttempt(after: .initialLoad, kind: .jsCrash, hasBackup: false),
+            .secondLoad
+        )
+        XCTAssertNil(
+            WebViewRenderGuard.nextLoadAttempt(after: .secondLoad, kind: .jsCrash, hasBackup: false)
+        )
+    }
+
+    func testBackupLoadIsAlwaysTerminal() {
+        for kind: WebViewFailKind in [.navigation, .jsCrash, .processTerminated] {
+            XCTAssertNil(
+                WebViewRenderGuard.nextLoadAttempt(after: .backupLoad, kind: kind, hasBackup: true),
+                "A failure in the fallback bundle must terminate the ladder (kind: \(kind))"
+            )
+        }
+    }
+
+    func testProcessTerminationKeepsFullLadder() {
+        XCTAssertEqual(
+            WebViewRenderGuard.nextLoadAttempt(after: .initialLoad, kind: .processTerminated, hasBackup: true),
+            .secondLoad
+        )
+        XCTAssertEqual(
+            WebViewRenderGuard.nextLoadAttempt(after: .secondLoad, kind: .processTerminated, hasBackup: true),
+            .backupLoad
+        )
+    }
+
+    // MARK: - Fatal window
+
+    func testErrorBeforeContentLoadedIsAlwaysWithinWindow() {
+        XCTAssertTrue(
+            WebViewRenderGuard.isWithinFatalWindow(isContentLoaded: false, contentLoadedAt: nil)
+        )
+    }
+
+    func testErrorShortlyAfterContentLoadedIsWithinWindow() {
+        let loadedAt = Date()
+        XCTAssertTrue(
+            WebViewRenderGuard.isWithinFatalWindow(
+                isContentLoaded: true,
+                contentLoadedAt: loadedAt,
+                now: loadedAt.addingTimeInterval(4.9)
+            )
+        )
+    }
+
+    func testLateErrorIsOutsideWindow() {
+        let loadedAt = Date()
+        XCTAssertFalse(
+            WebViewRenderGuard.isWithinFatalWindow(
+                isContentLoaded: true,
+                contentLoadedAt: loadedAt,
+                now: loadedAt.addingTimeInterval(5.1)
+            )
+        )
+    }
+
+    func testContentLoadedWithoutTimestampIsWithinWindow() {
+        XCTAssertTrue(
+            WebViewRenderGuard.isWithinFatalWindow(isContentLoaded: true, contentLoadedAt: nil)
+        )
+    }
+
+    // MARK: - Script sources
+
+    func testErrorHookScriptContainsTokenAndGuardedBridge() {
+        let source = WebViewRenderGuard.errorHookScriptSource(loadToken: "test-token-123")
+        XCTAssertTrue(source.contains("'test-token-123'"))
+        XCTAssertTrue(source.contains("window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.logging"))
+        XCTAssertTrue(source.contains("addEventListener('error'"))
+        XCTAssertTrue(source.contains("addEventListener('unhandledrejection'"))
+    }
+
+    // MARK: - Observability event shapes
+
+    private func wireProperties(for event: any HeliumObservabilityEvent) throws -> NSDictionary {
+        let json = try SegmentJSON(event.properties)
+        let data = try JSONEncoder().encode(json)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? NSDictionary)
+    }
+
+    func testJsErrorDetectedEventShape() throws {
+        let event = PaywallJSErrorDetected(
+            source: "error",
+            errorMessage: "locale.some is not a function",
+            errorStack: "TypeError: locale.some is not a function\n  at render",
+            loadAttempt: "initialLoad",
+            outcome: .fatalBlankScreen,
+            msSinceLoadStart: 250
+        )
+
+        XCTAssertEqual(event.name, "paywall_js_error_detected")
+        XCTAssertEqual(try wireProperties(for: event), NSDictionary(dictionary: [
+            "source": "error",
+            "loadAttempt": "initialLoad",
+            "outcome": "fatalBlankScreen",
+            "errorMessage": "locale.some is not a function",
+            "errorStack": "TypeError: locale.some is not a function\n  at render",
+            "msSinceLoadStart": 250,
+        ]))
+    }
+
+    func testJsErrorDetectedTruncatesLongStack() throws {
+        let event = PaywallJSErrorDetected(
+            source: "unhandledrejection",
+            errorMessage: nil,
+            errorStack: String(repeating: "x", count: 2000),
+            loadAttempt: "initialLoad",
+            outcome: .benign,
+            msSinceLoadStart: nil
+        )
+
+        let props = try wireProperties(for: event)
+        let stack = try XCTUnwrap(props["errorStack"] as? String)
+        XCTAssertTrue(stack.hasSuffix("…(truncated)"))
+        XCTAssertLessThan(stack.count, 1100)
+        XCTAssertNil(props["errorMessage"])
+        XCTAssertNil(props["msSinceLoadStart"])
+    }
+
+    func testWebProcessTerminatedEventShape() throws {
+        let event = PaywallWebProcessTerminated(loadAttempt: "backupLoad", wasContentLoaded: true)
+
+        XCTAssertEqual(event.name, "paywall_web_process_terminated")
+        XCTAssertEqual(try wireProperties(for: event), NSDictionary(dictionary: [
+            "loadAttempt": "backupLoad",
+            "wasContentLoaded": true,
+        ]))
+    }
+
+    // MARK: - Logging bridge routing
+
+    private final class FakeScriptMessage: WKScriptMessage {
+        private let fakeName: String
+        private let fakeBody: Any
+        init(name: String, body: Any) {
+            self.fakeName = name
+            self.fakeBody = body
+        }
+        override var name: String { fakeName }
+        override var body: Any { fakeBody }
+    }
+
+    func testJsErrorMessagePostsNotificationWithUserInfo() {
+        let handler = WebViewMessageHandler()
+        let body: [String: Any] = [
+            "type": "js-error",
+            "source": "error",
+            "message": "boom",
+            "stack": "TypeError: boom",
+            "loadToken": "tok-1",
+        ]
+
+        let notification = expectation(forNotification: .webViewJSErrorDetected, object: handler) { note in
+            let info = note.userInfo as? [String: Any]
+            return info?["loadToken"] as? String == "tok-1" && info?["message"] as? String == "boom"
+        }
+        let replied = expectation(description: "replyHandler called")
+
+        handler.userContentController(
+            WKUserContentController(),
+            didReceive: FakeScriptMessage(name: "logging", body: body)
+        ) { _, _ in replied.fulfill() }
+
+        wait(for: [notification, replied], timeout: 1.0)
+    }
+
+    func testNonJsErrorLoggingMessagePostsNothing() {
+        let handler = WebViewMessageHandler()
+
+        var received = false
+        let observer = NotificationCenter.default.addObserver(
+            forName: .webViewJSErrorDetected, object: handler, queue: nil
+        ) { _ in received = true }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        let replied = expectation(description: "replyHandler called")
+        handler.userContentController(
+            WKUserContentController(),
+            didReceive: FakeScriptMessage(name: "logging", body: ["level": "debug", "msg": "hi"])
+        ) { _, _ in replied.fulfill() }
+
+        wait(for: [replied], timeout: 1.0)
+        XCTAssertFalse(received)
+    }
+}

--- a/Tests/helium-swiftTests/WebViewRenderGuardTests.swift
+++ b/Tests/helium-swiftTests/WebViewRenderGuardTests.swift
@@ -179,7 +179,7 @@ final class WebViewRenderGuardTests: XCTestCase {
     func testJsErrorMessagePostsNotificationWithUserInfo() {
         let handler = WebViewMessageHandler()
         let body: [String: Any] = [
-            "type": "js-error",
+            "type": "sdk-detected-js-error",
             "source": "error",
             "message": "boom",
             "stack": "TypeError: boom",

--- a/Tests/helium-swiftTests/WebViewRenderGuardTests.swift
+++ b/Tests/helium-swiftTests/WebViewRenderGuardTests.swift
@@ -31,10 +31,9 @@ final class WebViewRenderGuardTests: XCTestCase {
         )
     }
 
-    func testJsCrashWithoutBackupStillGetsOneRetry() {
-        XCTAssertEqual(
-            WebViewRenderGuard.nextLoadAttempt(after: .initialLoad, kind: .jsCrash, hasBackup: false),
-            .secondLoad
+    func testJsCrashWithoutBackupIsTerminal() {
+        XCTAssertNil(
+            WebViewRenderGuard.nextLoadAttempt(after: .initialLoad, kind: .jsCrash, hasBackup: false)
         )
         XCTAssertNil(
             WebViewRenderGuard.nextLoadAttempt(after: .secondLoad, kind: .jsCrash, hasBackup: false)


### PR DESCRIPTION
## Why

A production paywall bundle compiled fine but threw a `TypeError` during initial render. WebKit reports a successful load either way, so the SDK logged a clean open + render event and never fell back — users saw a white screen with no signal anywhere. The bundle itself was fixed, but any broken bundle publish would reproduce this.

## What

A JS crash that leaves the screen blank now routes into the existing fallback ladder, natively, with no bundle changes required:

- **Error hook** — `window.onerror` / `unhandledrejection` listeners injected at document start (before any bundle code runs), reporting through the existing `logging` message bridge, which was previously a no-op. Per-load token so stale reports from pooled webviews are dropped.
- **Blank-screen probe** — a reported error only becomes fatal when a DOM probe confirms nothing rendered. Anything else (visible content, probe failure, error later than 5s after `didFinish`) is telemetry-only, so a working paywall is never replaced.
- **Ladder routing** — fatal errors feed the existing `initialLoad → secondLoad → backupLoad` ladder in `webViewLoadFail`. A JS crash is deterministic, so it skips the same-bundle retry and goes straight to the fallback bundle; a crash in the fallback bundle terminates (no loop) with the existing `PaywallOpenFailedEvent(.webviewRenderFail)`.
- **Process termination** — `webViewWebContentProcessDidTerminate` is now handled (previously a permanent white screen with zero events); it keeps the full ladder since process death is transient.
- **Observability** — new internal events `paywall_js_error_detected` (every reported error, with outcome) and `paywall_web_process_terminated`. No new customer-facing events.

Also hardens `loadWebView` against a stale async preparation task clobbering a newer load.

## Testing

- 21 new tests (395 total green): full decision-table coverage of the ladder + fatal window, and 6 integration tests against real WebKit reproducing the reported failure mode — a bundle throwing during initial render reports through the bridge, the crashed document probes `blank`, visible content probes `content`, and the hook doesn't interfere with a working page.
- Known limitation: bundles loaded via `loadHTMLString(baseURL: nil)` have an opaque origin, so WebKit sanitizes error text to "Script error." — detection still works; file-loaded bundles report full messages.

Follow-ups (separate PRs): Android parity (cloudcaptainai/helium-android#336); dashboard publish-gate on preview render.

HEL-6541

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core paywall WebView load/fallback behavior and when users see backup vs failure; mitigated by conservative blank probing and fatal-window gating.
> 
> **Overview**
> Paywall WebViews that **load successfully but throw JS** or **render blank** now recover through the existing `initialLoad → secondLoad → backupLoad` path instead of leaving a white screen with no signal.
> 
> **Detection:** A document-start hook reports `error` / `unhandledrejection` via the existing `logging` bridge (scoped by per-load `loadToken`). Fatal handling only runs inside a short post-`didFinish` window and after **two** DOM blank probes; visible content, probe failure, or late errors stay telemetry-only so working paywalls are not swapped out.
> 
> **Ladder:** `webViewLoadFail` now takes a `WebViewFailKind`—JS crashes **skip** same-bundle retry and jump to backup when available; **WebContent process termination** is handled and keeps the full ladder. Load retries reset probe/content state; superseded async `prepareForShowing` work releases pooled holders via `releaseHolderIfUnused`.
> 
> **Observability:** Internal `paywall_js_error_detected` (with outcome) and `paywall_web_process_terminated` events. Unit and WebKit integration tests cover ladder rules, hooks, and probes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26d1d4fd3412d230cdad81bed08dde30e4208e0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved paywall web view reliability by detecting JavaScript failures, blank pages, and terminated web processes.
  * Added safer retry and fallback handling to reduce stalled or empty web views.
  * Prevented outdated loading operations from interfering with current content.

* **Observability**
  * Added diagnostic reporting for web view errors, load attempts, failures, and recovery outcomes.

* **Tests**
  * Added coverage for JavaScript errors, blank-page detection, retries, process termination, and normal page rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->