### PR TITLE
[HEL-6551] | Introduce throttling logic

### DIFF
--- a/Sources/Helium/HeliumCore/Haptics/HapticThrottle.swift
+++ b/Sources/Helium/HeliumCore/Haptics/HapticThrottle.swift
@@ -1,0 +1,32 @@
+import QuartzCore
+
+/// Keyed on the source event, not the `HeliumHaptic`: distinct events can share a haptic.
+enum HapticThrottleKey: Hashable {
+    case product(ProductHapticAction)
+    case custom(String)
+}
+
+/// The first event for a key plays; repeats inside `window` are dropped, never delayed.
+@MainActor
+final class HapticThrottle {
+    nonisolated static let defaultWindow: CFTimeInterval = 0.05
+
+    private let window: CFTimeInterval
+    private let now: () -> CFTimeInterval
+    private var lastPlayedAt: [HapticThrottleKey: CFTimeInterval] = [:]
+
+    init(
+        window: CFTimeInterval = HapticThrottle.defaultWindow,
+        now: @escaping () -> CFTimeInterval = { CACurrentMediaTime() }
+    ) {
+        self.window = window
+        self.now = now
+    }
+
+    func tryAcquire(_ key: HapticThrottleKey) -> Bool {
+        let timestamp = now()
+        if let last = lastPlayedAt[key], timestamp - last < window { return false }
+        lastPlayedAt[key] = timestamp
+        return true
+    }
+}

--- a/Sources/Helium/HeliumCore/Haptics/PaywallHaptics.swift
+++ b/Sources/Helium/HeliumCore/Haptics/PaywallHaptics.swift
@@ -18,10 +18,17 @@ final class PaywallHapticsImpl: PaywallHaptics {
     private let player: HapticPlayer
     /// Re-read on every event so haptics resolve against whichever paywall is currently presented.
     private let enabledActions: () -> Set<ProductHapticAction>
+    private let throttle: HapticThrottle
 
-    init(player: HapticPlayer, enabledActions: @escaping () -> Set<ProductHapticAction>) {
+    /// Optional, not defaulted: a default argument is evaluated outside this type's isolation.
+    init(
+        player: HapticPlayer,
+        enabledActions: @escaping () -> Set<ProductHapticAction>,
+        throttle: HapticThrottle? = nil
+    ) {
         self.player = player
         self.enabledActions = enabledActions
+        self.throttle = throttle ?? HapticThrottle()
     }
 
     func onProductSelected() { playGated(.select) }
@@ -32,13 +39,14 @@ final class PaywallHapticsImpl: PaywallHaptics {
 
     func onCustomHaptic(_ value: String?) {
         guard let value, let haptic = customHaptic(for: value) else { return }
+        guard throttle.tryAcquire(.custom(value)) else { return }
         player.play(haptic)
     }
 
     private func playGated(_ action: ProductHapticAction) {
-        if enabledActions().contains(action) {
-            player.play(action.haptic)
-        }
+        guard enabledActions().contains(action) else { return }
+        guard throttle.tryAcquire(.product(action)) else { return }
+        player.play(action.haptic)
     }
 
     private func customHaptic(for value: String) -> HeliumHaptic? {

--- a/Tests/helium-swiftTests/HapticThrottleTests.swift
+++ b/Tests/helium-swiftTests/HapticThrottleTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import Helium
+
+@MainActor
+final class HapticThrottleTests: XCTestCase {
+
+    private final class Clock {
+        var now: CFTimeInterval = 0
+    }
+
+    private func makeThrottle() -> (HapticThrottle, Clock) {
+        let clock = Clock()
+        return (HapticThrottle(window: 1, now: { clock.now }), clock)
+    }
+
+    // MARK: - Window boundaries
+
+    func test_GIVEN_freshThrottle_WHEN_tryAcquire_THEN_allows() {
+        let (throttle, _) = makeThrottle()
+        XCTAssertTrue(throttle.tryAcquire(.product(.select)))
+    }
+
+    func test_GIVEN_keyJustAcquired_WHEN_tryAcquireInsideWindow_THEN_denies() {
+        let (throttle, clock) = makeThrottle()
+        _ = throttle.tryAcquire(.product(.select))
+
+        clock.now = 0.999
+
+        XCTAssertFalse(throttle.tryAcquire(.product(.select)))
+    }
+
+    func test_GIVEN_keyAcquired_WHEN_windowElapsedExactly_THEN_allows() {
+        let (throttle, clock) = makeThrottle()
+        _ = throttle.tryAcquire(.product(.select))
+
+        clock.now = 1
+
+        XCTAssertTrue(throttle.tryAcquire(.product(.select)))
+    }
+
+    func test_GIVEN_acquireDeniedMidWindow_WHEN_windowElapsesFromFirstAccept_THEN_allows() {
+        let (throttle, clock) = makeThrottle()
+        _ = throttle.tryAcquire(.product(.select))
+
+        clock.now = 0.5
+        XCTAssertFalse(throttle.tryAcquire(.product(.select)))
+
+        clock.now = 1
+        XCTAssertTrue(throttle.tryAcquire(.product(.select)))
+    }
+
+    // MARK: - Keys do not share buckets
+
+    func test_GIVEN_pressAcquired_WHEN_successAcquiredSameInstant_THEN_bothAllowed() {
+        let (throttle, _) = makeThrottle()
+
+        XCTAssertTrue(throttle.tryAcquire(.product(.press)))
+        XCTAssertTrue(throttle.tryAcquire(.product(.success)))
+    }
+
+    func test_GIVEN_productSuccessAcquired_WHEN_customSuccessAcquiredSameInstant_THEN_bothAllowed() {
+        let (throttle, _) = makeThrottle()
+
+        XCTAssertTrue(throttle.tryAcquire(.product(.success)))
+        XCTAssertTrue(throttle.tryAcquire(.custom("success")))
+    }
+
+    func test_GIVEN_differentCustomValues_WHEN_acquiredSameInstant_THEN_bothAllowed() {
+        let (throttle, _) = makeThrottle()
+
+        XCTAssertTrue(throttle.tryAcquire(.custom("selection")))
+        XCTAssertTrue(throttle.tryAcquire(.custom("success")))
+    }
+
+    // MARK: - The default window is a cross SDK parity value
+
+    func test_GIVEN_defaultWindow_WHEN_read_THEN_is50Milliseconds() {
+        XCTAssertEqual(HapticThrottle.defaultWindow, 0.05, accuracy: 0.0001)
+    }
+}

--- a/Tests/helium-swiftTests/PaywallHapticsImplTests.swift
+++ b/Tests/helium-swiftTests/PaywallHapticsImplTests.swift
@@ -9,11 +9,21 @@ final class PaywallHapticsImplTests: XCTestCase {
         func play(_ haptic: HeliumHaptic) { played.append(haptic) }
     }
 
+    private final class Clock {
+        var now: CFTimeInterval = 0
+    }
+
     private func makeHaptics(
-        enabled: Set<ProductHapticAction>
+        enabled: Set<ProductHapticAction>,
+        clock: Clock? = nil
     ) -> (PaywallHapticsImpl, FakeHapticPlayer) {
+        let clock = clock ?? Clock()
         let player = FakeHapticPlayer()
-        let haptics = PaywallHapticsImpl(player: player, enabledActions: { enabled })
+        let haptics = PaywallHapticsImpl(
+            player: player,
+            enabledActions: { enabled },
+            throttle: HapticThrottle(window: 1, now: { clock.now })
+        )
         return (haptics, player)
     }
 
@@ -51,8 +61,13 @@ final class PaywallHapticsImplTests: XCTestCase {
 
     func test_GIVEN_enabledActionsChange_WHEN_productSelected_THEN_reflectsLatest() {
         let player = FakeHapticPlayer()
+        let clock = Clock()
         var enabled: Set<ProductHapticAction> = []
-        let haptics = PaywallHapticsImpl(player: player, enabledActions: { enabled })
+        let haptics = PaywallHapticsImpl(
+            player: player,
+            enabledActions: { enabled },
+            throttle: HapticThrottle(window: 1, now: { clock.now })
+        )
 
         haptics.onProductSelected()
         XCTAssertTrue(player.played.isEmpty)
@@ -83,6 +98,92 @@ final class PaywallHapticsImplTests: XCTestCase {
         let (haptics, player) = makeHaptics(enabled: [])
         haptics.onCustomHaptic("explode")
         haptics.onCustomHaptic("")
+        XCTAssertTrue(player.played.isEmpty)
+    }
+
+    // MARK: - Repeats of one event are throttled, distinct events are not
+
+    func test_GIVEN_pressAndSuccessEnabled_WHEN_pressedThenSucceededWithinWindow_THEN_bothPlay() {
+        let (haptics, player) = makeHaptics(enabled: [.press, .success])
+
+        haptics.onPurchasePressed()
+        haptics.onPurchaseSucceeded()
+
+        XCTAssertEqual(player.played, [.success, .success])
+    }
+
+    func test_GIVEN_selectEnabled_WHEN_selectedTwiceWithinWindow_THEN_playsOnce() {
+        let clock = Clock()
+        let (haptics, player) = makeHaptics(enabled: [.select], clock: clock)
+
+        haptics.onProductSelected()
+        clock.now = 0.999
+        haptics.onProductSelected()
+
+        XCTAssertEqual(player.played, [.selection])
+    }
+
+    func test_GIVEN_selectEnabled_WHEN_selectedTwiceAfterWindow_THEN_playsTwice() {
+        let clock = Clock()
+        let (haptics, player) = makeHaptics(enabled: [.select], clock: clock)
+
+        haptics.onProductSelected()
+        clock.now = 1
+        haptics.onProductSelected()
+
+        XCTAssertEqual(player.played, [.selection, .selection])
+    }
+
+    func test_GIVEN_sameCustomValue_WHEN_playedTwiceWithinWindow_THEN_playsOnce() {
+        let (haptics, player) = makeHaptics(enabled: [])
+
+        haptics.onCustomHaptic("success")
+        haptics.onCustomHaptic("success")
+
+        XCTAssertEqual(player.played, [.success])
+    }
+
+    func test_GIVEN_customSuccessAndProductSuccess_WHEN_withinWindow_THEN_bothPlay() {
+        let (haptics, player) = makeHaptics(enabled: [.success])
+
+        haptics.onPurchaseSucceeded()
+        haptics.onCustomHaptic("success")
+
+        XCTAssertEqual(player.played, [.success, .success])
+    }
+
+    func test_GIVEN_selectDisabled_WHEN_selectedTwiceThenEnabled_THEN_stillPlays() {
+        let player = FakeHapticPlayer()
+        let clock = Clock()
+        var enabled: Set<ProductHapticAction> = []
+        let haptics = PaywallHapticsImpl(
+            player: player,
+            enabledActions: { enabled },
+            throttle: HapticThrottle(window: 1, now: { clock.now })
+        )
+
+        haptics.onProductSelected()
+        haptics.onProductSelected()
+        XCTAssertTrue(player.played.isEmpty)
+
+        enabled = [.select]
+        haptics.onProductSelected()
+
+        XCTAssertEqual(player.played, [.selection])
+    }
+
+    func test_GIVEN_unknownCustomValue_WHEN_onCustomHaptic_THEN_clockIsNeverRead() {
+        let player = FakeHapticPlayer()
+        var reads = 0
+        let haptics = PaywallHapticsImpl(
+            player: player,
+            enabledActions: { [] },
+            throttle: HapticThrottle(now: { reads += 1; return 0 })
+        )
+
+        haptics.onCustomHaptic("explode")
+
+        XCTAssertEqual(reads, 0)
         XCTAssertTrue(player.played.isEmpty)
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UX-only haptic deduplication with no purchase or auth impact; default behavior is additive and narrowly scoped to repeat suppression.
> 
> **Overview**
> Adds **`HapticThrottle`** so paywall haptics don’t fire in rapid bursts: the first event for a key plays, and repeats inside a **50ms** window are dropped (not queued). Keys are **per source event** (`ProductHapticAction` vs custom `hlm_haptic` string), so different actions can still play at the same time even if they map to the same haptic.
> 
> **`PaywallHapticsImpl`** now checks the throttle after existing enablement gating for product flows and after string mapping for custom haptics. Production call sites (e.g. web paywall handler) keep the same initializer; they get a default throttle instance unless tests inject one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd19794d2b30a2ffa33e473158d1cbe5e9579fb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated haptic feedback from playing within a brief cooldown window.
  * Kept different haptic actions independent, so distinct events continue to provide feedback.
  * Preserved existing action enablement behavior, including after suppressed events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->