### PR TITLE
[HEL-6506] | Second try paywall preview support

### DIFF
--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -487,7 +487,8 @@ fileprivate struct WebViewRepresentable: UIViewRepresentable {
         @objc func handleTripleTap() {
             guard HeliumControlPanelService.shared.allowPaywallControlPanel else { return }
             if HeliumFetchedConfigManager.isPreviewTrigger(trigger) {
-                // Just return to underlying control panel instead of stacking
+                // Step back one layer instead of stacking another panel: the main preview returns
+                // to the control panel, a second try preview returns to the main preview.
                 HeliumPaywallPresenter.shared.hideUpsell()
                 return
             }

--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -486,7 +486,7 @@ fileprivate struct WebViewRepresentable: UIViewRepresentable {
 
         @objc func handleTripleTap() {
             guard HeliumControlPanelService.shared.allowPaywallControlPanel else { return }
-            if trigger == HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER {
+            if HeliumFetchedConfigManager.isPreviewTrigger(trigger) {
                 // Just return to underlying control panel instead of stacking
                 HeliumPaywallPresenter.shared.hideUpsell()
                 return

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
@@ -24,8 +24,7 @@ struct HeliumPaywallPreviewSecondTry: Codable {
     let paywallName: String
     /// "published" when the second try paywall is live; "draft" when it has never been
     /// published, in which case real users do not see it until the paywall is published.
-    /// Optional so a malformed entry can't fail decoding the whole preview list; an absent
-    /// status is treated as unpublished so a preview never claims live coverage it lacks.
+    /// Optional so a malformed entry can't fail decoding the whole preview list.
     let versionStatus: String?
     let bundleUrl: String?
     let productIds: [String]?

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
@@ -24,7 +24,9 @@ struct HeliumPaywallPreviewSecondTry: Codable {
     let paywallName: String
     /// "published" when the second try paywall is live; "draft" when it has never been
     /// published, in which case real users do not see it until the paywall is published.
-    let versionStatus: String
+    /// Optional so a malformed entry can't fail decoding the whole preview list; an absent
+    /// status is treated as unpublished so a preview never claims live coverage it lacks.
+    let versionStatus: String?
     let bundleUrl: String?
     let productIds: [String]?
     let stripeProductIds: [String]?

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
@@ -10,10 +10,26 @@ struct HeliumPaywallPreviewEntry: Codable, Identifiable {
     let paywallName: String
     let isWeb: Bool?
     let versions: [HeliumPaywallPreviewVersion]
+    let secondTry: HeliumPaywallPreviewSecondTry?
     var id: String { paywallUuid }
 
     /// Web paywalls render in a browser, not in-app; previews open them there.
     var isWebPaywall: Bool { isWeb == true }
+}
+
+/// The resolved second try paywall served with a preview entry. Paywall-level, not per-version:
+/// every version of the entry shares the same second try link.
+struct HeliumPaywallPreviewSecondTry: Codable {
+    let paywallUuid: String
+    let paywallName: String
+    /// "published" when the second try paywall is live; "draft" when it has never been
+    /// published, in which case real users do not see it until the paywall is published.
+    let versionStatus: String
+    let bundleUrl: String?
+    let productIds: [String]?
+    let stripeProductIds: [String]?
+    let paddleProductIds: [String]?
+    let shouldEnableScroll: Bool?
 }
 
 struct HeliumPaywallPreviewVersion: Codable, Identifiable {

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelService.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelService.swift
@@ -4,6 +4,11 @@ class HeliumControlPanelService {
     static let shared = HeliumControlPanelService()
     private init() {}
 
+    /// True while the preview trigger is armed to render the bundled default fallback instead
+    /// of a fetched-config entry. Set by the config manager's preview install paths; presentation
+    /// and product lookups consult it to route the preview trigger to the fallback manager.
+    @HeliumAtomic var isFallbackPreviewArmed: Bool = false
+
     var allowPaywallControlPanel: Bool {
         if HeliumFetchedConfigManager.shared.fetchedConfig?.enableProductionPaywallPreviews == true {
             return true

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
@@ -389,7 +389,9 @@ struct HeliumControlPanelView: View {
             HeliumLogger.log(.warn, category: .ui, "[HeliumControlPanel] Second try paywall has no bundle URL", metadata: [
                 "secondTryPaywall": secondTry.paywallName,
             ])
-            return (nil, true)
+            // No bundle was ever built for this second try, so the retry advice of the
+            // load-failed diagnostic cannot resolve it; the dashboard remediation can.
+            return (nil, false)
         }
         do {
             let (bundleId, html) = try await HeliumControlPanelService.shared.fetchSingleBundle(bundleURL: secondTryBundleUrl)
@@ -401,7 +403,7 @@ struct HeliumControlPanelView: View {
                 productIdsStripe: secondTry.stripeProductIds ?? [],
                 productIdsPaddle: secondTry.paddleProductIds ?? [],
                 shouldEnableScroll: secondTry.shouldEnableScroll,
-                versionStatus: secondTry.versionStatus
+                versionStatus: secondTry.versionStatus ?? "draft"
             ), false)
         } catch {
             HeliumLogger.log(.warn, category: .ui, "[HeliumControlPanel] Failed to load second try bundle for preview", metadata: [

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
@@ -339,7 +339,7 @@ struct HeliumControlPanelView: View {
             do {
                 async let secondTryTask = fetchSecondTryBundle(for: paywall)
                 let (bundleId, html) = try await HeliumControlPanelService.shared.fetchSingleBundle(bundleURL: bundleUrl)
-                let secondTryResult = await secondTryTask
+                let secondTryBundle = await secondTryTask
 
                 try HeliumFetchedConfigManager.shared.setPreviewTriggerConfig(
                     bundleId: bundleId,
@@ -352,11 +352,8 @@ struct HeliumControlPanelView: View {
                     productIdsStripeWeb: version.webStripeProductIds ?? [],
                     webPaywallBundleUrl: version.webPaywallBundleUrl,
                     shouldEnableScroll: version.shouldEnableScroll,
-                    secondTry: secondTryResult.bundle
+                    secondTry: secondTryBundle
                 )
-                if secondTryResult.loadFailed {
-                    HeliumFetchedConfigManager.shared.markPreviewSecondTryLoadFailed()
-                }
 
                 guard !Task.isCancelled else {
                     await MainActor.run { activity = .idle }
@@ -377,40 +374,31 @@ struct HeliumControlPanelView: View {
     }
 
     /// Resolves a paywall's second try flow into a preview bundle. The second try must not block
-    /// or fail the main preview, so a download error only marks the load as failed — the preview
-    /// presents without a second try and the diagnostic explains why when one is requested.
+    /// or fail the main preview, so a failure only logs — the preview presents without a second
+    /// try entry and a request for it surfaces the standard second-try-no-match diagnostic.
     private func fetchSecondTryBundle(
         for paywall: HeliumPaywallPreviewEntry
-    ) async -> (bundle: HeliumFetchedConfigManager.PreviewSecondTryBundle?, loadFailed: Bool) {
-        guard let secondTry = paywall.secondTry else {
-            return (nil, false)
-        }
-        guard let secondTryBundleUrl = secondTry.bundleUrl else {
-            HeliumLogger.log(.warn, category: .ui, "[HeliumControlPanel] Second try paywall has no bundle URL", metadata: [
-                "secondTryPaywall": secondTry.paywallName,
-            ])
-            // No bundle was ever built for this second try, so the retry advice of the
-            // load-failed diagnostic cannot resolve it; the dashboard remediation can.
-            return (nil, false)
+    ) async -> HeliumFetchedConfigManager.PreviewSecondTryBundle? {
+        guard let secondTry = paywall.secondTry, let secondTryBundleUrl = secondTry.bundleUrl else {
+            return nil
         }
         do {
             let (bundleId, html) = try await HeliumControlPanelService.shared.fetchSingleBundle(bundleURL: secondTryBundleUrl)
-            return (HeliumFetchedConfigManager.PreviewSecondTryBundle(
+            return HeliumFetchedConfigManager.PreviewSecondTryBundle(
                 bundleId: bundleId,
                 bundleUrl: secondTryBundleUrl,
                 bundleHtml: html,
                 productIds: secondTry.productIds ?? [],
                 productIdsStripe: secondTry.stripeProductIds ?? [],
                 productIdsPaddle: secondTry.paddleProductIds ?? [],
-                shouldEnableScroll: secondTry.shouldEnableScroll,
-                versionStatus: secondTry.versionStatus ?? "draft"
-            ), false)
+                shouldEnableScroll: secondTry.shouldEnableScroll
+            )
         } catch {
             HeliumLogger.log(.warn, category: .ui, "[HeliumControlPanel] Failed to load second try bundle for preview", metadata: [
                 "secondTryPaywall": secondTry.paywallName,
                 "error": "\(error)",
             ])
-            return (nil, true)
+            return nil
         }
     }
 
@@ -436,7 +424,13 @@ struct HeliumControlPanelView: View {
     private func previewPresentationContext() -> PaywallPresentationContext {
         PaywallPresentationContext(
             config: PaywallPresentationConfig(dontShowIfAlreadyEntitled: false),
-            eventHandlers: PaywallEventHandlers().onClose { _ in activity = .idle },
+            // A second try preview shares this context and closes back onto the main preview,
+            // so only the main preview trigger closing releases the lock.
+            eventHandlers: PaywallEventHandlers().onClose { event in
+                if event.triggerName == HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER {
+                    activity = .idle
+                }
+            },
             onEntitled: nil,
             onPaywallNotShown: { _ in activity = .idle }
         )

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
@@ -337,7 +337,9 @@ struct HeliumControlPanelView: View {
         previewTask?.cancel()
         previewTask = Task {
             do {
+                async let secondTryTask = fetchSecondTryBundle(for: paywall)
                 let (bundleId, html) = try await HeliumControlPanelService.shared.fetchSingleBundle(bundleURL: bundleUrl)
+                let secondTryResult = await secondTryTask
 
                 try HeliumFetchedConfigManager.shared.setPreviewTriggerConfig(
                     bundleId: bundleId,
@@ -349,8 +351,12 @@ struct HeliumControlPanelView: View {
                     productIdsPaddleWeb: version.webPaddleProductIds ?? [],
                     productIdsStripeWeb: version.webStripeProductIds ?? [],
                     webPaywallBundleUrl: version.webPaywallBundleUrl,
-                    shouldEnableScroll: version.shouldEnableScroll
+                    shouldEnableScroll: version.shouldEnableScroll,
+                    secondTry: secondTryResult.bundle
                 )
+                if secondTryResult.loadFailed {
+                    HeliumFetchedConfigManager.shared.markPreviewSecondTryLoadFailed()
+                }
 
                 guard !Task.isCancelled else {
                     await MainActor.run { activity = .idle }
@@ -367,6 +373,42 @@ struct HeliumControlPanelView: View {
                     paywallLoadError = "Failed to load paywall: \(error.localizedDescription)"
                 }
             }
+        }
+    }
+
+    /// Resolves a paywall's second try flow into a preview bundle. The second try must not block
+    /// or fail the main preview, so a download error only marks the load as failed — the preview
+    /// presents without a second try and the diagnostic explains why when one is requested.
+    private func fetchSecondTryBundle(
+        for paywall: HeliumPaywallPreviewEntry
+    ) async -> (bundle: HeliumFetchedConfigManager.PreviewSecondTryBundle?, loadFailed: Bool) {
+        guard let secondTry = paywall.secondTry else {
+            return (nil, false)
+        }
+        guard let secondTryBundleUrl = secondTry.bundleUrl else {
+            HeliumLogger.log(.warn, category: .ui, "[HeliumControlPanel] Second try paywall has no bundle URL", metadata: [
+                "secondTryPaywall": secondTry.paywallName,
+            ])
+            return (nil, true)
+        }
+        do {
+            let (bundleId, html) = try await HeliumControlPanelService.shared.fetchSingleBundle(bundleURL: secondTryBundleUrl)
+            return (HeliumFetchedConfigManager.PreviewSecondTryBundle(
+                bundleId: bundleId,
+                bundleUrl: secondTryBundleUrl,
+                bundleHtml: html,
+                productIds: secondTry.productIds ?? [],
+                productIdsStripe: secondTry.stripeProductIds ?? [],
+                productIdsPaddle: secondTry.paddleProductIds ?? [],
+                shouldEnableScroll: secondTry.shouldEnableScroll,
+                versionStatus: secondTry.versionStatus
+            ), false)
+        } catch {
+            HeliumLogger.log(.warn, category: .ui, "[HeliumControlPanel] Failed to load second try bundle for preview", metadata: [
+                "secondTryPaywall": secondTry.paywallName,
+                "error": "\(error)",
+            ])
+            return (nil, true)
         }
     }
 

--- a/Sources/Helium/HeliumCore/Diagnostic/HeliumDiagnosticGate.swift
+++ b/Sources/Helium/HeliumCore/Diagnostic/HeliumDiagnosticGate.swift
@@ -140,6 +140,6 @@ extension HeliumDiagnosticGate {
     }
 
     private static func isPreviewTrigger(_ trigger: String) -> Bool {
-        trigger == HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER
+        HeliumFetchedConfigManager.isPreviewTrigger(trigger)
     }
 }

--- a/Sources/Helium/HeliumCore/Diagnostic/Mapper/DiagnosticContentMapper.swift
+++ b/Sources/Helium/HeliumCore/Diagnostic/Mapper/DiagnosticContentMapper.swift
@@ -113,22 +113,39 @@ struct DiagnosticContentMapper {
         }
     }
 
-    /// Maps a second try request coming from a triple-tap paywall preview, where second try flows
-    /// are disabled entirely. Not keyed by a `PaywallUnavailableReason`: the paywall itself rendered
-    /// fine, so no not-shown event carries this state — the presentation layer asks for it directly.
-    func mapSecondTryInPreview() -> DiagnosticContent {
-        DiagnosticContent(
-            category: .expected,
-            title: "Second try flows can't be previewed",
-            body: "This paywall asked Helium to open its second try paywall, but second try flows "
-                + "are not supported in paywall previews. Add this paywall to a workflow and "
-                + "trigger it from there to test its second try flow.",
-            usersWillSee: "This only applies to paywall previews. Users who reach this paywall "
-                + "through a workflow see its second try flow normally.",
-            usersWillSeeLink: nil,
-            cta: .openUrl(label: "Open Workflows", url: Url.workflows),
-            reasonCode: "secondTryNotSupportedInPreview"
-        )
+    /// Maps a second try request from a triple-tap paywall preview that has no second try to
+    /// present. Not keyed by a `PaywallUnavailableReason`: the paywall itself rendered fine, so
+    /// no not-shown event carries this state — the presentation layer asks for it directly.
+    func mapSecondTryPreviewUnavailable(
+        _ state: HeliumFetchedConfigManager.PreviewSecondTryState
+    ) -> DiagnosticContent {
+        switch state {
+        case .loadFailed:
+            return DiagnosticContent(
+                category: .expected,
+                title: "Second try flow couldn't be loaded",
+                body: "This paywall has a second try flow, but its bundle failed to download "
+                    + "when this preview was opened. Close the preview and open it again to retry.",
+                usersWillSee: "This only applies to paywall previews. Users who reach this paywall "
+                    + "through a workflow see its second try flow normally.",
+                usersWillSeeLink: nil,
+                cta: .copyReport,
+                reasonCode: "secondTryPreviewLoadFailed"
+            )
+        case .notConfigured, .armed:
+            return DiagnosticContent(
+                category: .expected,
+                title: "No second try flow to preview",
+                body: "This paywall asked Helium to open its second try paywall, but no second "
+                    + "try flow is configured for it. Configure one in the dashboard, then "
+                    + "reopen this preview to test it.",
+                usersWillSee: "Users stay on this paywall when it requests its second try, until "
+                    + "a second try flow is configured and the paywall is published.",
+                usersWillSeeLink: nil,
+                cta: .openUrl(label: "Open Paywalls", url: Url.paywalls),
+                reasonCode: "secondTryNotConfiguredInPreview"
+            )
+        }
     }
 
     // MARK: - EXPECTED

--- a/Sources/Helium/HeliumCore/Diagnostic/Mapper/DiagnosticContentMapper.swift
+++ b/Sources/Helium/HeliumCore/Diagnostic/Mapper/DiagnosticContentMapper.swift
@@ -113,41 +113,6 @@ struct DiagnosticContentMapper {
         }
     }
 
-    /// Maps a second try request from a triple-tap paywall preview that has no second try to
-    /// present. Not keyed by a `PaywallUnavailableReason`: the paywall itself rendered fine, so
-    /// no not-shown event carries this state — the presentation layer asks for it directly.
-    func mapSecondTryPreviewUnavailable(
-        _ state: HeliumFetchedConfigManager.PreviewSecondTryState
-    ) -> DiagnosticContent {
-        switch state {
-        case .loadFailed:
-            return DiagnosticContent(
-                category: .expected,
-                title: "Second try flow couldn't be loaded",
-                body: "This paywall has a second try flow, but its bundle failed to download "
-                    + "when this preview was opened. Close the preview and open it again to retry.",
-                usersWillSee: "This only applies to paywall previews. Users who reach this paywall "
-                    + "through a workflow see its second try flow normally.",
-                usersWillSeeLink: nil,
-                cta: .copyReport,
-                reasonCode: "secondTryPreviewLoadFailed"
-            )
-        case .notConfigured, .armed:
-            return DiagnosticContent(
-                category: .expected,
-                title: "No second try flow to preview",
-                body: "This paywall asked Helium to open its second try paywall, but no second "
-                    + "try flow is configured for it. Configure one in the dashboard, then "
-                    + "reopen this preview to test it.",
-                usersWillSee: "Users stay on this paywall when it requests its second try, until "
-                    + "a second try flow is configured and the paywall is published.",
-                usersWillSeeLink: nil,
-                cta: .openUrl(label: "Open Paywalls", url: Url.paywalls),
-                reasonCode: "secondTryNotConfiguredInPreview"
-            )
-        }
-    }
-
     // MARK: - EXPECTED
 
     private func targetingHoldout() -> DiagnosticContent {

--- a/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
@@ -171,13 +171,6 @@ class HeliumActionsDelegate: ObservableObject {
     
     func showSecondaryPaywall(uuid: String?) {
         if !isLoading {
-            if HeliumFetchedConfigManager.isPreviewTrigger(trigger) {
-                // A uuid lookup here could resolve to a real trigger and present a production
-                // paywall inside a preview, so previews only ever use the preview second try
-                // entry the control panel installed.
-                showSecondaryPaywallForPreview()
-                return
-            }
             // Re-use same presentation context as underlying paywall. Integrator can check
             // isSecondTry to distinguish events.
             let presentationContext = paywallSession.presentationContext
@@ -203,43 +196,6 @@ class HeliumActionsDelegate: ObservableObject {
         }
     }
     
-    private func showSecondaryPaywallForPreview() {
-        let secondTryTrigger = HeliumFetchedConfigManager.HELIUM_PREVIEW_SECOND_TRY_TRIGGER
-        let state = HeliumFetchedConfigManager.shared.previewSecondTryState
-
-        if trigger == HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER,
-           case .armed(let versionStatus) = state,
-           Helium.shared.getPaywallInfo(trigger: secondTryTrigger) != nil {
-            if versionStatus != "published" {
-                HeliumLogger.log(.info, category: .ui, "Previewing a second try flow that has never been published; real users will not see it until the paywall is published", metadata: ["trigger": trigger])
-            }
-            lastShownSecondTryTrigger = secondTryTrigger
-            // The presenting context belongs to the control panel, whose close handler re-enables
-            // the panel. The second try closing while the main preview is still on screen must not
-            // fire it, so only the config carries over.
-            let secondTryContext = PaywallPresentationContext(
-                config: paywallSession.presentationContext.config,
-                eventHandlers: nil,
-                onEntitled: nil,
-                onPaywallNotShown: nil
-            )
-            HeliumPaywallPresenter.shared.presentUpsell(trigger: secondTryTrigger, isSecondTry: true, presentationContext: secondTryContext)
-            return
-        }
-
-        // A second try preview requesting its own second try lands here too and gets the
-        // not-configured explanation rather than another level of nesting.
-        let content = DiagnosticContentMapper().mapSecondTryPreviewUnavailable(state)
-        HeliumLogger.log(.info, category: .ui, DiagnosticLogLineMapper().map(content), metadata: ["trigger": trigger])
-        Task { @MainActor in
-            HeliumPaywallDiagnosticView.presentIfNeeded(
-                trigger: trigger,
-                content: content,
-                fallbackShown: false
-            )
-        }
-    }
-
     func onCTAPress(contentComponentName: String) {
         if (!isLoading) {
             let event = PaywallButtonPressedEvent(

--- a/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
@@ -175,8 +175,11 @@ class HeliumActionsDelegate: ObservableObject {
             // isSecondTry to distinguish events.
             let presentationContext = paywallSession.presentationContext
             let secondTryTrigger = "\(trigger)_second_try"
-            // Try uuid lookup first
-            if let uuid, let foundTrigger = HeliumFetchedConfigManager.shared.getTriggerFromPaywallUuid(uuid) {
+            // Try uuid lookup first. Previews skip it: the uuid can match the same paywall
+            // served under a live trigger, which would present a production entry — real
+            // experiment attribution and checkout — instead of the installed preview entry.
+            if let uuid, !HeliumFetchedConfigManager.isPreviewTrigger(trigger),
+               let foundTrigger = HeliumFetchedConfigManager.shared.getTriggerFromPaywallUuid(uuid) {
                 lastShownSecondTryTrigger = foundTrigger
                 HeliumPaywallPresenter.shared.presentUpsell(trigger: foundTrigger, isSecondTry: true, presentationContext: presentationContext)
             } // Otherwise try second_try trigger

--- a/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
@@ -171,8 +171,11 @@ class HeliumActionsDelegate: ObservableObject {
     
     func showSecondaryPaywall(uuid: String?) {
         if !isLoading {
-            if trigger == HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER {
-                showSecondTryUnsupportedInPreviewDiagnostic()
+            if HeliumFetchedConfigManager.isPreviewTrigger(trigger) {
+                // A uuid lookup here could resolve to a real trigger and present a production
+                // paywall inside a preview, so previews only ever use the preview second try
+                // entry the control panel installed.
+                showSecondaryPaywallForPreview()
                 return
             }
             // Re-use same presentation context as underlying paywall. Integrator can check
@@ -200,8 +203,24 @@ class HeliumActionsDelegate: ObservableObject {
         }
     }
     
-    private func showSecondTryUnsupportedInPreviewDiagnostic() {
-        let content = DiagnosticContentMapper().mapSecondTryInPreview()
+    private func showSecondaryPaywallForPreview() {
+        let secondTryTrigger = HeliumFetchedConfigManager.HELIUM_PREVIEW_SECOND_TRY_TRIGGER
+        let state = HeliumFetchedConfigManager.shared.previewSecondTryState
+
+        if trigger == HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER,
+           case .armed(let versionStatus) = state,
+           Helium.shared.getPaywallInfo(trigger: secondTryTrigger) != nil {
+            if versionStatus != "published" {
+                HeliumLogger.log(.info, category: .ui, "Previewing a second try flow that has never been published; real users will not see it until the paywall is published", metadata: ["trigger": trigger])
+            }
+            lastShownSecondTryTrigger = secondTryTrigger
+            HeliumPaywallPresenter.shared.presentUpsell(trigger: secondTryTrigger, isSecondTry: true, presentationContext: paywallSession.presentationContext)
+            return
+        }
+
+        // A second try preview requesting its own second try lands here too and gets the
+        // not-configured explanation rather than another level of nesting.
+        let content = DiagnosticContentMapper().mapSecondTryPreviewUnavailable(state)
         HeliumLogger.log(.info, category: .ui, DiagnosticLogLineMapper().map(content), metadata: ["trigger": trigger])
         Task { @MainActor in
             HeliumPaywallDiagnosticView.presentIfNeeded(

--- a/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
@@ -214,7 +214,16 @@ class HeliumActionsDelegate: ObservableObject {
                 HeliumLogger.log(.info, category: .ui, "Previewing a second try flow that has never been published; real users will not see it until the paywall is published", metadata: ["trigger": trigger])
             }
             lastShownSecondTryTrigger = secondTryTrigger
-            HeliumPaywallPresenter.shared.presentUpsell(trigger: secondTryTrigger, isSecondTry: true, presentationContext: paywallSession.presentationContext)
+            // The presenting context belongs to the control panel, whose close handler re-enables
+            // the panel. The second try closing while the main preview is still on screen must not
+            // fire it, so only the config carries over.
+            let secondTryContext = PaywallPresentationContext(
+                config: paywallSession.presentationContext.config,
+                eventHandlers: nil,
+                onEntitled: nil,
+                onPaywallNotShown: nil
+            )
+            HeliumPaywallPresenter.shared.presentUpsell(trigger: secondTryTrigger, isSecondTry: true, presentationContext: secondTryContext)
             return
         }
 

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -1060,9 +1060,14 @@ public class HeliumFetchedConfigManager {
     }
 
     /// Records that the previewed paywall has a second try flow whose bundle could not be
-    /// fetched, after the preview config was installed without one.
+    /// fetched, after the preview config was installed without one. Only upgrades the
+    /// not-configured state: a late call from an abandoned preview task must not clobber a
+    /// second try a newer preview has since armed.
     func markPreviewSecondTryLoadFailed() {
-        previewSecondTryState = .loadFailed
+        _previewSecondTryState.withValue { state in
+            guard case .notConfigured = state else { return }
+            state = .loadFailed
+        }
     }
 
     /// True when a bundled default fallback paywall is available to preview on this device.

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -211,8 +211,7 @@ public class HeliumFetchedConfigManager {
         shared.fetchedConfigJSON = nil
         shared.triggersWithSkippedBundleAndReason = []
         shared.localizedPriceMap = [:]
-        shared.isFallbackPreviewArmed = false
-        shared.previewSecondTryState = .notConfigured
+        HeliumControlPanelService.shared.isFallbackPreviewArmed = false
     }
 
     /// Inject config for testing purposes only. Accessible via @testable import.
@@ -237,8 +236,6 @@ public class HeliumFetchedConfigManager {
     @HeliumAtomic private(set) var fetchedConfigJSON: JSON?
     @HeliumAtomic private(set) var triggersWithSkippedBundleAndReason: [(trigger: String, reason: PaywallUnavailableReason)] = []
     @HeliumAtomic private var localizedPriceMap: [String: LocalizedPrice] = [:]
-    @HeliumAtomic private(set) var isFallbackPreviewArmed: Bool = false
-    @HeliumAtomic private(set) var previewSecondTryState: PreviewSecondTryState = .notConfigured
     
     func fetchConfig(
         endpoint: String,
@@ -996,7 +993,7 @@ public class HeliumFetchedConfigManager {
     public func getProductIDsForTrigger(_ trigger: String) -> [String]? {
         // While a fallback preview is armed, the paywall under the preview trigger is the
         // bundled fallback entry, which only the fallback manager knows about.
-        if trigger == Self.HELIUM_PREVIEW_TRIGGER, isFallbackPreviewArmed {
+        if trigger == Self.HELIUM_PREVIEW_TRIGGER, HeliumControlPanelService.shared.isFallbackPreviewArmed {
             return HeliumFallbackViewManager.shared.getFallbackInfo(trigger: trigger)?.productIds
         }
         return fetchedConfig?.triggerToPaywalls[trigger]?.productIds
@@ -1037,15 +1034,6 @@ public class HeliumFetchedConfigManager {
         trigger == HELIUM_PREVIEW_TRIGGER || trigger == HELIUM_PREVIEW_SECOND_TRY_TRIGGER
     }
 
-    /// Why a second try request from the current preview can present or not — set alongside the
-    /// preview trigger config so the diagnostic shown for an unpresentable second try can say
-    /// whether nothing is configured or this preview simply failed to load it.
-    enum PreviewSecondTryState: Equatable {
-        case notConfigured
-        case loadFailed
-        case armed(versionStatus: String)
-    }
-
     /// The bundle and products for a preview's second try paywall, resolved by the control
     /// panel before the preview presents.
     struct PreviewSecondTryBundle {
@@ -1056,18 +1044,6 @@ public class HeliumFetchedConfigManager {
         let productIdsStripe: [String]
         let productIdsPaddle: [String]
         let shouldEnableScroll: Bool?
-        let versionStatus: String
-    }
-
-    /// Records that the previewed paywall has a second try flow whose bundle could not be
-    /// fetched, after the preview config was installed without one. Only upgrades the
-    /// not-configured state: a late call from an abandoned preview task must not clobber a
-    /// second try a newer preview has since armed.
-    func markPreviewSecondTryLoadFailed() {
-        _previewSecondTryState.withValue { state in
-            guard case .notConfigured = state else { return }
-            state = .loadFailed
-        }
     }
 
     /// True when a bundled default fallback paywall is available to preview on this device.
@@ -1098,8 +1074,7 @@ public class HeliumFetchedConfigManager {
             guard removedPreview || removedSecondTry else { return }
             json?["triggerToPaywalls"].dictionaryObject = triggers
         }
-        previewSecondTryState = .notConfigured
-        isFallbackPreviewArmed = true
+        HeliumControlPanelService.shared.isFallbackPreviewArmed = true
         return true
     }
 
@@ -1153,8 +1128,7 @@ public class HeliumFetchedConfigManager {
             )
         }
 
-        previewSecondTryState = secondTry.map { .armed(versionStatus: $0.versionStatus) } ?? .notConfigured
-        isFallbackPreviewArmed = false
+        HeliumControlPanelService.shared.isFallbackPreviewArmed = false
     }
 
     /// Returns the trigger the preview was cloned from: the JSON mirror has to clone the same
@@ -1287,21 +1261,27 @@ public class HeliumFetchedConfigManager {
         secondTry: PreviewSecondTryBundle?
     ) -> JSON {
         var configJSON = configJSON
-        var sourceJSON = configJSON["triggerToPaywalls"][sourceTrigger]
-        sourceJSON["resolvedConfig"]["baseStack"]["componentProps"]["bundleURL"] = JSON(bundleUrl)
-        sourceJSON["resolvedConfig"]["baseStack"]["componentProps"]["shouldEnableScroll"] = JSON(shouldEnableScroll ?? true)
-        configJSON["triggerToPaywalls"][HELIUM_PREVIEW_TRIGGER] = sourceJSON
+        let sourceJSON = configJSON["triggerToPaywalls"][sourceTrigger]
+        configJSON["triggerToPaywalls"][HELIUM_PREVIEW_TRIGGER] = previewEntryJSON(
+            clonedFrom: sourceJSON, bundleUrl: bundleUrl, shouldEnableScroll: shouldEnableScroll
+        )
 
         if let secondTry {
-            var secondTryJSON = configJSON["triggerToPaywalls"][sourceTrigger]
-            secondTryJSON["resolvedConfig"]["baseStack"]["componentProps"]["bundleURL"] = JSON(secondTry.bundleUrl)
-            secondTryJSON["resolvedConfig"]["baseStack"]["componentProps"]["shouldEnableScroll"] = JSON(secondTry.shouldEnableScroll ?? true)
-            configJSON["triggerToPaywalls"][HELIUM_PREVIEW_SECOND_TRY_TRIGGER] = secondTryJSON
+            configJSON["triggerToPaywalls"][HELIUM_PREVIEW_SECOND_TRY_TRIGGER] = previewEntryJSON(
+                clonedFrom: sourceJSON, bundleUrl: secondTry.bundleUrl, shouldEnableScroll: secondTry.shouldEnableScroll
+            )
         } else if var triggers = configJSON["triggerToPaywalls"].dictionaryObject,
                   triggers.removeValue(forKey: HELIUM_PREVIEW_SECOND_TRY_TRIGGER) != nil {
             configJSON["triggerToPaywalls"].dictionaryObject = triggers
         }
         return configJSON
+    }
+
+    private static func previewEntryJSON(clonedFrom sourceJSON: JSON, bundleUrl: String, shouldEnableScroll: Bool?) -> JSON {
+        var entryJSON = sourceJSON
+        entryJSON["resolvedConfig"]["baseStack"]["componentProps"]["bundleURL"] = JSON(bundleUrl)
+        entryJSON["resolvedConfig"]["baseStack"]["componentProps"]["shouldEnableScroll"] = JSON(shouldEnableScroll ?? true)
+        return entryJSON
     }
 }
 

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -212,6 +212,7 @@ public class HeliumFetchedConfigManager {
         shared.triggersWithSkippedBundleAndReason = []
         shared.localizedPriceMap = [:]
         shared.isFallbackPreviewArmed = false
+        shared.previewSecondTryState = .notConfigured
     }
 
     /// Inject config for testing purposes only. Accessible via @testable import.
@@ -237,6 +238,7 @@ public class HeliumFetchedConfigManager {
     @HeliumAtomic private(set) var triggersWithSkippedBundleAndReason: [(trigger: String, reason: PaywallUnavailableReason)] = []
     @HeliumAtomic private var localizedPriceMap: [String: LocalizedPrice] = [:]
     @HeliumAtomic private(set) var isFallbackPreviewArmed: Bool = false
+    @HeliumAtomic private(set) var previewSecondTryState: PreviewSecondTryState = .notConfigured
     
     func fetchConfig(
         endpoint: String,
@@ -1024,6 +1026,44 @@ public class HeliumFetchedConfigManager {
     // MARK: - Preview Control Panel
 
     static let HELIUM_PREVIEW_TRIGGER = "helium_preview_trigger"
+    /// Derived with the same `_second_try` suffix the actions delegate appends to a presenting
+    /// trigger, so a preview paywall's second try request resolves to this entry.
+    static let HELIUM_PREVIEW_SECOND_TRY_TRIGGER = HELIUM_PREVIEW_TRIGGER + "_second_try"
+
+    /// True for both synthetic control-panel triggers. Preview-only behaviors (no silent
+    /// fallback substitution, diagnostics always allowed, triple-tap returns to the panel)
+    /// apply to the second try preview the same as to the main one.
+    static func isPreviewTrigger(_ trigger: String?) -> Bool {
+        trigger == HELIUM_PREVIEW_TRIGGER || trigger == HELIUM_PREVIEW_SECOND_TRY_TRIGGER
+    }
+
+    /// Why a second try request from the current preview can present or not — set alongside the
+    /// preview trigger config so the diagnostic shown for an unpresentable second try can say
+    /// whether nothing is configured or this preview simply failed to load it.
+    enum PreviewSecondTryState: Equatable {
+        case notConfigured
+        case loadFailed
+        case armed(versionStatus: String)
+    }
+
+    /// The bundle and products for a preview's second try paywall, resolved by the control
+    /// panel before the preview presents.
+    struct PreviewSecondTryBundle {
+        let bundleId: String
+        let bundleUrl: String
+        let bundleHtml: String
+        let productIds: [String]
+        let productIdsStripe: [String]
+        let productIdsPaddle: [String]
+        let shouldEnableScroll: Bool?
+        let versionStatus: String
+    }
+
+    /// Records that the previewed paywall has a second try flow whose bundle could not be
+    /// fetched, after the preview config was installed without one.
+    func markPreviewSecondTryLoadFailed() {
+        previewSecondTryState = .loadFailed
+    }
 
     /// True when a bundled default fallback paywall is available to preview on this device.
     /// Requires the same resolvable bundle path presentation requires, so a default entry that
@@ -1044,12 +1084,16 @@ public class HeliumFetchedConfigManager {
         // the typed config and keep the JSON mirror agreeing that no entry exists.
         _fetchedConfig.withValue {
             $0?.triggerToPaywalls.removeValue(forKey: Self.HELIUM_PREVIEW_TRIGGER)
+            $0?.triggerToPaywalls.removeValue(forKey: Self.HELIUM_PREVIEW_SECOND_TRY_TRIGGER)
         }
         _fetchedConfigJSON.withValue { json in
-            guard var triggers = json?["triggerToPaywalls"].dictionaryObject,
-                  triggers.removeValue(forKey: Self.HELIUM_PREVIEW_TRIGGER) != nil else { return }
+            guard var triggers = json?["triggerToPaywalls"].dictionaryObject else { return }
+            let removedPreview = triggers.removeValue(forKey: Self.HELIUM_PREVIEW_TRIGGER) != nil
+            let removedSecondTry = triggers.removeValue(forKey: Self.HELIUM_PREVIEW_SECOND_TRY_TRIGGER) != nil
+            guard removedPreview || removedSecondTry else { return }
             json?["triggerToPaywalls"].dictionaryObject = triggers
         }
+        previewSecondTryState = .notConfigured
         isFallbackPreviewArmed = true
         return true
     }
@@ -1067,6 +1111,7 @@ public class HeliumFetchedConfigManager {
         productIdsStripeWeb: [String],
         webPaywallBundleUrl: String? = nil,
         shouldEnableScroll: Bool? = nil,
+        secondTry: PreviewSecondTryBundle? = nil
     ) throws {
         // Read-modify-write under the lock, so a fetch landing mid-update is not clobbered by the
         // write-back of a copy taken before it.
@@ -1085,7 +1130,8 @@ public class HeliumFetchedConfigManager {
                 productIdsPaddleWeb: productIdsPaddleWeb,
                 productIdsStripeWeb: productIdsStripeWeb,
                 webPaywallBundleUrl: webPaywallBundleUrl,
-                shouldEnableScroll: shouldEnableScroll
+                shouldEnableScroll: shouldEnableScroll,
+                secondTry: secondTry
             )
             stored = config
             return sourceTrigger
@@ -1097,10 +1143,12 @@ public class HeliumFetchedConfigManager {
                 configJSON,
                 clonedFrom: sourceTrigger,
                 bundleUrl: bundleUrl,
-                shouldEnableScroll: shouldEnableScroll
+                shouldEnableScroll: shouldEnableScroll,
+                secondTry: secondTry
             )
         }
 
+        previewSecondTryState = secondTry.map { .armed(versionStatus: $0.versionStatus) } ?? .notConfigured
         isFallbackPreviewArmed = false
     }
 
@@ -1117,15 +1165,72 @@ public class HeliumFetchedConfigManager {
         productIdsPaddleWeb: [String],
         productIdsStripeWeb: [String],
         webPaywallBundleUrl: String?,
-        shouldEnableScroll: Bool?
+        shouldEnableScroll: Bool?,
+        secondTry: PreviewSecondTryBundle?
     ) throws -> String {
         guard let sourceTrigger = config.triggerToPaywalls.keys
-            .filter({ $0 != HELIUM_PREVIEW_TRIGGER })
+            .filter({ !isPreviewTrigger($0) })
             .sorted()
             .first,
-              var previewPaywallInfo = config.triggerToPaywalls[sourceTrigger] else {
+              let donorPaywallInfo = config.triggerToPaywalls[sourceTrigger] else {
             throw HeliumControlPanelError.noSourceTrigger
         }
+
+        config.triggerToPaywalls[HELIUM_PREVIEW_TRIGGER] = try previewEntry(
+            clonedFrom: donorPaywallInfo,
+            bundleUrl: bundleUrl,
+            productIds: productIds,
+            productIdsStripe: productIdsStripe,
+            productIdsPaddle: productIdsPaddle,
+            productIdsPaddleWeb: productIdsPaddleWeb,
+            productIdsStripeWeb: productIdsStripeWeb,
+            webPaywallBundleUrl: webPaywallBundleUrl,
+            shouldEnableScroll: shouldEnableScroll
+        )
+
+        // A second try entry from an earlier preview must not survive into a preview of a
+        // paywall that has none.
+        if let secondTry {
+            config.triggerToPaywalls[HELIUM_PREVIEW_SECOND_TRY_TRIGGER] = try previewEntry(
+                clonedFrom: donorPaywallInfo,
+                bundleUrl: secondTry.bundleUrl,
+                productIds: secondTry.productIds,
+                productIdsStripe: secondTry.productIdsStripe,
+                productIdsPaddle: secondTry.productIdsPaddle,
+                productIdsPaddleWeb: [],
+                productIdsStripeWeb: [],
+                webPaywallBundleUrl: nil,
+                shouldEnableScroll: secondTry.shouldEnableScroll
+            )
+        } else {
+            config.triggerToPaywalls.removeValue(forKey: HELIUM_PREVIEW_SECOND_TRY_TRIGGER)
+        }
+
+        if config.bundles == nil {
+            config.bundles = [:]
+        }
+        config.bundles?[bundleId] = bundleHtml
+        if let secondTry {
+            config.bundles?[secondTry.bundleId] = secondTry.bundleHtml
+        }
+
+        return sourceTrigger
+    }
+
+    /// Clones a donor trigger's paywall info and overrides everything specific to the previewed
+    /// version, so nothing of the donor's own paywall leaks into the preview.
+    private static func previewEntry(
+        clonedFrom donorPaywallInfo: HeliumPaywallInfo,
+        bundleUrl: String,
+        productIds: [String],
+        productIdsStripe: [String],
+        productIdsPaddle: [String],
+        productIdsPaddleWeb: [String],
+        productIdsStripeWeb: [String],
+        webPaywallBundleUrl: String?,
+        shouldEnableScroll: Bool?
+    ) throws -> HeliumPaywallInfo {
+        var previewPaywallInfo = donorPaywallInfo
 
         // A paywall's bundle URL is resolved from this nested config before any other field, so a
         // donor URL left in place here would win over the preview's own.
@@ -1166,27 +1271,31 @@ public class HeliumFetchedConfigManager {
         // instead of the version the developer picked.
         previewPaywallInfo.forceShowFallback = nil
 
-        config.triggerToPaywalls[HELIUM_PREVIEW_TRIGGER] = previewPaywallInfo
-
-        if config.bundles == nil {
-            config.bundles = [:]
-        }
-        config.bundles?[bundleId] = bundleHtml
-
-        return sourceTrigger
+        return previewPaywallInfo
     }
 
     private static func withPreviewTrigger(
         _ configJSON: JSON,
         clonedFrom sourceTrigger: String,
         bundleUrl: String,
-        shouldEnableScroll: Bool?
+        shouldEnableScroll: Bool?,
+        secondTry: PreviewSecondTryBundle?
     ) -> JSON {
         var configJSON = configJSON
         var sourceJSON = configJSON["triggerToPaywalls"][sourceTrigger]
         sourceJSON["resolvedConfig"]["baseStack"]["componentProps"]["bundleURL"] = JSON(bundleUrl)
         sourceJSON["resolvedConfig"]["baseStack"]["componentProps"]["shouldEnableScroll"] = JSON(shouldEnableScroll ?? true)
         configJSON["triggerToPaywalls"][HELIUM_PREVIEW_TRIGGER] = sourceJSON
+
+        if let secondTry {
+            var secondTryJSON = configJSON["triggerToPaywalls"][sourceTrigger]
+            secondTryJSON["resolvedConfig"]["baseStack"]["componentProps"]["bundleURL"] = JSON(secondTry.bundleUrl)
+            secondTryJSON["resolvedConfig"]["baseStack"]["componentProps"]["shouldEnableScroll"] = JSON(secondTry.shouldEnableScroll ?? true)
+            configJSON["triggerToPaywalls"][HELIUM_PREVIEW_SECOND_TRY_TRIGGER] = secondTryJSON
+        } else if var triggers = configJSON["triggerToPaywalls"].dictionaryObject,
+                  triggers.removeValue(forKey: HELIUM_PREVIEW_SECOND_TRY_TRIGGER) != nil {
+            configJSON["triggerToPaywalls"].dictionaryObject = triggers
+        }
         return configJSON
     }
 }

--- a/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
+++ b/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
@@ -561,7 +561,7 @@ extension HeliumPaywallPresenter {
         // forceShowFallback, and with it the same banner, diagnostic copy, and analytics
         // labeling as a trigger configured to force its fallback.
         if trigger == HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER,
-           HeliumFetchedConfigManager.shared.isFallbackPreviewArmed {
+           HeliumControlPanelService.shared.isFallbackPreviewArmed {
             return fallbackBundleViewFor(trigger: trigger, fallbackReason: .forceShowFallback, presentationContext: presentationContext)
         }
 

--- a/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
+++ b/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
@@ -646,7 +646,7 @@ extension HeliumPaywallPresenter {
     private func fallbackViewFor(trigger: String, paywallInfo: HeliumPaywallInfo?, fallbackReason: PaywallUnavailableReason, presentationContext: PaywallPresentationContext) -> PaywallViewResult {
         
         // A failed preview must surface its failure, never silently render a fallback in its place.
-        if trigger == HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER {
+        if HeliumFetchedConfigManager.isPreviewTrigger(trigger) {
             return PaywallViewResult(viewAndSession: nil, fallbackReason: fallbackReason)
         }
 

--- a/Tests/helium-swiftTests/DiagnosticContentMapperTests.swift
+++ b/Tests/helium-swiftTests/DiagnosticContentMapperTests.swift
@@ -29,7 +29,12 @@ final class DiagnosticContentMapperTests: XCTestCase {
     private func allContent() -> [DiagnosticContent] {
         PaywallSkippedReason.allCases.map { mapper.mapSkip($0) }
             + PaywallUnavailableReason.allCases.map { content(for: $0) }
-            + [content(for: nil), mapper.mapSecondTryInPreview(), previewFallbackContent()]
+            + [
+                content(for: nil),
+                mapper.mapSecondTryPreviewUnavailable(.notConfigured),
+                mapper.mapSecondTryPreviewUnavailable(.loadFailed),
+                previewFallbackContent(),
+            ]
     }
 
     // MARK: - Forward compat: no raw codes leak into displayed prose
@@ -189,20 +194,41 @@ final class DiagnosticContentMapperTests: XCTestCase {
         )
     }
 
-    /// Nothing is broken when a preview declines a second try, so the record is expected-category,
-    /// names the workflow remediation, and reassures that real users are unaffected.
-    func testSecondTryInPreviewAdvisesAWorkflowAndReassuresAboutRealUsers() {
-        let content = mapper.mapSecondTryInPreview()
+    /// Nothing is broken when a preview has no second try to present, so the record is
+    /// expected-category, names the dashboard remediation, and states what real users see.
+    func testSecondTryPreviewNotConfiguredAdvisesConfiguringAndStatesUserOutcome() {
+        let content = mapper.mapSecondTryPreviewUnavailable(.notConfigured)
 
         XCTAssertEqual(content.category, .expected)
-        XCTAssertEqual(content.title, "Second try flows can't be previewed")
-        XCTAssertTrue(content.body.contains("Add this paywall to a workflow"))
-        XCTAssertTrue(content.usersWillSee.contains("see its second try flow normally"))
+        XCTAssertEqual(content.title, "No second try flow to preview")
+        XCTAssertTrue(content.body.contains("no second try flow is configured"))
+        XCTAssertTrue(content.usersWillSee.contains("Users stay on this paywall"))
         XCTAssertEqual(
             content.cta,
-            .openUrl(label: "Open Workflows", url: "https://app.tryhelium.com/workflows")
+            .openUrl(label: "Open Paywalls", url: "https://app.tryhelium.com/paywalls")
         )
-        XCTAssertEqual(content.reasonCode, "secondTryNotSupportedInPreview")
+        XCTAssertEqual(content.reasonCode, "secondTryNotConfiguredInPreview")
+    }
+
+    /// A download failure is preview-local, so the record advises a retry and reassures that
+    /// real users are unaffected.
+    func testSecondTryPreviewLoadFailedAdvisesRetryAndReassuresAboutRealUsers() {
+        let content = mapper.mapSecondTryPreviewUnavailable(.loadFailed)
+
+        XCTAssertEqual(content.category, .expected)
+        XCTAssertEqual(content.title, "Second try flow couldn't be loaded")
+        XCTAssertTrue(content.body.contains("failed to download"))
+        XCTAssertTrue(content.usersWillSee.contains("see its second try flow normally"))
+        XCTAssertEqual(content.cta, .copyReport)
+        XCTAssertEqual(content.reasonCode, "secondTryPreviewLoadFailed")
+    }
+
+    /// The armed state reaches the mapper when a second try preview requests its own second try,
+    /// or when the armed entry is missing from the config; both must map to a coherent record.
+    func testSecondTryPreviewArmedMapsToNotConfiguredRecord() {
+        let content = mapper.mapSecondTryPreviewUnavailable(.armed(versionStatus: "published"))
+
+        XCTAssertEqual(content.reasonCode, "secondTryNotConfiguredInPreview")
     }
 
     /// The modal only presents when nothing rendered, so a forced fallback reaching it means the

--- a/Tests/helium-swiftTests/DiagnosticContentMapperTests.swift
+++ b/Tests/helium-swiftTests/DiagnosticContentMapperTests.swift
@@ -25,16 +25,11 @@ final class DiagnosticContentMapperTests: XCTestCase {
     }
 
     /// Every authored record: both skip reasons, every unavailable reason, the nil path, and the
-    /// preview-only records (second try, fallback preview).
+    /// preview-only fallback record.
     private func allContent() -> [DiagnosticContent] {
         PaywallSkippedReason.allCases.map { mapper.mapSkip($0) }
             + PaywallUnavailableReason.allCases.map { content(for: $0) }
-            + [
-                content(for: nil),
-                mapper.mapSecondTryPreviewUnavailable(.notConfigured),
-                mapper.mapSecondTryPreviewUnavailable(.loadFailed),
-                previewFallbackContent(),
-            ]
+            + [content(for: nil), previewFallbackContent()]
     }
 
     // MARK: - Forward compat: no raw codes leak into displayed prose
@@ -194,42 +189,6 @@ final class DiagnosticContentMapperTests: XCTestCase {
         )
     }
 
-    /// Nothing is broken when a preview has no second try to present, so the record is
-    /// expected-category, names the dashboard remediation, and states what real users see.
-    func testSecondTryPreviewNotConfiguredAdvisesConfiguringAndStatesUserOutcome() {
-        let content = mapper.mapSecondTryPreviewUnavailable(.notConfigured)
-
-        XCTAssertEqual(content.category, .expected)
-        XCTAssertEqual(content.title, "No second try flow to preview")
-        XCTAssertTrue(content.body.contains("no second try flow is configured"))
-        XCTAssertTrue(content.usersWillSee.contains("Users stay on this paywall"))
-        XCTAssertEqual(
-            content.cta,
-            .openUrl(label: "Open Paywalls", url: "https://app.tryhelium.com/paywalls")
-        )
-        XCTAssertEqual(content.reasonCode, "secondTryNotConfiguredInPreview")
-    }
-
-    /// A download failure is preview-local, so the record advises a retry and reassures that
-    /// real users are unaffected.
-    func testSecondTryPreviewLoadFailedAdvisesRetryAndReassuresAboutRealUsers() {
-        let content = mapper.mapSecondTryPreviewUnavailable(.loadFailed)
-
-        XCTAssertEqual(content.category, .expected)
-        XCTAssertEqual(content.title, "Second try flow couldn't be loaded")
-        XCTAssertTrue(content.body.contains("failed to download"))
-        XCTAssertTrue(content.usersWillSee.contains("see its second try flow normally"))
-        XCTAssertEqual(content.cta, .copyReport)
-        XCTAssertEqual(content.reasonCode, "secondTryPreviewLoadFailed")
-    }
-
-    /// The armed state reaches the mapper when a second try preview requests its own second try,
-    /// or when the armed entry is missing from the config; both must map to a coherent record.
-    func testSecondTryPreviewArmedMapsToNotConfiguredRecord() {
-        let content = mapper.mapSecondTryPreviewUnavailable(.armed(versionStatus: "published"))
-
-        XCTAssertEqual(content.reasonCode, "secondTryNotConfiguredInPreview")
-    }
 
     /// The modal only presents when nothing rendered, so a forced fallback reaching it means the
     /// fallback itself failed. The title and body state the cause — true in both the modal and the

--- a/Tests/helium-swiftTests/FallbackPreviewTests.swift
+++ b/Tests/helium-swiftTests/FallbackPreviewTests.swift
@@ -84,13 +84,13 @@ final class FallbackPreviewTests: XCTestCase {
 
         XCTAssertTrue(HeliumFetchedConfigManager.shared.hasConfiguredFallbackPreview())
         XCTAssertTrue(HeliumFetchedConfigManager.shared.setFallbackPreviewTrigger())
-        XCTAssertTrue(HeliumFetchedConfigManager.shared.isFallbackPreviewArmed)
+        XCTAssertTrue(HeliumControlPanelService.shared.isFallbackPreviewArmed)
     }
 
     func testSetFallbackPreviewTriggerReturnsFalseWithNoFallbackLoaded() {
         XCTAssertFalse(HeliumFetchedConfigManager.shared.hasConfiguredFallbackPreview())
         XCTAssertFalse(HeliumFetchedConfigManager.shared.setFallbackPreviewTrigger())
-        XCTAssertFalse(HeliumFetchedConfigManager.shared.isFallbackPreviewArmed)
+        XCTAssertFalse(HeliumControlPanelService.shared.isFallbackPreviewArmed)
     }
 
     /// A default entry can exist while missing the bundle URL presentation resolves its local
@@ -110,7 +110,7 @@ final class FallbackPreviewTests: XCTestCase {
         )?.localBundlePath)
         XCTAssertFalse(HeliumFetchedConfigManager.shared.hasConfiguredFallbackPreview())
         XCTAssertFalse(HeliumFetchedConfigManager.shared.setFallbackPreviewTrigger())
-        XCTAssertFalse(HeliumFetchedConfigManager.shared.isFallbackPreviewArmed)
+        XCTAssertFalse(HeliumControlPanelService.shared.isFallbackPreviewArmed)
     }
 
     // MARK: - Resolution
@@ -182,7 +182,7 @@ final class FallbackPreviewTests: XCTestCase {
 
         try installDashboardPreview()
 
-        XCTAssertFalse(HeliumFetchedConfigManager.shared.isFallbackPreviewArmed)
+        XCTAssertFalse(HeliumControlPanelService.shared.isFallbackPreviewArmed)
         XCTAssertEqual(
             HeliumFetchedConfigManager.shared.getProductIDsForTrigger(previewTrigger),
             ["preview.product"]
@@ -238,7 +238,7 @@ final class FallbackPreviewTests: XCTestCase {
         let freshConfig = makeTestConfig(triggers: ["a_trigger": makeTestPaywallInfo(paywallName: "fresh_paywall")])
         injectConfig(freshConfig, json: try JSON(data: JSONEncoder().encode(freshConfig)))
 
-        XCTAssertTrue(HeliumFetchedConfigManager.shared.isFallbackPreviewArmed)
+        XCTAssertTrue(HeliumControlPanelService.shared.isFallbackPreviewArmed)
         XCTAssertEqual(
             HeliumFetchedConfigManager.shared.getProductIDsForTrigger(previewTrigger),
             ["fallback.product"]
@@ -254,7 +254,7 @@ final class FallbackPreviewTests: XCTestCase {
 
         HeliumFetchedConfigManager.reset()
 
-        XCTAssertFalse(HeliumFetchedConfigManager.shared.isFallbackPreviewArmed)
+        XCTAssertFalse(HeliumControlPanelService.shared.isFallbackPreviewArmed)
     }
 
     // MARK: - Wire format parity with Android

--- a/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
+++ b/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
@@ -338,6 +338,18 @@ final class PreviewTriggerConfigTests: XCTestCase {
         XCTAssertNil(secondTryInfo)
     }
 
+    func testMarkLoadFailedDoesNotClobberAnArmedSecondTry() throws {
+        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
+
+        try setPreviewConfig(secondTry: makeSecondTryBundle())
+        HeliumFetchedConfigManager.shared.markPreviewSecondTryLoadFailed()
+
+        XCTAssertEqual(
+            HeliumFetchedConfigManager.shared.previewSecondTryState,
+            .armed(versionStatus: "published")
+        )
+    }
+
     func testDonorSelectionSkipsStaleSecondTryEntry() throws {
         // The second try trigger sorts before real triggers starting with letters > "h", so a
         // stale entry would win alphabetical donor selection if it weren't excluded.
@@ -493,6 +505,7 @@ final class PreviewTriggerConfigTests: XCTestCase {
         XCTAssertNil(response.paywalls[0].versions[0].webPaywallBundleUrl)
         XCTAssertNil(response.paywalls[0].versions[0].paddleProductIds)
         XCTAssertNil(response.paywalls[0].versions[0].shouldEnableScroll)
+        XCTAssertNil(response.paywalls[0].secondTry)
         XCTAssertFalse(response.paywalls[0].isWebPaywall)
     }
 

--- a/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
+++ b/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
@@ -10,6 +10,8 @@ final class PreviewTriggerConfigTests: XCTestCase {
     private let donorBundleUrl = "https://cdn.example.com/bundles/bundle_donor123.html"
     private let donorWebCheckoutUrl = "https://checkout.example.com/donor-web-paywall"
     private let previewBundleUrl = "https://cdn.example.com/bundles/bundle_preview456.html"
+    private let secondTryTrigger = HeliumFetchedConfigManager.HELIUM_PREVIEW_SECOND_TRY_TRIGGER
+    private let secondTryBundleUrl = "https://cdn.example.com/bundles/bundle_secondtry789.html"
 
     override func setUp() {
         super.setUp()
@@ -49,7 +51,8 @@ final class PreviewTriggerConfigTests: XCTestCase {
         productIdsPaddleWeb: [String] = [],
         productIdsStripeWeb: [String] = [],
         webPaywallBundleUrl: String? = nil,
-        shouldEnableScroll: Bool? = nil
+        shouldEnableScroll: Bool? = nil,
+        secondTry: HeliumFetchedConfigManager.PreviewSecondTryBundle? = nil
     ) throws {
         try HeliumFetchedConfigManager.shared.setPreviewTriggerConfig(
             bundleId: "preview456",
@@ -61,7 +64,24 @@ final class PreviewTriggerConfigTests: XCTestCase {
             productIdsPaddleWeb: productIdsPaddleWeb,
             productIdsStripeWeb: productIdsStripeWeb,
             webPaywallBundleUrl: webPaywallBundleUrl,
-            shouldEnableScroll: shouldEnableScroll
+            shouldEnableScroll: shouldEnableScroll,
+            secondTry: secondTry
+        )
+    }
+
+    private func makeSecondTryBundle(
+        versionStatus: String = "published",
+        shouldEnableScroll: Bool? = nil
+    ) -> HeliumFetchedConfigManager.PreviewSecondTryBundle {
+        HeliumFetchedConfigManager.PreviewSecondTryBundle(
+            bundleId: "secondtry789",
+            bundleUrl: secondTryBundleUrl,
+            bundleHtml: "<html>second try</html>",
+            productIds: ["secondtry.product"],
+            productIdsStripe: ["secondtry_stripe:price_2"],
+            productIdsPaddle: [],
+            shouldEnableScroll: shouldEnableScroll,
+            versionStatus: versionStatus
         )
     }
 
@@ -261,6 +281,113 @@ final class PreviewTriggerConfigTests: XCTestCase {
         XCTAssertNil(previewInfo?.webPaywallBundleUrl)
     }
 
+    // MARK: - Second try preview trigger
+
+    private var secondTryInfo: HeliumPaywallInfo? {
+        HeliumFetchedConfigManager.shared.fetchedConfig?.triggerToPaywalls[secondTryTrigger]
+    }
+
+    func testSecondTryInstallsItsOwnTriggerEntry() throws {
+        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
+
+        try setPreviewConfig(secondTry: makeSecondTryBundle())
+
+        XCTAssertEqual(secondTryInfo?.extractedBundleUrl, secondTryBundleUrl)
+        XCTAssertEqual(secondTryInfo?.productsOfferedIOS, ["secondtry.product"])
+        XCTAssertEqual(secondTryInfo?.productsOfferedStripe, ["secondtry_stripe:price_2"])
+        XCTAssertEqual(secondTryInfo?.webProductsOfferedPaddle, [])
+        XCTAssertNil(secondTryInfo?.webPaywallBundleUrl)
+        XCTAssertEqual(
+            HeliumFetchedConfigManager.shared.fetchedConfig?.bundles?["secondtry789"],
+            "<html>second try</html>"
+        )
+        XCTAssertEqual(
+            HeliumFetchedConfigManager.shared.previewSecondTryState,
+            .armed(versionStatus: "published")
+        )
+    }
+
+    func testSecondTryStateArmsWithDraftStatus() throws {
+        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
+
+        try setPreviewConfig(secondTry: makeSecondTryBundle(versionStatus: "draft"))
+
+        XCTAssertEqual(
+            HeliumFetchedConfigManager.shared.previewSecondTryState,
+            .armed(versionStatus: "draft")
+        )
+    }
+
+    func testPreviewWithoutSecondTryClearsStaleSecondTryEntry() throws {
+        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
+
+        try setPreviewConfig(secondTry: makeSecondTryBundle())
+        try setPreviewConfig()
+
+        XCTAssertNil(secondTryInfo)
+        XCTAssertEqual(HeliumFetchedConfigManager.shared.previewSecondTryState, .notConfigured)
+    }
+
+    func testMarkLoadFailedTransitionsStateWithoutInstallingAnEntry() throws {
+        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
+
+        try setPreviewConfig()
+        HeliumFetchedConfigManager.shared.markPreviewSecondTryLoadFailed()
+
+        XCTAssertEqual(HeliumFetchedConfigManager.shared.previewSecondTryState, .loadFailed)
+        XCTAssertNil(secondTryInfo)
+    }
+
+    func testDonorSelectionSkipsStaleSecondTryEntry() throws {
+        // The second try trigger sorts before real triggers starting with letters > "h", so a
+        // stale entry would win alphabetical donor selection if it weren't excluded.
+        injectConfig(makeTestConfig(triggers: ["z_trigger": makeDonorPaywallInfo()]))
+
+        try setPreviewConfig(secondTry: makeSecondTryBundle())
+        try setPreviewConfig(secondTry: makeSecondTryBundle())
+
+        XCTAssertEqual(previewInfo?.paywallTemplateName, "donor_paywall")
+        XCTAssertEqual(secondTryInfo?.paywallTemplateName, "donor_paywall")
+    }
+
+    func testFallbackPreviewClearsSecondTryEntry() throws {
+        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
+        let fallbackConfig = makeTestConfig(
+            triggers: [HeliumFallbackViewManager.defaultFallbackTrigger: makeDonorPaywallInfo()],
+            bundles: ["donor123": "<html>fallback</html>"]
+        )
+        HeliumFallbackViewManager.shared.injectFallbackConfigForTesting(fallbackConfig)
+        defer { HeliumFallbackViewManager.reset() }
+
+        try setPreviewConfig(secondTry: makeSecondTryBundle())
+        XCTAssertTrue(HeliumFetchedConfigManager.shared.setFallbackPreviewTrigger())
+
+        XCTAssertNil(secondTryInfo)
+        XCTAssertEqual(HeliumFetchedConfigManager.shared.previewSecondTryState, .notConfigured)
+    }
+
+    func testJsonMirrorInstallsAndClearsSecondTryEntry() throws {
+        let config = makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()])
+        let configJSON = try JSON(data: JSONEncoder().encode(config))
+        injectConfig(config, json: configJSON)
+
+        try setPreviewConfig(secondTry: makeSecondTryBundle(shouldEnableScroll: false))
+        XCTAssertEqual(
+            HeliumFetchedConfigManager.shared.getResolvedConfigJSONForTrigger(secondTryTrigger)?["baseStack"]["componentProps"]["bundleURL"].string,
+            secondTryBundleUrl
+        )
+        XCTAssertEqual(
+            HeliumFetchedConfigManager.shared.getResolvedConfigJSONForTrigger(secondTryTrigger)?["baseStack"]["componentProps"]["shouldEnableScroll"].bool,
+            false
+        )
+
+        try setPreviewConfig()
+        XCTAssertEqual(
+            HeliumFetchedConfigManager.shared.fetchedConfigJSON?["triggerToPaywalls"][secondTryTrigger],
+            JSON.null
+        )
+    }
+
     func testThrowsWhenNoConfigAvailable() {
         XCTAssertThrowsError(try setPreviewConfig()) { error in
             guard case HeliumControlPanelError.noConfigAvailable = error else {
@@ -367,6 +494,49 @@ final class PreviewTriggerConfigTests: XCTestCase {
         XCTAssertNil(response.paywalls[0].versions[0].paddleProductIds)
         XCTAssertNil(response.paywalls[0].versions[0].shouldEnableScroll)
         XCTAssertFalse(response.paywalls[0].isWebPaywall)
+    }
+
+    func testDecodesSecondTryEntry() throws {
+        let json = """
+        {
+          "productIds": [],
+          "paywalls": [
+            {
+              "paywallUuid": "f3e96335-f7df-4f28-b439-9506d37c793e",
+              "paywallName": "Main Paywall",
+              "versions": [],
+              "secondTry": {
+                "paywallUuid": "aa11bb22-cc33-4444-9555-666677778888",
+                "paywallName": "Discount Offer",
+                "versionStatus": "published",
+                "bundleUrl": "https://bundles-staging.heliumpaywall.com/x/bundle_2nd.html",
+                "productIds": ["yearly_1999"],
+                "stripeProductIds": [],
+                "paddleProductIds": [],
+                "shouldEnableScroll": false
+              }
+            },
+            {
+              "paywallUuid": "1c8d6e2b-7777-4888-9999-000011112222",
+              "paywallName": "No Second Try",
+              "versions": [],
+              "secondTry": null
+            }
+          ]
+        }
+        """
+        let response = try JSONDecoder().decode(
+            HeliumControlPanelResponse.self,
+            from: Data(json.utf8)
+        )
+
+        let secondTry = response.paywalls[0].secondTry
+        XCTAssertEqual(secondTry?.paywallName, "Discount Offer")
+        XCTAssertEqual(secondTry?.versionStatus, "published")
+        XCTAssertEqual(secondTry?.bundleUrl, "https://bundles-staging.heliumpaywall.com/x/bundle_2nd.html")
+        XCTAssertEqual(secondTry?.productIds, ["yearly_1999"])
+        XCTAssertEqual(secondTry?.shouldEnableScroll, false)
+        XCTAssertNil(response.paywalls[1].secondTry)
     }
 
     func testDecodesWebPaywallEntry() throws {

--- a/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
+++ b/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
@@ -70,7 +70,6 @@ final class PreviewTriggerConfigTests: XCTestCase {
     }
 
     private func makeSecondTryBundle(
-        versionStatus: String = "published",
         shouldEnableScroll: Bool? = nil
     ) -> HeliumFetchedConfigManager.PreviewSecondTryBundle {
         HeliumFetchedConfigManager.PreviewSecondTryBundle(
@@ -80,8 +79,7 @@ final class PreviewTriggerConfigTests: XCTestCase {
             productIds: ["secondtry.product"],
             productIdsStripe: ["secondtry_stripe:price_2"],
             productIdsPaddle: [],
-            shouldEnableScroll: shouldEnableScroll,
-            versionStatus: versionStatus
+            shouldEnableScroll: shouldEnableScroll
         )
     }
 
@@ -301,21 +299,6 @@ final class PreviewTriggerConfigTests: XCTestCase {
             HeliumFetchedConfigManager.shared.fetchedConfig?.bundles?["secondtry789"],
             "<html>second try</html>"
         )
-        XCTAssertEqual(
-            HeliumFetchedConfigManager.shared.previewSecondTryState,
-            .armed(versionStatus: "published")
-        )
-    }
-
-    func testSecondTryStateArmsWithDraftStatus() throws {
-        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
-
-        try setPreviewConfig(secondTry: makeSecondTryBundle(versionStatus: "draft"))
-
-        XCTAssertEqual(
-            HeliumFetchedConfigManager.shared.previewSecondTryState,
-            .armed(versionStatus: "draft")
-        )
     }
 
     func testPreviewWithoutSecondTryClearsStaleSecondTryEntry() throws {
@@ -325,29 +308,6 @@ final class PreviewTriggerConfigTests: XCTestCase {
         try setPreviewConfig()
 
         XCTAssertNil(secondTryInfo)
-        XCTAssertEqual(HeliumFetchedConfigManager.shared.previewSecondTryState, .notConfigured)
-    }
-
-    func testMarkLoadFailedTransitionsStateWithoutInstallingAnEntry() throws {
-        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
-
-        try setPreviewConfig()
-        HeliumFetchedConfigManager.shared.markPreviewSecondTryLoadFailed()
-
-        XCTAssertEqual(HeliumFetchedConfigManager.shared.previewSecondTryState, .loadFailed)
-        XCTAssertNil(secondTryInfo)
-    }
-
-    func testMarkLoadFailedDoesNotClobberAnArmedSecondTry() throws {
-        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
-
-        try setPreviewConfig(secondTry: makeSecondTryBundle())
-        HeliumFetchedConfigManager.shared.markPreviewSecondTryLoadFailed()
-
-        XCTAssertEqual(
-            HeliumFetchedConfigManager.shared.previewSecondTryState,
-            .armed(versionStatus: "published")
-        )
     }
 
     func testDonorSelectionSkipsStaleSecondTryEntry() throws {
@@ -375,7 +335,6 @@ final class PreviewTriggerConfigTests: XCTestCase {
         XCTAssertTrue(HeliumFetchedConfigManager.shared.setFallbackPreviewTrigger())
 
         XCTAssertNil(secondTryInfo)
-        XCTAssertEqual(HeliumFetchedConfigManager.shared.previewSecondTryState, .notConfigured)
     }
 
     func testJsonMirrorInstallsAndClearsSecondTryEntry() throws {


### PR DESCRIPTION
## What

Second try flows now work from triple-tap paywall previews, replacing the blanket "not supported in previews" block from #311.

- The control panel downloads the second try bundle alongside the main one (concurrently via `async let`) and installs it as a `helium_preview_trigger_second_try` entry; a download failure never blocks the main preview, it just flips a `loadFailed` state.
- `showSecondaryPaywall` on the preview trigger presents the armed second try through the normal presentation path. uuid lookups are skipped in previews so a preview can never present a production paywall.
- The diagnostic now covers the two remaining cases with distinct copy: no second try configured (`secondTryNotConfiguredInPreview`) and bundle load failure (`secondTryPreviewLoadFailed`).
- Preview-only behaviors (no silent fallback substitution, diagnostics always allowed, triple-tap returns to the panel) apply to the second try preview via a shared `isPreviewTrigger` helper. That also closes a latent donor-selection hole where a stale synthetic entry could have been cloned as a donor.

## Server contract

Consumes the new `secondTry` field from cloudcaptainai/bandit-server-lite-phoenix#136. Against a Bandit without it, `secondTry` decodes nil and previews show the not-configured diagnostic — no breakage either way.

## Decisions worth a second opinion

- A never-published (draft-only) second try is previewable, matching the web-paywall preview precedent, but logs a "real users will not see it until the paywall is published" warning and carries `versionStatus` for future UI.
- Preview second try presentations reuse the same session/context semantics as production second tries, so event behavior is unchanged in shape.

## Testing

Full unit suite green on iPhone 17 Pro simulator. New coverage: second try trigger install/clear, donor selection skipping synthetic entries, fallback-preview arming clearing the second try, JSON mirror install/clear, state transitions, response decoding, and the two diagnostic records.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches preview config mutation, second-try presentation routing, and paywall dismiss/navigation in dev-only paths; production `showSecondaryPaywall` gains an explicit preview guard on UUID lookup but behavior is otherwise unchanged.
> 
> **Overview**
> **Second try flows now work in paywall previews** instead of blocking with a dedicated “not supported in preview” diagnostic. The control panel decodes optional `secondTry` on each preview entry, fetches that bundle concurrently with the main preview (`async let`), and installs it under `helium_preview_trigger_second_try` via `setPreviewTriggerConfig`; a failed second-try download only logs and leaves the main preview intact, with missing config surfacing the normal `secondTryNoMatch` path.
> 
> `showSecondaryPaywall` on preview triggers skips UUID→live-trigger resolution so previews cannot accidentally present production paywalls, then presents through the usual `trigger_second_try` lookup. Shared **`isPreviewTrigger`** covers both synthetic triggers so preview rules apply to the second-try layer too: no silent fallback substitution, triple-tap **steps back one layer** (second try → main preview → panel), and the control panel **activity lock** releases only when the main preview trigger closes.
> 
> **`isFallbackPreviewArmed`** moves to `HeliumControlPanelService`; fallback and dashboard preview install/clear paths also remove stale second-try synthetic entries so donor selection cannot clone a leftover preview trigger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d717a7625550c14491b2b3ef70c850f9a760c857. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for optional “second-try” paywall previews, including product details, bundle configuration, and scroll settings.
  - Preview flows can present a configured second-try paywall when available.
  - Added support for fallback preview state across preview flows.

- **Bug Fixes**
  - Improved preview trigger recognition across preview and fallback experiences.
  - Primary previews continue to open when an optional second-try preview cannot be loaded.
  - Improved cleanup of outdated preview configuration during fallback and reset flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->