### PR TITLE
Apply paywall preview server product details to fetched config and price map

### DIFF
--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
@@ -3,6 +3,9 @@ import Foundation
 struct HeliumControlPanelResponse: Codable {
     let productIds: [String]
     let paywalls: [HeliumPaywallPreviewEntry]
+    let stripeProducts: [String: ServerProductPrice]?
+    let paddleProducts: [String: ServerProductPrice]?
+    let paddleClientToken: String?
 }
 
 struct HeliumPaywallPreviewEntry: Codable, Identifiable {

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelService.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelService.swift
@@ -63,6 +63,21 @@ class HeliumControlPanelService {
         return (bundleId, html)
     }
 
+    /// Installs a preview response's server products, unless the calling task was canceled.
+    /// Refreshing cancels the in-flight fetch and starts another, and these products replace
+    /// rather than merge, so a response that arrived before its cancel would otherwise discard
+    /// the newer one's. Returns whether the products were installed.
+    @discardableResult
+    func applyServerProducts(from response: HeliumControlPanelResponse) -> Bool {
+        guard !Task.isCancelled else { return false }
+        HeliumFetchedConfigManager.shared.setPreviewServerProducts(
+            stripeProducts: response.stripeProducts,
+            paddleProducts: response.paddleProducts,
+            paddleClientToken: response.paddleClientToken
+        )
+        return true
+    }
+
     func fetchPreviewPaywalls() async throws -> HeliumControlPanelResponse {
         guard let apiKey = Helium.shared.controller?.apiKey else {
             throw HeliumControlPanelError.noApiKey

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelService.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelService.swift
@@ -63,10 +63,9 @@ class HeliumControlPanelService {
         return (bundleId, html)
     }
 
-    /// Installs a preview response's server products, unless the calling task was canceled.
-    /// Refreshing cancels the in-flight fetch and starts another, and these products replace
-    /// rather than merge, so a response that arrived before its cancel would otherwise discard
-    /// the newer one's. Returns whether the products were installed.
+    /// Installs a preview response's server products unless the calling task was canceled —
+    /// installs replace rather than merge, so a canceled fetch resolving late would otherwise
+    /// discard a newer response's products.
     @discardableResult
     func applyServerProducts(from response: HeliumControlPanelResponse) -> Bool {
         guard !Task.isCancelled else { return false }

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
@@ -306,6 +306,10 @@ struct HeliumControlPanelView: View {
             // Fetch all products data
             await HeliumFetchedConfigManager.shared.buildLocalizedPriceMap(response.productIds)
 
+            // A refresh cancels the in-flight fetch and starts another. Without this, a
+            // response that arrived before the cancel would replace the newer one's products.
+            guard !Task.isCancelled else { return }
+
             HeliumFetchedConfigManager.shared.setPreviewServerProducts(
                 stripeProducts: response.stripeProducts,
                 paddleProducts: response.paddleProducts,

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
@@ -306,7 +306,7 @@ struct HeliumControlPanelView: View {
             // Fetch all products data
             await HeliumFetchedConfigManager.shared.buildLocalizedPriceMap(response.productIds)
 
-            HeliumFetchedConfigManager.shared.mergePreviewServerProducts(
+            HeliumFetchedConfigManager.shared.setPreviewServerProducts(
                 stripeProducts: response.stripeProducts,
                 paddleProducts: response.paddleProducts,
                 paddleClientToken: response.paddleClientToken

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
@@ -306,15 +306,7 @@ struct HeliumControlPanelView: View {
             // Fetch all products data
             await HeliumFetchedConfigManager.shared.buildLocalizedPriceMap(response.productIds)
 
-            // A refresh cancels the in-flight fetch and starts another. Without this, a
-            // response that arrived before the cancel would replace the newer one's products.
-            guard !Task.isCancelled else { return }
-
-            HeliumFetchedConfigManager.shared.setPreviewServerProducts(
-                stripeProducts: response.stripeProducts,
-                paddleProducts: response.paddleProducts,
-                paddleClientToken: response.paddleClientToken
-            )
+            guard HeliumControlPanelService.shared.applyServerProducts(from: response) else { return }
 
             state = .loaded(response)
         } catch {

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
@@ -306,6 +306,12 @@ struct HeliumControlPanelView: View {
             // Fetch all products data
             await HeliumFetchedConfigManager.shared.buildLocalizedPriceMap(response.productIds)
 
+            HeliumFetchedConfigManager.shared.mergePreviewServerProducts(
+                stripeProducts: response.stripeProducts,
+                paddleProducts: response.paddleProducts,
+                paddleClientToken: response.paddleClientToken
+            )
+
             state = .loaded(response)
         } catch {
             if !Task.isCancelled {

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -211,6 +211,7 @@ public class HeliumFetchedConfigManager {
         shared.fetchedConfigJSON = nil
         shared.triggersWithSkippedBundleAndReason = []
         shared.localizedPriceMap = [:]
+        shared.previewInstalledProductKeys = []
         HeliumControlPanelService.shared.isFallbackPreviewArmed = false
     }
 
@@ -218,6 +219,7 @@ public class HeliumFetchedConfigManager {
     func injectConfigForTesting(_ config: HeliumFetchedConfig, json: JSON? = nil) {
         self.fetchedConfig = config
         self.fetchedConfigJSON = json
+        self.previewInstalledProductKeys = []
         self._downloadStatus = .downloadSuccess
     }
 
@@ -236,7 +238,8 @@ public class HeliumFetchedConfigManager {
     @HeliumAtomic private(set) var fetchedConfigJSON: JSON?
     @HeliumAtomic private(set) var triggersWithSkippedBundleAndReason: [(trigger: String, reason: PaywallUnavailableReason)] = []
     @HeliumAtomic private var localizedPriceMap: [String: LocalizedPrice] = [:]
-    
+    @HeliumAtomic private var previewInstalledProductKeys: Set<String> = []
+
     func fetchConfig(
         endpoint: String,
         apiKey: String,
@@ -345,6 +348,9 @@ public class HeliumFetchedConfigManager {
             self.fetchedConfig = newConfig
             self.fetchedConfigJSON = newConfigJSON
             triggersWithSkippedBundleAndReason = []
+            // A replaced config carries none of the preview's entries, so nothing of theirs
+            // is still owned — and its own values must not be treated as overwritable.
+            previewInstalledProductKeys = []
             
             if let stripeCustomerId = fetchedConfig?.stripeCustomerId {
                 applyCustomerIdFromConfig(stripeCustomerId, provider: .stripe)
@@ -896,18 +902,24 @@ public class HeliumFetchedConfigManager {
         let token = paddleClientToken ?? ""
         guard !stripeProducts.isEmpty || !paddleProducts.isEmpty || !token.isEmpty else { return }
 
+        // Entries a previous preview merge installed are replaceable: only on-launch's
+        // values need protecting, and the panel's refresh exists to pick up edits.
+        let replaceable = previewInstalledProductKeys
+        var installed: Set<String> = []
+
         _fetchedConfig.withValue { stored in
             guard var config = stored else { return }
             if !stripeProducts.isEmpty {
-                config.stripeProducts = (config.stripeProducts ?? [:])
-                    .merging(stripeProducts) { existing, _ in existing }
+                config.stripeProducts = Self.applyPreviewValues(
+                    stripeProducts, to: config.stripeProducts, replaceable: replaceable, installed: &installed)
             }
             if !paddleProducts.isEmpty {
-                config.paddleProducts = (config.paddleProducts ?? [:])
-                    .merging(paddleProducts) { existing, _ in existing }
+                config.paddleProducts = Self.applyPreviewValues(
+                    paddleProducts, to: config.paddleProducts, replaceable: replaceable, installed: &installed)
             }
-            if !token.isEmpty, config.paddleClientToken?.isEmpty != false {
+            if !token.isEmpty, config.paddleClientToken?.isEmpty != false || replaceable.contains(Self.previewPaddleTokenKey) {
                 config.paddleClientToken = token
+                installed.insert(Self.previewPaddleTokenKey)
             }
             stored = config
         }
@@ -916,11 +928,34 @@ public class HeliumFetchedConfigManager {
         let previewPrices = stripeProducts
             .merging(paddleProducts) { current, _ in current }
             .mapValues { $0.toLocalizedPrice() }
-        guard !previewPrices.isEmpty else { return }
-        _localizedPriceMap.withValue { map in
-            map.merge(previewPrices) { existing, _ in existing }
+        if !previewPrices.isEmpty {
+            _localizedPriceMap.withValue { map in
+                map = Self.applyPreviewValues(previewPrices, to: map, replaceable: replaceable, installed: &installed)
+            }
         }
+
+        previewInstalledProductKeys = replaceable.union(installed)
     }
+
+    /// Writes preview values over gaps and over entries an earlier preview merge owns, leaving
+    /// everything else intact, and records which keys the preview now owns.
+    private static func applyPreviewValues<Value>(
+        _ preview: [String: Value],
+        to existing: [String: Value]?,
+        replaceable: Set<String>,
+        installed: inout Set<String>
+    ) -> [String: Value] {
+        var result = existing ?? [:]
+        for (key, value) in preview where result[key] == nil || replaceable.contains(key) {
+            result[key] = value
+            installed.insert(key)
+        }
+        return result
+    }
+
+    /// Sentinel for the Paddle client token, which is tracked alongside product keys but is not
+    /// itself a product. Colons make it unmatchable by a real "productId:priceId" key.
+    private static let previewPaddleTokenKey = "::preview-paddle-client-token::"
 
     func buildLocalizedPriceMap(_ productIds: [String]) async {
         if !productIds.isEmpty {

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -908,17 +908,6 @@ public class HeliumFetchedConfigManager {
         )
     }
 
-    /// Whether on-launch served Paddle to this device. On-launch drops every Paddle trigger for
-    /// users its request-IP geo compliance gate rejects (and when Paddle credentials are unusable),
-    /// so an empty Paddle payload is the observable outcome of those filters. The preview endpoint
-    /// runs none of them, so its Paddle products are eligible here only when on-launch's are —
-    /// otherwise a preview would offer an app2web checkout production never serves this device.
-    var isPaddleServedByOnLaunch: Bool {
-        guard let config = fetchedConfig else { return false }
-        return !(config.paddleProducts ?? [:]).isEmpty
-            || !(config.paddleClientToken ?? "").isEmpty
-    }
-
     /// Preview values fill only the keys `live` does not already carry.
     private static func overlayingPreview<Value>(
         on live: [String: Value]?,
@@ -928,16 +917,11 @@ public class HeliumFetchedConfigManager {
         return preview.merging(live ?? [:]) { _, liveValue in liveValue }
     }
 
-    private var eligiblePreviewPaddleProducts: [String: ServerProductPrice] {
-        isPaddleServedByOnLaunch ? previewServerProducts.paddle : [:]
-    }
-
     private var previewLocalizedPrices: [String: LocalizedPrice] {
         let preview = previewServerProducts
-        let paddle = eligiblePreviewPaddleProducts
-        guard !preview.stripe.isEmpty || !paddle.isEmpty else { return [:] }
+        guard !preview.stripe.isEmpty || !preview.paddle.isEmpty else { return [:] }
         return preview.stripe
-            .merging(paddle) { current, _ in current }
+            .merging(preview.paddle) { current, _ in current }
             .mapValues { $0.toLocalizedPrice() }
     }
 
@@ -969,18 +953,16 @@ public class HeliumFetchedConfigManager {
         return Self.overlayingPreview(on: fetchedConfig?.stripeProducts, previewServerProducts.stripe)
     }
     public func getPaddleProductsPriceMap() -> [String: ServerProductPrice]? {
-        return Self.overlayingPreview(on: fetchedConfig?.paddleProducts, eligiblePreviewPaddleProducts)
+        return Self.overlayingPreview(on: fetchedConfig?.paddleProducts, previewServerProducts.paddle)
     }
 
-    /// The token Paddle checkout should use. A preview supplies one only when on-launch served
-    /// Paddle to this device but the paywall being previewed is not live, so on-launch carried
-    /// products yet no token for it. A device on-launch filtered out of Paddle gets no token from
-    /// a preview either, keeping the preview's checkout as unreachable as production's.
+    /// The token Paddle checkout should use. A preview supplies one when the paywall being
+    /// previewed is not live, in which case on-launch carried no Paddle products and no token.
     var paddleClientToken: String? {
         if let token = fetchedConfig?.paddleClientToken, !token.isEmpty {
             return token
         }
-        return isPaddleServedByOnLaunch ? previewServerProducts.paddleClientToken : nil
+        return previewServerProducts.paddleClientToken
     }
 
     /// When config fetch returns a customerId for a payment provider, persist it and
@@ -1243,19 +1225,13 @@ public class HeliumFetchedConfigManager {
             throw HeliumControlPanelError.noSourceTrigger
         }
 
-        // Paddle rides on on-launch's verdict for this device: an empty on-launch Paddle payload
-        // means its request-IP geo compliance (or credentials) filter dropped Paddle, and a
-        // preview must not reintroduce a checkout production would never serve here.
-        let paddleServed = !(config.paddleProducts ?? [:]).isEmpty
-            || !(config.paddleClientToken ?? "").isEmpty
-
         config.triggerToPaywalls[HELIUM_PREVIEW_TRIGGER] = try previewEntry(
             clonedFrom: donorPaywallInfo,
             bundleUrl: bundleUrl,
             productIds: productIds,
             productIdsStripe: productIdsStripe,
-            productIdsPaddle: paddleServed ? productIdsPaddle : [],
-            productIdsPaddleWeb: paddleServed ? productIdsPaddleWeb : [],
+            productIdsPaddle: productIdsPaddle,
+            productIdsPaddleWeb: productIdsPaddleWeb,
             productIdsStripeWeb: productIdsStripeWeb,
             webPaywallBundleUrl: webPaywallBundleUrl,
             shouldEnableScroll: shouldEnableScroll
@@ -1269,7 +1245,7 @@ public class HeliumFetchedConfigManager {
                 bundleUrl: secondTry.bundleUrl,
                 productIds: secondTry.productIds,
                 productIdsStripe: secondTry.productIdsStripe,
-                productIdsPaddle: paddleServed ? secondTry.productIdsPaddle : [],
+                productIdsPaddle: secondTry.productIdsPaddle,
                 productIdsPaddleWeb: [],
                 productIdsStripeWeb: [],
                 webPaywallBundleUrl: nil,

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -908,6 +908,17 @@ public class HeliumFetchedConfigManager {
         )
     }
 
+    /// Whether on-launch served Paddle to this device. On-launch drops every Paddle trigger for
+    /// users its request-IP geo compliance gate rejects (and when Paddle credentials are unusable),
+    /// so an empty Paddle payload is the observable outcome of those filters. The preview endpoint
+    /// runs none of them, so its Paddle products are eligible here only when on-launch's are —
+    /// otherwise a preview would offer an app2web checkout production never serves this device.
+    var isPaddleServedByOnLaunch: Bool {
+        guard let config = fetchedConfig else { return false }
+        return !(config.paddleProducts ?? [:]).isEmpty
+            || !(config.paddleClientToken ?? "").isEmpty
+    }
+
     /// Preview values fill only the keys `live` does not already carry.
     private static func overlayingPreview<Value>(
         on live: [String: Value]?,
@@ -917,11 +928,16 @@ public class HeliumFetchedConfigManager {
         return preview.merging(live ?? [:]) { _, liveValue in liveValue }
     }
 
+    private var eligiblePreviewPaddleProducts: [String: ServerProductPrice] {
+        isPaddleServedByOnLaunch ? previewServerProducts.paddle : [:]
+    }
+
     private var previewLocalizedPrices: [String: LocalizedPrice] {
         let preview = previewServerProducts
-        guard !preview.stripe.isEmpty || !preview.paddle.isEmpty else { return [:] }
+        let paddle = eligiblePreviewPaddleProducts
+        guard !preview.stripe.isEmpty || !paddle.isEmpty else { return [:] }
         return preview.stripe
-            .merging(preview.paddle) { current, _ in current }
+            .merging(paddle) { current, _ in current }
             .mapValues { $0.toLocalizedPrice() }
     }
 
@@ -953,16 +969,18 @@ public class HeliumFetchedConfigManager {
         return Self.overlayingPreview(on: fetchedConfig?.stripeProducts, previewServerProducts.stripe)
     }
     public func getPaddleProductsPriceMap() -> [String: ServerProductPrice]? {
-        return Self.overlayingPreview(on: fetchedConfig?.paddleProducts, previewServerProducts.paddle)
+        return Self.overlayingPreview(on: fetchedConfig?.paddleProducts, eligiblePreviewPaddleProducts)
     }
 
-    /// The token Paddle checkout should use. A preview supplies one when the paywall being
-    /// previewed is not live, in which case on-launch carried no Paddle products and no token.
+    /// The token Paddle checkout should use. A preview supplies one only when on-launch served
+    /// Paddle to this device but the paywall being previewed is not live, so on-launch carried
+    /// products yet no token for it. A device on-launch filtered out of Paddle gets no token from
+    /// a preview either, keeping the preview's checkout as unreachable as production's.
     var paddleClientToken: String? {
         if let token = fetchedConfig?.paddleClientToken, !token.isEmpty {
             return token
         }
-        return previewServerProducts.paddleClientToken
+        return isPaddleServedByOnLaunch ? previewServerProducts.paddleClientToken : nil
     }
 
     /// When config fetch returns a customerId for a payment provider, persist it and
@@ -1205,13 +1223,19 @@ public class HeliumFetchedConfigManager {
             throw HeliumControlPanelError.noSourceTrigger
         }
 
+        // Paddle rides on on-launch's verdict for this device: an empty on-launch Paddle payload
+        // means its request-IP geo compliance (or credentials) filter dropped Paddle, and a
+        // preview must not reintroduce a checkout production would never serve here.
+        let paddleServed = !(config.paddleProducts ?? [:]).isEmpty
+            || !(config.paddleClientToken ?? "").isEmpty
+
         config.triggerToPaywalls[HELIUM_PREVIEW_TRIGGER] = try previewEntry(
             clonedFrom: donorPaywallInfo,
             bundleUrl: bundleUrl,
             productIds: productIds,
             productIdsStripe: productIdsStripe,
-            productIdsPaddle: productIdsPaddle,
-            productIdsPaddleWeb: productIdsPaddleWeb,
+            productIdsPaddle: paddleServed ? productIdsPaddle : [],
+            productIdsPaddleWeb: paddleServed ? productIdsPaddleWeb : [],
             productIdsStripeWeb: productIdsStripeWeb,
             webPaywallBundleUrl: webPaywallBundleUrl,
             shouldEnableScroll: shouldEnableScroll
@@ -1225,7 +1249,7 @@ public class HeliumFetchedConfigManager {
                 bundleUrl: secondTry.bundleUrl,
                 productIds: secondTry.productIds,
                 productIdsStripe: secondTry.productIdsStripe,
-                productIdsPaddle: secondTry.productIdsPaddle,
+                productIdsPaddle: paddleServed ? secondTry.productIdsPaddle : [],
                 productIdsPaddleWeb: [],
                 productIdsStripeWeb: [],
                 webPaywallBundleUrl: nil,

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -892,10 +892,8 @@ public class HeliumFetchedConfigManager {
         return allFound
     }
     
-    /// Replaces the products served for paywall previews. Held apart from the fetched config
-    /// rather than merged into it, so on-launch's values win regardless of which arrives first:
-    /// they are resolved against a real customer, while the preview endpoint has no user to
-    /// check eligibility against and reports every intro offer as available.
+    /// Replaces the products served for paywall previews, held apart from the fetched config
+    /// so on-launch's values win regardless of which arrives first.
     func setPreviewServerProducts(
         stripeProducts: [String: ServerProductPrice]?,
         paddleProducts: [String: ServerProductPrice]?,
@@ -956,8 +954,7 @@ public class HeliumFetchedConfigManager {
         return Self.overlayingPreview(on: fetchedConfig?.paddleProducts, previewServerProducts.paddle)
     }
 
-    /// The token Paddle checkout should use. A preview supplies one when the paywall being
-    /// previewed is not live, in which case on-launch carried no Paddle products and no token.
+    /// On-launch's token wins; a preview's fills in when there is none.
     var paddleClientToken: String? {
         if let token = fetchedConfig?.paddleClientToken, !token.isEmpty {
             return token

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -884,6 +884,44 @@ public class HeliumFetchedConfigManager {
         return allFound
     }
     
+    /// Existing values win: they were resolved against a real customer, while the preview endpoint
+    /// has no user to check eligibility against and reports every intro offer as available.
+    func mergePreviewServerProducts(
+        stripeProducts: [String: ServerProductPrice]?,
+        paddleProducts: [String: ServerProductPrice]?,
+        paddleClientToken: String?
+    ) {
+        let stripeProducts = stripeProducts ?? [:]
+        let paddleProducts = paddleProducts ?? [:]
+        let token = paddleClientToken ?? ""
+        guard !stripeProducts.isEmpty || !paddleProducts.isEmpty || !token.isEmpty else { return }
+
+        _fetchedConfig.withValue { stored in
+            guard var config = stored else { return }
+            if !stripeProducts.isEmpty {
+                config.stripeProducts = (config.stripeProducts ?? [:])
+                    .merging(stripeProducts) { existing, _ in existing }
+            }
+            if !paddleProducts.isEmpty {
+                config.paddleProducts = (config.paddleProducts ?? [:])
+                    .merging(paddleProducts) { existing, _ in existing }
+            }
+            if !token.isEmpty, config.paddleClientToken?.isEmpty != false {
+                config.paddleClientToken = token
+            }
+            stored = config
+        }
+
+        // The rendered paywall reads prices from the localized map, not from the config.
+        let previewPrices = stripeProducts
+            .merging(paddleProducts) { current, _ in current }
+            .mapValues { $0.toLocalizedPrice() }
+        guard !previewPrices.isEmpty else { return }
+        _localizedPriceMap.withValue { map in
+            map.merge(previewPrices) { existing, _ in existing }
+        }
+    }
+
     func buildLocalizedPriceMap(_ productIds: [String]) async {
         if !productIds.isEmpty {
             let newProductToPriceMap = await PriceFetcher.localizedPricing(for: productIds)

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -102,6 +102,12 @@ private struct SingleBundleFetchResult {
     let lastServerMessage: String?
 }
 
+struct PreviewServerProducts {
+    var stripe: [String: ServerProductPrice] = [:]
+    var paddle: [String: ServerProductPrice] = [:]
+    var paddleClientToken: String?
+}
+
 enum BundleFetchError: Error {
     case permanentFailure(PaywallUnavailableReason)
     case httpError(statusCode: Int, serverMessage: String?)
@@ -211,7 +217,7 @@ public class HeliumFetchedConfigManager {
         shared.fetchedConfigJSON = nil
         shared.triggersWithSkippedBundleAndReason = []
         shared.localizedPriceMap = [:]
-        shared.previewInstalledProductKeys = []
+        shared.previewServerProducts = PreviewServerProducts()
         HeliumControlPanelService.shared.isFallbackPreviewArmed = false
     }
 
@@ -219,7 +225,6 @@ public class HeliumFetchedConfigManager {
     func injectConfigForTesting(_ config: HeliumFetchedConfig, json: JSON? = nil) {
         self.fetchedConfig = config
         self.fetchedConfigJSON = json
-        self.previewInstalledProductKeys = []
         self._downloadStatus = .downloadSuccess
     }
 
@@ -238,7 +243,7 @@ public class HeliumFetchedConfigManager {
     @HeliumAtomic private(set) var fetchedConfigJSON: JSON?
     @HeliumAtomic private(set) var triggersWithSkippedBundleAndReason: [(trigger: String, reason: PaywallUnavailableReason)] = []
     @HeliumAtomic private var localizedPriceMap: [String: LocalizedPrice] = [:]
-    @HeliumAtomic private var previewInstalledProductKeys: Set<String> = []
+    @HeliumAtomic private var previewServerProducts = PreviewServerProducts()
 
     func fetchConfig(
         endpoint: String,
@@ -348,9 +353,6 @@ public class HeliumFetchedConfigManager {
             self.fetchedConfig = newConfig
             self.fetchedConfigJSON = newConfigJSON
             triggersWithSkippedBundleAndReason = []
-            // A replaced config carries none of the preview's entries, so nothing of theirs
-            // is still owned — and its own values must not be treated as overwritable.
-            previewInstalledProductKeys = []
             
             if let stripeCustomerId = fetchedConfig?.stripeCustomerId {
                 applyCustomerIdFromConfig(stripeCustomerId, provider: .stripe)
@@ -890,72 +892,38 @@ public class HeliumFetchedConfigManager {
         return allFound
     }
     
-    /// Existing values win: they were resolved against a real customer, while the preview endpoint
-    /// has no user to check eligibility against and reports every intro offer as available.
-    func mergePreviewServerProducts(
+    /// Replaces the products served for paywall previews. Held apart from the fetched config
+    /// rather than merged into it, so on-launch's values win regardless of which arrives first:
+    /// they are resolved against a real customer, while the preview endpoint has no user to
+    /// check eligibility against and reports every intro offer as available.
+    func setPreviewServerProducts(
         stripeProducts: [String: ServerProductPrice]?,
         paddleProducts: [String: ServerProductPrice]?,
         paddleClientToken: String?
     ) {
-        let stripeProducts = stripeProducts ?? [:]
-        let paddleProducts = paddleProducts ?? [:]
-        let token = paddleClientToken ?? ""
-        guard !stripeProducts.isEmpty || !paddleProducts.isEmpty || !token.isEmpty else { return }
+        previewServerProducts = PreviewServerProducts(
+            stripe: stripeProducts ?? [:],
+            paddle: paddleProducts ?? [:],
+            paddleClientToken: paddleClientToken
+        )
+    }
 
-        // Entries a previous preview merge installed are replaceable: only on-launch's
-        // values need protecting, and the panel's refresh exists to pick up edits.
-        let replaceable = previewInstalledProductKeys
-        var installed: Set<String> = []
+    /// Preview values fill only the keys `live` does not already carry.
+    private static func overlayingPreview<Value>(
+        on live: [String: Value]?,
+        _ preview: [String: Value]
+    ) -> [String: Value]? {
+        guard !preview.isEmpty else { return live }
+        return preview.merging(live ?? [:]) { _, liveValue in liveValue }
+    }
 
-        _fetchedConfig.withValue { stored in
-            guard var config = stored else { return }
-            if !stripeProducts.isEmpty {
-                config.stripeProducts = Self.applyPreviewValues(
-                    stripeProducts, to: config.stripeProducts, replaceable: replaceable, installed: &installed)
-            }
-            if !paddleProducts.isEmpty {
-                config.paddleProducts = Self.applyPreviewValues(
-                    paddleProducts, to: config.paddleProducts, replaceable: replaceable, installed: &installed)
-            }
-            if !token.isEmpty, config.paddleClientToken?.isEmpty != false || replaceable.contains(Self.previewPaddleTokenKey) {
-                config.paddleClientToken = token
-                installed.insert(Self.previewPaddleTokenKey)
-            }
-            stored = config
-        }
-
-        // The rendered paywall reads prices from the localized map, not from the config.
-        let previewPrices = stripeProducts
-            .merging(paddleProducts) { current, _ in current }
+    private var previewLocalizedPrices: [String: LocalizedPrice] {
+        let preview = previewServerProducts
+        guard !preview.stripe.isEmpty || !preview.paddle.isEmpty else { return [:] }
+        return preview.stripe
+            .merging(preview.paddle) { current, _ in current }
             .mapValues { $0.toLocalizedPrice() }
-        if !previewPrices.isEmpty {
-            _localizedPriceMap.withValue { map in
-                map = Self.applyPreviewValues(previewPrices, to: map, replaceable: replaceable, installed: &installed)
-            }
-        }
-
-        previewInstalledProductKeys = replaceable.union(installed)
     }
-
-    /// Writes preview values over gaps and over entries an earlier preview merge owns, leaving
-    /// everything else intact, and records which keys the preview now owns.
-    private static func applyPreviewValues<Value>(
-        _ preview: [String: Value],
-        to existing: [String: Value]?,
-        replaceable: Set<String>,
-        installed: inout Set<String>
-    ) -> [String: Value] {
-        var result = existing ?? [:]
-        for (key, value) in preview where result[key] == nil || replaceable.contains(key) {
-            result[key] = value
-            installed.insert(key)
-        }
-        return result
-    }
-
-    /// Sentinel for the Paddle client token, which is tracked alongside product keys but is not
-    /// itself a product. Colons make it unmatchable by a real "productId:priceId" key.
-    private static let previewPaddleTokenKey = "::preview-paddle-client-token::"
 
     func buildLocalizedPriceMap(_ productIds: [String]) async {
         if !productIds.isEmpty {
@@ -976,16 +944,25 @@ public class HeliumFetchedConfigManager {
     // NOTE - be careful about removing the public declaration here because this is in use
     // by some sdk integrations.
     public func getLocalizedPriceMap() -> [String: LocalizedPrice] {
-        return localizedPriceMap
+        return Self.overlayingPreview(on: localizedPriceMap, previewLocalizedPrices) ?? [:]
     }
 
     // NOTE - be careful about removing the public declaration here because this is in use
     // by some sdk integrations.
     public func getStripeProductsPriceMap() -> [String: ServerProductPrice]? {
-        return fetchedConfig?.stripeProducts
+        return Self.overlayingPreview(on: fetchedConfig?.stripeProducts, previewServerProducts.stripe)
     }
     public func getPaddleProductsPriceMap() -> [String: ServerProductPrice]? {
-        return fetchedConfig?.paddleProducts
+        return Self.overlayingPreview(on: fetchedConfig?.paddleProducts, previewServerProducts.paddle)
+    }
+
+    /// The token Paddle checkout should use. A preview supplies one when the paywall being
+    /// previewed is not live, in which case on-launch carried no Paddle products and no token.
+    var paddleClientToken: String? {
+        if let token = fetchedConfig?.paddleClientToken, !token.isEmpty {
+            return token
+        }
+        return previewServerProducts.paddleClientToken
     }
 
     /// When config fetch returns a customerId for a payment provider, persist it and
@@ -1014,7 +991,7 @@ public class HeliumFetchedConfigManager {
             return [:]
         }
         
-        return localizedPriceMap.filter { productIDs.contains($0.key) }
+        return getLocalizedPriceMap().filter { productIDs.contains($0.key) }
     }
     
     private func updateDownloadState(_ status: HeliumFetchedConfigStatus) {

--- a/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
@@ -70,7 +70,7 @@ final class PaddleCheckoutPrefetchCoordinator {
         guard let info = paywallSession.paywallInfoWithBackups,
               let webProducts = info.webProductsOfferedPaddle,
               !webProducts.isEmpty,
-              let clientToken = HeliumFetchedConfigManager.shared.fetchedConfig?.paddleClientToken,
+              let clientToken = HeliumFetchedConfigManager.shared.paddleClientToken,
               !clientToken.isEmpty else {
             return
         }

--- a/Tests/helium-swiftTests/PreviewServerProductsTests.swift
+++ b/Tests/helium-swiftTests/PreviewServerProductsTests.swift
@@ -51,39 +51,7 @@ final class PreviewServerProductsTests: XCTestCase {
         injectConfig(config)
     }
 
-    /// On-launch served Paddle products for a live paywall but no token: the case where a
-    /// preview of a not-yet-live paywall has to supply the token itself.
-    private func injectPaddleServedConfigWithoutToken() {
-        injectBaseConfig(
-            paddleProducts: [liveKey: makeServerPrice(formattedPrice: "$4.99", value: 4.99, title: "Live")],
-            paddleClientToken: nil
-        )
-    }
-
     func testPreviewProductsSurfaceThroughTheProductMaps() {
-        // On-launch served Paddle to this device, so preview Paddle is eligible too.
-        injectBaseConfig(paddleClientToken: "live_token_for_other_paywall")
-
-        HeliumFetchedConfigManager.shared.setPreviewServerProducts(
-            stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99)],
-            paddleProducts: [paddleKey: makeServerPrice(formattedPrice: "$19.99", value: 19.99)],
-            paddleClientToken: "preview_token"
-        )
-
-        XCTAssertNotNil(HeliumFetchedConfigManager.shared.getStripeProductsPriceMap()?[stripeKey])
-        XCTAssertNotNil(HeliumFetchedConfigManager.shared.getPaddleProductsPriceMap()?[paddleKey])
-        XCTAssertEqual(HeliumFetchedConfigManager.shared.paddleClientToken, "live_token_for_other_paywall")
-
-        let priceMap = HeliumFetchedConfigManager.shared.getLocalizedPriceMap()
-        XCTAssertEqual(priceMap[stripeKey]?.baseInfo.formattedPrice, "$9.99")
-        XCTAssertEqual(priceMap[paddleKey]?.baseInfo.formattedPrice, "$19.99")
-    }
-
-    /// On-launch drops every Paddle trigger for a device its request-IP compliance gate rejects.
-    /// The preview endpoint runs no such gate, so its Paddle set must defer to on-launch's
-    /// verdict, or a tester outside the served region would reach a checkout production never
-    /// offers them. Stripe carries no such gate and stays available.
-    func testPreviewPaddleIsWithheldWhenOnLaunchServedNone() {
         injectBaseConfig()
 
         HeliumFetchedConfigManager.shared.setPreviewServerProducts(
@@ -92,28 +60,13 @@ final class PreviewServerProductsTests: XCTestCase {
             paddleClientToken: "preview_token"
         )
 
-        XCTAssertFalse(HeliumFetchedConfigManager.shared.isPaddleServedByOnLaunch)
         XCTAssertNotNil(HeliumFetchedConfigManager.shared.getStripeProductsPriceMap()?[stripeKey])
-        XCTAssertNil(HeliumFetchedConfigManager.shared.getPaddleProductsPriceMap())
-        XCTAssertNil(HeliumFetchedConfigManager.shared.paddleClientToken)
+        XCTAssertNotNil(HeliumFetchedConfigManager.shared.getPaddleProductsPriceMap()?[paddleKey])
+        XCTAssertEqual(HeliumFetchedConfigManager.shared.paddleClientToken, "preview_token")
 
         let priceMap = HeliumFetchedConfigManager.shared.getLocalizedPriceMap()
         XCTAssertEqual(priceMap[stripeKey]?.baseInfo.formattedPrice, "$9.99")
-        XCTAssertNil(priceMap[paddleKey])
-    }
-
-    func testOnLaunchPaddleProductsAloneMakePreviewPaddleEligible() {
-        injectBaseConfig(paddleProducts: [liveKey: makeServerPrice(formattedPrice: "$4.99", value: 4.99, title: "Live")])
-
-        HeliumFetchedConfigManager.shared.setPreviewServerProducts(
-            stripeProducts: nil,
-            paddleProducts: [paddleKey: makeServerPrice(formattedPrice: "$19.99", value: 19.99)],
-            paddleClientToken: "preview_token"
-        )
-
-        XCTAssertTrue(HeliumFetchedConfigManager.shared.isPaddleServedByOnLaunch)
-        XCTAssertNotNil(HeliumFetchedConfigManager.shared.getPaddleProductsPriceMap()?[paddleKey])
-        XCTAssertEqual(HeliumFetchedConfigManager.shared.paddleClientToken, "preview_token")
+        XCTAssertEqual(priceMap[paddleKey]?.baseInfo.formattedPrice, "$19.99")
     }
 
     func testPreviewNeverEntersTheFetchedConfig() {
@@ -177,7 +130,7 @@ final class PreviewServerProductsTests: XCTestCase {
     }
 
     func testRefreshReplacesEarlierPreviewValues() {
-        injectPaddleServedConfigWithoutToken()
+        injectBaseConfig()
 
         HeliumFetchedConfigManager.shared.setPreviewServerProducts(
             stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99, title: "Before")],
@@ -199,7 +152,7 @@ final class PreviewServerProductsTests: XCTestCase {
     }
 
     func testMissingClientTokenIsSuppliedByThePreview() {
-        injectPaddleServedConfigWithoutToken()
+        injectBaseConfig(paddleClientToken: nil)
 
         HeliumFetchedConfigManager.shared.setPreviewServerProducts(
             stripeProducts: nil,
@@ -241,7 +194,7 @@ final class PreviewServerProductsTests: XCTestCase {
     }
 
     func testCanceledRefreshDoesNotApplyItsProducts() async {
-        injectPaddleServedConfigWithoutToken()
+        injectBaseConfig()
         let response = makeResponse(
             stripe: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99)],
             paddleClientToken: "stale_token"
@@ -261,7 +214,7 @@ final class PreviewServerProductsTests: XCTestCase {
     }
 
     func testOverlappingRefreshKeepsTheNewerResponse() async {
-        injectPaddleServedConfigWithoutToken()
+        injectBaseConfig()
         let stale = makeResponse(
             stripe: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99, title: "Stale")],
             paddleClientToken: "stale_token"

--- a/Tests/helium-swiftTests/PreviewServerProductsTests.swift
+++ b/Tests/helium-swiftTests/PreviewServerProductsTests.swift
@@ -5,6 +5,7 @@ final class PreviewServerProductsTests: XCTestCase {
 
     private let stripeKey = "prod_preview:price_preview"
     private let paddleKey = "pro_preview:pri_preview"
+    private let liveKey = "prod_live:price_live"
 
     override func setUp() {
         super.setUp()
@@ -50,138 +51,147 @@ final class PreviewServerProductsTests: XCTestCase {
         injectConfig(config)
     }
 
-    func testPreviewProductsLandInConfigAndPriceMap() {
+    func testPreviewProductsSurfaceThroughTheProductMaps() {
         injectBaseConfig()
 
-        HeliumFetchedConfigManager.shared.mergePreviewServerProducts(
+        HeliumFetchedConfigManager.shared.setPreviewServerProducts(
             stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99)],
             paddleProducts: [paddleKey: makeServerPrice(formattedPrice: "$19.99", value: 19.99)],
-            paddleClientToken: "live_abc123"
+            paddleClientToken: "preview_token"
         )
 
         XCTAssertNotNil(HeliumFetchedConfigManager.shared.getStripeProductsPriceMap()?[stripeKey])
         XCTAssertNotNil(HeliumFetchedConfigManager.shared.getPaddleProductsPriceMap()?[paddleKey])
-        XCTAssertEqual(HeliumFetchedConfigManager.shared.fetchedConfig?.paddleClientToken, "live_abc123")
+        XCTAssertEqual(HeliumFetchedConfigManager.shared.paddleClientToken, "preview_token")
 
         let priceMap = HeliumFetchedConfigManager.shared.getLocalizedPriceMap()
         XCTAssertEqual(priceMap[stripeKey]?.baseInfo.formattedPrice, "$9.99")
         XCTAssertEqual(priceMap[paddleKey]?.baseInfo.formattedPrice, "$19.99")
     }
 
-    func testExistingConfigValuesAreNotOverwritten() {
-        injectBaseConfig(
-            stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$4.99", value: 4.99, title: "Live")],
-            paddleClientToken: "live_existing"
+    func testPreviewNeverEntersTheFetchedConfig() {
+        injectBaseConfig()
+
+        HeliumFetchedConfigManager.shared.setPreviewServerProducts(
+            stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99)],
+            paddleProducts: [paddleKey: makeServerPrice(formattedPrice: "$19.99", value: 19.99)],
+            paddleClientToken: "preview_token"
         )
 
-        HeliumFetchedConfigManager.shared.mergePreviewServerProducts(
+        XCTAssertNil(HeliumFetchedConfigManager.shared.fetchedConfig?.stripeProducts?[stripeKey])
+        XCTAssertNil(HeliumFetchedConfigManager.shared.fetchedConfig?.paddleProducts?[paddleKey])
+        XCTAssertNil(HeliumFetchedConfigManager.shared.fetchedConfig?.paddleClientToken)
+    }
+
+    func testLiveValuesWinOverPreviewValues() {
+        injectBaseConfig(
+            stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$4.99", value: 4.99, title: "Live")],
+            paddleClientToken: "live_token"
+        )
+
+        HeliumFetchedConfigManager.shared.setPreviewServerProducts(
             stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99, title: "Preview")],
             paddleProducts: nil,
             paddleClientToken: "preview_token"
         )
 
         XCTAssertEqual(HeliumFetchedConfigManager.shared.getStripeProductsPriceMap()?[stripeKey]?.localizedTitle, "Live")
-        XCTAssertEqual(HeliumFetchedConfigManager.shared.fetchedConfig?.paddleClientToken, "live_existing")
+        XCTAssertEqual(HeliumFetchedConfigManager.shared.paddleClientToken, "live_token")
     }
 
-    func testNewKeysAreAddedAlongsideExistingOnes() {
-        let liveKey = "prod_live:price_live"
-        injectBaseConfig(stripeProducts: [liveKey: makeServerPrice(formattedPrice: "$4.99", value: 4.99)])
+    func testLiveValuesWinEvenWhenThePreviewArrivedFirst() {
+        HeliumFetchedConfigManager.shared.setPreviewServerProducts(
+            stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99, title: "Preview")],
+            paddleProducts: nil,
+            paddleClientToken: "preview_token"
+        )
 
-        HeliumFetchedConfigManager.shared.mergePreviewServerProducts(
+        injectBaseConfig(
+            stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$4.99", value: 4.99, title: "Live")],
+            paddleClientToken: "live_token"
+        )
+
+        XCTAssertEqual(HeliumFetchedConfigManager.shared.getStripeProductsPriceMap()?[stripeKey]?.localizedTitle, "Live")
+        XCTAssertEqual(HeliumFetchedConfigManager.shared.paddleClientToken, "live_token")
+    }
+
+    func testPreviewFillsOnlyTheKeysLiveDoesNotCarry() {
+        injectBaseConfig(stripeProducts: [liveKey: makeServerPrice(formattedPrice: "$4.99", value: 4.99, title: "Live")])
+
+        HeliumFetchedConfigManager.shared.setPreviewServerProducts(
             stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99)],
             paddleProducts: nil,
             paddleClientToken: nil
         )
 
         let map = HeliumFetchedConfigManager.shared.getStripeProductsPriceMap()
-        XCTAssertNotNil(map?[liveKey])
+        XCTAssertEqual(map?[liveKey]?.localizedTitle, "Live")
         XCTAssertNotNil(map?[stripeKey])
     }
 
-    func testMissingClientTokenIsFilledIn() {
-        injectBaseConfig(paddleClientToken: nil)
+    func testRefreshReplacesEarlierPreviewValues() {
+        injectBaseConfig()
 
-        HeliumFetchedConfigManager.shared.mergePreviewServerProducts(
-            stripeProducts: nil,
-            paddleProducts: [paddleKey: makeServerPrice(formattedPrice: "$19.99", value: 19.99)],
-            paddleClientToken: "preview_token"
-        )
-
-        XCTAssertEqual(HeliumFetchedConfigManager.shared.fetchedConfig?.paddleClientToken, "preview_token")
-    }
-
-    func testEmptyResponseLeavesConfigUntouched() {
-        injectBaseConfig(paddleClientToken: "live_existing")
-
-        HeliumFetchedConfigManager.shared.mergePreviewServerProducts(
-            stripeProducts: nil,
-            paddleProducts: nil,
-            paddleClientToken: nil
-        )
-
-        XCTAssertNil(HeliumFetchedConfigManager.shared.getStripeProductsPriceMap())
-        XCTAssertNil(HeliumFetchedConfigManager.shared.getPaddleProductsPriceMap())
-        XCTAssertEqual(HeliumFetchedConfigManager.shared.fetchedConfig?.paddleClientToken, "live_existing")
-    }
-
-    func testRefreshReplacesValuesAnEarlierPreviewMergeInstalled() {
-        injectBaseConfig(
-            stripeProducts: ["prod_live:price_live": makeServerPrice(formattedPrice: "$4.99", value: 4.99, title: "Live")]
-        )
-
-        HeliumFetchedConfigManager.shared.mergePreviewServerProducts(
+        HeliumFetchedConfigManager.shared.setPreviewServerProducts(
             stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99, title: "Before")],
             paddleProducts: nil,
             paddleClientToken: "first_token"
         )
-
-        HeliumFetchedConfigManager.shared.mergePreviewServerProducts(
+        HeliumFetchedConfigManager.shared.setPreviewServerProducts(
             stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$14.99", value: 14.99, title: "After")],
             paddleProducts: nil,
             paddleClientToken: "second_token"
         )
 
-        let map = HeliumFetchedConfigManager.shared.getStripeProductsPriceMap()
-        XCTAssertEqual(map?[stripeKey]?.localizedTitle, "After")
-        XCTAssertEqual(map?[stripeKey]?.formattedPrice, "$14.99")
+        XCTAssertEqual(HeliumFetchedConfigManager.shared.getStripeProductsPriceMap()?[stripeKey]?.localizedTitle, "After")
         XCTAssertEqual(
             HeliumFetchedConfigManager.shared.getLocalizedPriceMap()[stripeKey]?.baseInfo.formattedPrice,
             "$14.99"
         )
-        XCTAssertEqual(HeliumFetchedConfigManager.shared.fetchedConfig?.paddleClientToken, "second_token")
-
-        XCTAssertEqual(map?["prod_live:price_live"]?.localizedTitle, "Live")
+        XCTAssertEqual(HeliumFetchedConfigManager.shared.paddleClientToken, "second_token")
     }
 
-    func testNewConfigEndsPreviewOwnership() {
-        HeliumFetchedConfigManager.shared.mergePreviewServerProducts(
-            stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99, title: "Preview")],
-            paddleProducts: nil,
-            paddleClientToken: nil
+    func testMissingClientTokenIsSuppliedByThePreview() {
+        injectBaseConfig(paddleClientToken: nil)
+
+        HeliumFetchedConfigManager.shared.setPreviewServerProducts(
+            stripeProducts: nil,
+            paddleProducts: [paddleKey: makeServerPrice(formattedPrice: "$19.99", value: 19.99)],
+            paddleClientToken: "preview_token"
         )
 
+        XCTAssertEqual(HeliumFetchedConfigManager.shared.paddleClientToken, "preview_token")
+    }
+
+    func testEmptyPreviewLeavesLiveValuesIntact() {
         injectBaseConfig(
-            stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$4.99", value: 4.99, title: "Live")]
+            stripeProducts: [liveKey: makeServerPrice(formattedPrice: "$4.99", value: 4.99, title: "Live")],
+            paddleClientToken: "live_token"
         )
 
-        HeliumFetchedConfigManager.shared.mergePreviewServerProducts(
-            stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$19.99", value: 19.99, title: "Preview2")],
+        HeliumFetchedConfigManager.shared.setPreviewServerProducts(
+            stripeProducts: nil,
             paddleProducts: nil,
             paddleClientToken: nil
         )
 
-        XCTAssertEqual(HeliumFetchedConfigManager.shared.getStripeProductsPriceMap()?[stripeKey]?.localizedTitle, "Live")
+        XCTAssertEqual(HeliumFetchedConfigManager.shared.getStripeProductsPriceMap()?[liveKey]?.localizedTitle, "Live")
+        XCTAssertNil(HeliumFetchedConfigManager.shared.getPaddleProductsPriceMap())
+        XCTAssertEqual(HeliumFetchedConfigManager.shared.paddleClientToken, "live_token")
     }
 
-    func testMergeWithNoConfigDoesNotCrash() {
-        HeliumFetchedConfigManager.shared.mergePreviewServerProducts(
+    func testPreviewWithNoConfigDoesNotCrash() {
+        HeliumFetchedConfigManager.shared.setPreviewServerProducts(
             stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99)],
             paddleProducts: nil,
             paddleClientToken: "preview_token"
         )
 
         XCTAssertNil(HeliumFetchedConfigManager.shared.fetchedConfig)
-        XCTAssertEqual(HeliumFetchedConfigManager.shared.getLocalizedPriceMap()[stripeKey]?.baseInfo.formattedPrice, "$9.99")
+        XCTAssertNotNil(HeliumFetchedConfigManager.shared.getStripeProductsPriceMap()?[stripeKey])
+        XCTAssertEqual(
+            HeliumFetchedConfigManager.shared.getLocalizedPriceMap()[stripeKey]?.baseInfo.formattedPrice,
+            "$9.99"
+        )
     }
 }

--- a/Tests/helium-swiftTests/PreviewServerProductsTests.swift
+++ b/Tests/helium-swiftTests/PreviewServerProductsTests.swift
@@ -125,6 +125,55 @@ final class PreviewServerProductsTests: XCTestCase {
         XCTAssertEqual(HeliumFetchedConfigManager.shared.fetchedConfig?.paddleClientToken, "live_existing")
     }
 
+    func testRefreshReplacesValuesAnEarlierPreviewMergeInstalled() {
+        injectBaseConfig(
+            stripeProducts: ["prod_live:price_live": makeServerPrice(formattedPrice: "$4.99", value: 4.99, title: "Live")]
+        )
+
+        HeliumFetchedConfigManager.shared.mergePreviewServerProducts(
+            stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99, title: "Before")],
+            paddleProducts: nil,
+            paddleClientToken: "first_token"
+        )
+
+        HeliumFetchedConfigManager.shared.mergePreviewServerProducts(
+            stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$14.99", value: 14.99, title: "After")],
+            paddleProducts: nil,
+            paddleClientToken: "second_token"
+        )
+
+        let map = HeliumFetchedConfigManager.shared.getStripeProductsPriceMap()
+        XCTAssertEqual(map?[stripeKey]?.localizedTitle, "After")
+        XCTAssertEqual(map?[stripeKey]?.formattedPrice, "$14.99")
+        XCTAssertEqual(
+            HeliumFetchedConfigManager.shared.getLocalizedPriceMap()[stripeKey]?.baseInfo.formattedPrice,
+            "$14.99"
+        )
+        XCTAssertEqual(HeliumFetchedConfigManager.shared.fetchedConfig?.paddleClientToken, "second_token")
+
+        XCTAssertEqual(map?["prod_live:price_live"]?.localizedTitle, "Live")
+    }
+
+    func testNewConfigEndsPreviewOwnership() {
+        HeliumFetchedConfigManager.shared.mergePreviewServerProducts(
+            stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99, title: "Preview")],
+            paddleProducts: nil,
+            paddleClientToken: nil
+        )
+
+        injectBaseConfig(
+            stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$4.99", value: 4.99, title: "Live")]
+        )
+
+        HeliumFetchedConfigManager.shared.mergePreviewServerProducts(
+            stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$19.99", value: 19.99, title: "Preview2")],
+            paddleProducts: nil,
+            paddleClientToken: nil
+        )
+
+        XCTAssertEqual(HeliumFetchedConfigManager.shared.getStripeProductsPriceMap()?[stripeKey]?.localizedTitle, "Live")
+    }
+
     func testMergeWithNoConfigDoesNotCrash() {
         HeliumFetchedConfigManager.shared.mergePreviewServerProducts(
             stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99)],

--- a/Tests/helium-swiftTests/PreviewServerProductsTests.swift
+++ b/Tests/helium-swiftTests/PreviewServerProductsTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+@testable import Helium
+
+final class PreviewServerProductsTests: XCTestCase {
+
+    private let stripeKey = "prod_preview:price_preview"
+    private let paddleKey = "pro_preview:pri_preview"
+
+    override func setUp() {
+        super.setUp()
+        HeliumFetchedConfigManager.reset()
+    }
+
+    override func tearDown() {
+        HeliumFetchedConfigManager.reset()
+        super.tearDown()
+    }
+
+    private func makeServerPrice(
+        formattedPrice: String,
+        value: Decimal,
+        title: String = "Preview Monthly"
+    ) -> ServerProductPrice {
+        ServerProductPrice(
+            id: "prod_preview",
+            priceId: "price_preview",
+            formattedPrice: formattedPrice,
+            localizedTitle: title,
+            localizedDescription: nil,
+            currency: "USD",
+            value: value,
+            currencySymbol: "$",
+            duration: "Month",
+            productType: "subscription",
+            subscriptionPeriod: "month",
+            subscription: nil,
+            defaultDiscountId: nil
+        )
+    }
+
+    private func injectBaseConfig(
+        stripeProducts: [String: ServerProductPrice]? = nil,
+        paddleProducts: [String: ServerProductPrice]? = nil,
+        paddleClientToken: String? = nil
+    ) {
+        var config = makeTestConfig(triggers: ["live_trigger": makeTestPaywallInfo()])
+        config.stripeProducts = stripeProducts
+        config.paddleProducts = paddleProducts
+        config.paddleClientToken = paddleClientToken
+        injectConfig(config)
+    }
+
+    func testPreviewProductsLandInConfigAndPriceMap() {
+        injectBaseConfig()
+
+        HeliumFetchedConfigManager.shared.mergePreviewServerProducts(
+            stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99)],
+            paddleProducts: [paddleKey: makeServerPrice(formattedPrice: "$19.99", value: 19.99)],
+            paddleClientToken: "live_abc123"
+        )
+
+        XCTAssertNotNil(HeliumFetchedConfigManager.shared.getStripeProductsPriceMap()?[stripeKey])
+        XCTAssertNotNil(HeliumFetchedConfigManager.shared.getPaddleProductsPriceMap()?[paddleKey])
+        XCTAssertEqual(HeliumFetchedConfigManager.shared.fetchedConfig?.paddleClientToken, "live_abc123")
+
+        let priceMap = HeliumFetchedConfigManager.shared.getLocalizedPriceMap()
+        XCTAssertEqual(priceMap[stripeKey]?.baseInfo.formattedPrice, "$9.99")
+        XCTAssertEqual(priceMap[paddleKey]?.baseInfo.formattedPrice, "$19.99")
+    }
+
+    func testExistingConfigValuesAreNotOverwritten() {
+        injectBaseConfig(
+            stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$4.99", value: 4.99, title: "Live")],
+            paddleClientToken: "live_existing"
+        )
+
+        HeliumFetchedConfigManager.shared.mergePreviewServerProducts(
+            stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99, title: "Preview")],
+            paddleProducts: nil,
+            paddleClientToken: "preview_token"
+        )
+
+        XCTAssertEqual(HeliumFetchedConfigManager.shared.getStripeProductsPriceMap()?[stripeKey]?.localizedTitle, "Live")
+        XCTAssertEqual(HeliumFetchedConfigManager.shared.fetchedConfig?.paddleClientToken, "live_existing")
+    }
+
+    func testNewKeysAreAddedAlongsideExistingOnes() {
+        let liveKey = "prod_live:price_live"
+        injectBaseConfig(stripeProducts: [liveKey: makeServerPrice(formattedPrice: "$4.99", value: 4.99)])
+
+        HeliumFetchedConfigManager.shared.mergePreviewServerProducts(
+            stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99)],
+            paddleProducts: nil,
+            paddleClientToken: nil
+        )
+
+        let map = HeliumFetchedConfigManager.shared.getStripeProductsPriceMap()
+        XCTAssertNotNil(map?[liveKey])
+        XCTAssertNotNil(map?[stripeKey])
+    }
+
+    func testMissingClientTokenIsFilledIn() {
+        injectBaseConfig(paddleClientToken: nil)
+
+        HeliumFetchedConfigManager.shared.mergePreviewServerProducts(
+            stripeProducts: nil,
+            paddleProducts: [paddleKey: makeServerPrice(formattedPrice: "$19.99", value: 19.99)],
+            paddleClientToken: "preview_token"
+        )
+
+        XCTAssertEqual(HeliumFetchedConfigManager.shared.fetchedConfig?.paddleClientToken, "preview_token")
+    }
+
+    func testEmptyResponseLeavesConfigUntouched() {
+        injectBaseConfig(paddleClientToken: "live_existing")
+
+        HeliumFetchedConfigManager.shared.mergePreviewServerProducts(
+            stripeProducts: nil,
+            paddleProducts: nil,
+            paddleClientToken: nil
+        )
+
+        XCTAssertNil(HeliumFetchedConfigManager.shared.getStripeProductsPriceMap())
+        XCTAssertNil(HeliumFetchedConfigManager.shared.getPaddleProductsPriceMap())
+        XCTAssertEqual(HeliumFetchedConfigManager.shared.fetchedConfig?.paddleClientToken, "live_existing")
+    }
+
+    func testMergeWithNoConfigDoesNotCrash() {
+        HeliumFetchedConfigManager.shared.mergePreviewServerProducts(
+            stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99)],
+            paddleProducts: nil,
+            paddleClientToken: "preview_token"
+        )
+
+        XCTAssertNil(HeliumFetchedConfigManager.shared.fetchedConfig)
+        XCTAssertEqual(HeliumFetchedConfigManager.shared.getLocalizedPriceMap()[stripeKey]?.baseInfo.formattedPrice, "$9.99")
+    }
+}

--- a/Tests/helium-swiftTests/PreviewServerProductsTests.swift
+++ b/Tests/helium-swiftTests/PreviewServerProductsTests.swift
@@ -180,6 +180,65 @@ final class PreviewServerProductsTests: XCTestCase {
         XCTAssertEqual(HeliumFetchedConfigManager.shared.paddleClientToken, "live_token")
     }
 
+    private func makeResponse(
+        stripe: [String: ServerProductPrice]? = nil,
+        paddleClientToken: String? = nil
+    ) -> HeliumControlPanelResponse {
+        HeliumControlPanelResponse(
+            productIds: [],
+            paywalls: [],
+            stripeProducts: stripe,
+            paddleProducts: nil,
+            paddleClientToken: paddleClientToken
+        )
+    }
+
+    func testCanceledRefreshDoesNotApplyItsProducts() async {
+        injectBaseConfig()
+        let response = makeResponse(
+            stripe: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99)],
+            paddleClientToken: "stale_token"
+        )
+
+        let task = Task { () -> Bool in
+            // Cancellation lands during this sleep, so the call below always sees it.
+            try? await Task.sleep(nanoseconds: 50_000_000)
+            return HeliumControlPanelService.shared.applyServerProducts(from: response)
+        }
+        task.cancel()
+        let applied = await task.value
+
+        XCTAssertFalse(applied)
+        XCTAssertNil(HeliumFetchedConfigManager.shared.getStripeProductsPriceMap()?[stripeKey])
+        XCTAssertNil(HeliumFetchedConfigManager.shared.paddleClientToken)
+    }
+
+    func testOverlappingRefreshKeepsTheNewerResponse() async {
+        injectBaseConfig()
+        let stale = makeResponse(
+            stripe: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99, title: "Stale")],
+            paddleClientToken: "stale_token"
+        )
+        let fresh = makeResponse(
+            stripe: [stripeKey: makeServerPrice(formattedPrice: "$14.99", value: 14.99, title: "Fresh")],
+            paddleClientToken: "fresh_token"
+        )
+
+        let freshTask = Task { HeliumControlPanelService.shared.applyServerProducts(from: fresh) }
+        _ = await freshTask.value
+
+        // The canceled refresh resolves last; its products must not displace the newer ones.
+        let staleTask = Task { () -> Bool in
+            try? await Task.sleep(nanoseconds: 50_000_000)
+            return HeliumControlPanelService.shared.applyServerProducts(from: stale)
+        }
+        staleTask.cancel()
+        _ = await staleTask.value
+
+        XCTAssertEqual(HeliumFetchedConfigManager.shared.getStripeProductsPriceMap()?[stripeKey]?.localizedTitle, "Fresh")
+        XCTAssertEqual(HeliumFetchedConfigManager.shared.paddleClientToken, "fresh_token")
+    }
+
     func testPreviewWithNoConfigDoesNotCrash() {
         HeliumFetchedConfigManager.shared.setPreviewServerProducts(
             stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99)],

--- a/Tests/helium-swiftTests/PreviewServerProductsTests.swift
+++ b/Tests/helium-swiftTests/PreviewServerProductsTests.swift
@@ -51,8 +51,18 @@ final class PreviewServerProductsTests: XCTestCase {
         injectConfig(config)
     }
 
+    /// On-launch served Paddle products for a live paywall but no token: the case where a
+    /// preview of a not-yet-live paywall has to supply the token itself.
+    private func injectPaddleServedConfigWithoutToken() {
+        injectBaseConfig(
+            paddleProducts: [liveKey: makeServerPrice(formattedPrice: "$4.99", value: 4.99, title: "Live")],
+            paddleClientToken: nil
+        )
+    }
+
     func testPreviewProductsSurfaceThroughTheProductMaps() {
-        injectBaseConfig()
+        // On-launch served Paddle to this device, so preview Paddle is eligible too.
+        injectBaseConfig(paddleClientToken: "live_token_for_other_paywall")
 
         HeliumFetchedConfigManager.shared.setPreviewServerProducts(
             stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99)],
@@ -62,11 +72,48 @@ final class PreviewServerProductsTests: XCTestCase {
 
         XCTAssertNotNil(HeliumFetchedConfigManager.shared.getStripeProductsPriceMap()?[stripeKey])
         XCTAssertNotNil(HeliumFetchedConfigManager.shared.getPaddleProductsPriceMap()?[paddleKey])
-        XCTAssertEqual(HeliumFetchedConfigManager.shared.paddleClientToken, "preview_token")
+        XCTAssertEqual(HeliumFetchedConfigManager.shared.paddleClientToken, "live_token_for_other_paywall")
 
         let priceMap = HeliumFetchedConfigManager.shared.getLocalizedPriceMap()
         XCTAssertEqual(priceMap[stripeKey]?.baseInfo.formattedPrice, "$9.99")
         XCTAssertEqual(priceMap[paddleKey]?.baseInfo.formattedPrice, "$19.99")
+    }
+
+    /// On-launch drops every Paddle trigger for a device its request-IP compliance gate rejects.
+    /// The preview endpoint runs no such gate, so its Paddle set must defer to on-launch's
+    /// verdict, or a tester outside the served region would reach a checkout production never
+    /// offers them. Stripe carries no such gate and stays available.
+    func testPreviewPaddleIsWithheldWhenOnLaunchServedNone() {
+        injectBaseConfig()
+
+        HeliumFetchedConfigManager.shared.setPreviewServerProducts(
+            stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99)],
+            paddleProducts: [paddleKey: makeServerPrice(formattedPrice: "$19.99", value: 19.99)],
+            paddleClientToken: "preview_token"
+        )
+
+        XCTAssertFalse(HeliumFetchedConfigManager.shared.isPaddleServedByOnLaunch)
+        XCTAssertNotNil(HeliumFetchedConfigManager.shared.getStripeProductsPriceMap()?[stripeKey])
+        XCTAssertNil(HeliumFetchedConfigManager.shared.getPaddleProductsPriceMap())
+        XCTAssertNil(HeliumFetchedConfigManager.shared.paddleClientToken)
+
+        let priceMap = HeliumFetchedConfigManager.shared.getLocalizedPriceMap()
+        XCTAssertEqual(priceMap[stripeKey]?.baseInfo.formattedPrice, "$9.99")
+        XCTAssertNil(priceMap[paddleKey])
+    }
+
+    func testOnLaunchPaddleProductsAloneMakePreviewPaddleEligible() {
+        injectBaseConfig(paddleProducts: [liveKey: makeServerPrice(formattedPrice: "$4.99", value: 4.99, title: "Live")])
+
+        HeliumFetchedConfigManager.shared.setPreviewServerProducts(
+            stripeProducts: nil,
+            paddleProducts: [paddleKey: makeServerPrice(formattedPrice: "$19.99", value: 19.99)],
+            paddleClientToken: "preview_token"
+        )
+
+        XCTAssertTrue(HeliumFetchedConfigManager.shared.isPaddleServedByOnLaunch)
+        XCTAssertNotNil(HeliumFetchedConfigManager.shared.getPaddleProductsPriceMap()?[paddleKey])
+        XCTAssertEqual(HeliumFetchedConfigManager.shared.paddleClientToken, "preview_token")
     }
 
     func testPreviewNeverEntersTheFetchedConfig() {
@@ -130,7 +177,7 @@ final class PreviewServerProductsTests: XCTestCase {
     }
 
     func testRefreshReplacesEarlierPreviewValues() {
-        injectBaseConfig()
+        injectPaddleServedConfigWithoutToken()
 
         HeliumFetchedConfigManager.shared.setPreviewServerProducts(
             stripeProducts: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99, title: "Before")],
@@ -152,7 +199,7 @@ final class PreviewServerProductsTests: XCTestCase {
     }
 
     func testMissingClientTokenIsSuppliedByThePreview() {
-        injectBaseConfig(paddleClientToken: nil)
+        injectPaddleServedConfigWithoutToken()
 
         HeliumFetchedConfigManager.shared.setPreviewServerProducts(
             stripeProducts: nil,
@@ -194,7 +241,7 @@ final class PreviewServerProductsTests: XCTestCase {
     }
 
     func testCanceledRefreshDoesNotApplyItsProducts() async {
-        injectBaseConfig()
+        injectPaddleServedConfigWithoutToken()
         let response = makeResponse(
             stripe: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99)],
             paddleClientToken: "stale_token"
@@ -214,7 +261,7 @@ final class PreviewServerProductsTests: XCTestCase {
     }
 
     func testOverlappingRefreshKeepsTheNewerResponse() async {
-        injectBaseConfig()
+        injectPaddleServedConfigWithoutToken()
         let stale = makeResponse(
             stripe: [stripeKey: makeServerPrice(formattedPrice: "$9.99", value: 9.99, title: "Stale")],
             paddleClientToken: "stale_token"

--- a/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
+++ b/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
@@ -131,24 +131,55 @@ final class PreviewTriggerConfigTests: XCTestCase {
     }
 
     func testPreviewUsesProvidedBundleUrlAndProducts() throws {
-        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
+        // On-launch served Paddle to this device, so preview Paddle products are eligible.
+        var config = makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()])
+        config.paddleClientToken = "live_token"
+        injectConfig(config)
 
         try setPreviewConfig(
             productIds: ["preview.product"],
             productIdsStripe: ["preview_stripe:price_9"],
-            productIdsPaddle: [],
+            productIdsPaddle: ["preview_paddle:pri_9"],
             productIdsPaddleWeb: ["preview_paddle_web:pri_9"]
         )
 
         XCTAssertEqual(previewInfo?.extractedBundleUrl, previewBundleUrl)
         XCTAssertEqual(previewInfo?.productsOfferedIOS, ["preview.product"])
         XCTAssertEqual(previewInfo?.productsOfferedStripe, ["preview_stripe:price_9"])
-        XCTAssertEqual(previewInfo?.productsOfferedPaddle, [])
+        XCTAssertEqual(previewInfo?.productsOfferedPaddle, ["preview_paddle:pri_9"])
         XCTAssertEqual(previewInfo?.webProductsOfferedPaddle, ["preview_paddle_web:pri_9"])
         XCTAssertEqual(
             HeliumFetchedConfigManager.shared.fetchedConfig?.bundles?["preview456"],
             "<html>preview</html>"
         )
+    }
+
+    /// On-launch drops every Paddle trigger for a device its request-IP compliance gate rejects.
+    /// A preview installed on such a device must not carry Paddle products, or the presenter
+    /// would offer an app2web checkout production never serves here. Native, Stripe, and the
+    /// web checkout URL (shared with web-Stripe) are untouched.
+    func testPreviewWithholdsPaddleProductsWhenOnLaunchServedNone() throws {
+        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
+        let webCheckoutUrl = "https://bundles-staging.clickthrough.to/x/bundle_web.html"
+
+        try setPreviewConfig(
+            productIds: ["preview.product"],
+            productIdsStripe: ["preview_stripe:price_9"],
+            productIdsPaddle: ["preview_paddle:pri_9"],
+            productIdsPaddleWeb: ["preview_paddle_web:pri_9"],
+            productIdsStripeWeb: ["preview_stripe_web:price_9"],
+            webPaywallBundleUrl: webCheckoutUrl,
+            secondTry: makeSecondTryBundle()
+        )
+
+        XCTAssertEqual(previewInfo?.productsOfferedIOS, ["preview.product"])
+        XCTAssertEqual(previewInfo?.productsOfferedStripe, ["preview_stripe:price_9"])
+        XCTAssertEqual(previewInfo?.productsOfferedPaddle, [])
+        XCTAssertEqual(previewInfo?.webProductsOfferedPaddle, [])
+        XCTAssertEqual(previewInfo?.webProductsOfferedStripe, ["preview_stripe_web:price_9"])
+        XCTAssertEqual(previewInfo?.webPaywallBundleUrl, webCheckoutUrl)
+        XCTAssertEqual(secondTryInfo?.productsOfferedPaddle, [])
+        XCTAssertEqual(secondTryInfo?.productsOfferedStripe, ["secondtry_stripe:price_2"])
     }
 
     func testPreviewDoesNotInheritDonorScrollSetting() throws {

--- a/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
+++ b/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
@@ -131,55 +131,24 @@ final class PreviewTriggerConfigTests: XCTestCase {
     }
 
     func testPreviewUsesProvidedBundleUrlAndProducts() throws {
-        // On-launch served Paddle to this device, so preview Paddle products are eligible.
-        var config = makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()])
-        config.paddleClientToken = "live_token"
-        injectConfig(config)
+        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
 
         try setPreviewConfig(
             productIds: ["preview.product"],
             productIdsStripe: ["preview_stripe:price_9"],
-            productIdsPaddle: ["preview_paddle:pri_9"],
+            productIdsPaddle: [],
             productIdsPaddleWeb: ["preview_paddle_web:pri_9"]
         )
 
         XCTAssertEqual(previewInfo?.extractedBundleUrl, previewBundleUrl)
         XCTAssertEqual(previewInfo?.productsOfferedIOS, ["preview.product"])
         XCTAssertEqual(previewInfo?.productsOfferedStripe, ["preview_stripe:price_9"])
-        XCTAssertEqual(previewInfo?.productsOfferedPaddle, ["preview_paddle:pri_9"])
+        XCTAssertEqual(previewInfo?.productsOfferedPaddle, [])
         XCTAssertEqual(previewInfo?.webProductsOfferedPaddle, ["preview_paddle_web:pri_9"])
         XCTAssertEqual(
             HeliumFetchedConfigManager.shared.fetchedConfig?.bundles?["preview456"],
             "<html>preview</html>"
         )
-    }
-
-    /// On-launch drops every Paddle trigger for a device its request-IP compliance gate rejects.
-    /// A preview installed on such a device must not carry Paddle products, or the presenter
-    /// would offer an app2web checkout production never serves here. Native, Stripe, and the
-    /// web checkout URL (shared with web-Stripe) are untouched.
-    func testPreviewWithholdsPaddleProductsWhenOnLaunchServedNone() throws {
-        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
-        let webCheckoutUrl = "https://bundles-staging.clickthrough.to/x/bundle_web.html"
-
-        try setPreviewConfig(
-            productIds: ["preview.product"],
-            productIdsStripe: ["preview_stripe:price_9"],
-            productIdsPaddle: ["preview_paddle:pri_9"],
-            productIdsPaddleWeb: ["preview_paddle_web:pri_9"],
-            productIdsStripeWeb: ["preview_stripe_web:price_9"],
-            webPaywallBundleUrl: webCheckoutUrl,
-            secondTry: makeSecondTryBundle()
-        )
-
-        XCTAssertEqual(previewInfo?.productsOfferedIOS, ["preview.product"])
-        XCTAssertEqual(previewInfo?.productsOfferedStripe, ["preview_stripe:price_9"])
-        XCTAssertEqual(previewInfo?.productsOfferedPaddle, [])
-        XCTAssertEqual(previewInfo?.webProductsOfferedPaddle, [])
-        XCTAssertEqual(previewInfo?.webProductsOfferedStripe, ["preview_stripe_web:price_9"])
-        XCTAssertEqual(previewInfo?.webPaywallBundleUrl, webCheckoutUrl)
-        XCTAssertEqual(secondTryInfo?.productsOfferedPaddle, [])
-        XCTAssertEqual(secondTryInfo?.productsOfferedStripe, ["secondtry_stripe:price_2"])
     }
 
     func testPreviewDoesNotInheritDonorScrollSetting() throws {


### PR DESCRIPTION
## Problem

The server side of this now returns localized Stripe/Paddle product details on `/paywall-previews`, but the SDK dropped them on the floor: `HeliumControlPanelResponse` didn't declare the fields, so the decoder discarded them.

Even decoded, nothing consumed them. `fetchPaywalls` calls the `[String]` overload of `buildLocalizedPriceMap`, which only queries StoreKit — the server-price merge lives in the `config:` overload. And `setPreviewTriggerConfig` installs product ID lists into the cloned trigger without touching `stripeProducts` / `paddleProducts`.

Net effect: previewing a draft paywall renders no price, `HeliumPaymentProcessor.resolve(for:)` returns `.appStore` for its SKUs (routing purchases to StoreKit rather than the web processor), and Paddle checkout has no client token.

**Requires the corresponding bandit change to be deployed.** Without it these fields are simply absent and behavior is unchanged.

## Changes

- Declare `stripeProducts`, `paddleProducts`, `paddleClientToken` on `HeliumControlPanelResponse`. `ServerProductPrice` already matches the server's shape, so decoding needed no new types.
- New `HeliumFetchedConfigManager.mergePreviewServerProducts(...)`, writing to both places that matter for different consumers:
  - `fetchedConfig.stripeProducts` / `.paddleProducts` / `.paddleClientToken` — purchase routing, provider attribution, Paddle checkout prefetch
  - `localizedPriceMap` — what `DynamicWebView` actually renders, via `getLocalizedPriceMapForTrigger`
- Called from `fetchPaywalls` after the StoreKit price fetch.

## Notes for review

**Existing values win on collision.** On-launch resolved those against a real customer; the preview endpoint has no user and reports every intro offer as available. Letting it overwrite would show an ineligible tester a trial they can't actually get. It only ever fills gaps — which is the entire bug.

**Merged at fetch time rather than per-preview-arm,** since the maps are response-level and cover every version including the web handoff. This touches the shared config when the panel opens, which is safe: the added keys belong to no live trigger, and the control panel only opens in debug/sandbox/TestFlight builds.

## Testing

Full suite green — 380 tests, 0 failures. New `PreviewServerProductsTests` covers the config and price-map writes, the collision policy, filling a missing client token, the empty response, and a merge with no config present (no crash).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches product price maps and Paddle token used for purchase routing, but only overlays preview data and keeps live config values on collision. Limited to control-panel preview flows.
> 
> **Overview**
> Paywall previews now use Stripe/Paddle product details and a Paddle client token from `/paywall-previews`, so draft paywalls can show prices and route web checkout instead of dropping those fields.
> 
> Preview products live in a separate `previewServerProducts` store, not on `fetchedConfig`. Getters overlay them at read time so **live keys always win**, even if the preview arrives first. `applyServerProducts` skips canceled fetches so a late stale response cannot replace a newer one.
> 
> Paddle checkout prefetch reads the overlayed `paddleClientToken`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc5e6dd9aba5a3b929675ebae21bf70715a52ad6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Stripe and Paddle product pricing from preview configurations.
  * Added support for Paddle client tokens in preview configuration data.
  * Preview pricing and checkout settings now merge with fetched values while preserving live data precedence.
  * Paddle products and checkout settings now respect regional eligibility.

* **Bug Fixes**
  * Improved handling of empty, canceled, overlapping, or unavailable previews without disrupting existing settings.

* **Tests**
  * Added coverage for merging, localization, refresh behavior, precedence, eligibility, and missing configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->