### PR TITLE
[HEL-6506] | Treat the second try preview trigger as a preview in the diagnostic view

### DIFF
--- a/Sources/Helium/HeliumCore/HeliumPaywallDiagnosticView.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDiagnosticView.swift
@@ -37,7 +37,7 @@ struct HeliumPaywallDiagnosticView: View {
     }
 
     private var isForPreview: Bool {
-        triggerName == HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER
+        HeliumFetchedConfigManager.isPreviewTrigger(triggerName)
     }
 
     var body: some View {


### PR DESCRIPTION
## What

Follow-up from the review of cloudcaptainai/helium-android#340: `HeliumPaywallDiagnosticView.isForPreview` still used main-preview-only equality, so a diagnostic presented for the second try preview trigger exposed the internal `helium_preview_trigger_second_try` name in the trigger pill and showed the "do not show again" toggle. It now uses `HeliumFetchedConfigManager.isPreviewTrigger`, consistent with `HeliumDiagnosticGate` and with Android's diagnostic activity.

## Testing

Diagnostic view, diagnostic mapper, and preview trigger config suites green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line behavioral fix in diagnostic UI preview detection; no auth, paywall, or data-path changes.
> 
> **Overview**
> **Helium paywall diagnostic** now treats **both** dashboard preview triggers (main and second try) as preview sessions in the UI, not only the primary preview trigger.
> 
> `isForPreview` switches from a single-trigger equality check to `HeliumFetchedConfigManager.isPreviewTrigger`, matching `HeliumDiagnosticGate` and Android. For second-try preview failures, the modal no longer shows the internal trigger name pill or the “do not show again” toggle, and it uses the same preview-oriented footer behavior as the main preview path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7474f9aab9f1e62673279befad277d6e8b44acc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved paywall preview detection for more consistent behavior across supported preview triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->