### PR TITLE
Resolve server feature flags and gate JS-crash detection behind jsCrashFallback

### DIFF
--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -279,8 +279,6 @@ struct DynamicWebView: View {
                 forMainFrameOnly: true
             )
 
-            // The server-driven flag gates the whole JS-crash detection path here at
-            // its root: with no hook installed, nothing downstream can ever fire.
             let errorHookScript: WKUserScript?
             if HeliumFetchedConfigManager.shared.isFeatureEnabled(.jsCrashFallback) {
                 errorHookScript = WKUserScript(

--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -200,6 +200,7 @@ struct DynamicWebView: View {
               ),
               scope: actionsDelegate.observabilityScope
           )
+          guard HeliumFetchedConfigManager.shared.isFeatureEnabled(.jsCrashFallback) else { return }
           webViewLoadFail(reason: "WebContentProcessTerminated", kind: .processTerminated)
       }
       .onReceive(NotificationCenter.default.publisher(for: .heliumWebCheckoutProcessingChanged)) { notification in

--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -279,11 +279,18 @@ struct DynamicWebView: View {
                 forMainFrameOnly: true
             )
 
-            let errorHookScript = WKUserScript(
-                source: WebViewRenderGuard.errorHookScriptSource(loadToken: loadToken),
-                injectionTime: .atDocumentStart,
-                forMainFrameOnly: true
-            )
+            // The server-driven flag gates the whole JS-crash detection path here at
+            // its root: with no hook installed, nothing downstream can ever fire.
+            let errorHookScript: WKUserScript?
+            if HeliumFetchedConfigManager.shared.isFeatureEnabled(.jsCrashFallback) {
+                errorHookScript = WKUserScript(
+                    source: WebViewRenderGuard.errorHookScriptSource(loadToken: loadToken),
+                    injectionTime: .atDocumentStart,
+                    forMainFrameOnly: true
+                )
+            } else {
+                errorHookScript = nil
+            }
 
             let preparingToken = loadToken
             Task {
@@ -312,7 +319,9 @@ struct DynamicWebView: View {
                 _ = Date()
                 preparedWebView.configuration.userContentController.removeAllUserScripts()
                 preparedWebView.configuration.userContentController.addUserScript(combinedScript)
-                preparedWebView.configuration.userContentController.addUserScript(errorHookScript)
+                if let errorHookScript {
+                    preparedWebView.configuration.userContentController.addUserScript(errorHookScript)
+                }
                 
                 // File loading timing
                 _ = Date()

--- a/Sources/Helium/HeliumCore/HeliumFeatureFlags.swift
+++ b/Sources/Helium/HeliumCore/HeliumFeatureFlags.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Declaration of every server-driven feature flag the SDK understands.
+///
+/// The server delivers flags in the on-launch response's `featureFlags` map. Every
+/// flag is off unless the server sends `true`.
+enum HeliumFeatureFlag: String, CaseIterable {
+    /// Gates JS-crash detection at its root: the error hook is only injected into
+    /// paywall bundles when enabled, so probes and fallback recovery can never fire
+    /// without it. WebContent-process-death handling is deliberately not gated —
+    /// that is a definitive OS signal, not a heuristic.
+    case jsCrashFallback
+}
+
+/// Immutable resolved view of the server's `featureFlags` map.
+///
+/// Coercion is strict: only JSON booleans count. Any other value (the string
+/// `"true"`, numbers, null, structures) is logged and the flag stays off. Keys
+/// the SDK doesn't declare are ignored.
+struct HeliumFeatureFlags {
+    private let resolved: [HeliumFeatureFlag: Bool]
+
+    static let empty = HeliumFeatureFlags(resolved: [:])
+
+    func isEnabled(_ flag: HeliumFeatureFlag) -> Bool {
+        resolved[flag] ?? false
+    }
+
+    static func from(_ raw: JSON?) -> HeliumFeatureFlags {
+        guard let dict = raw?.dictionary, !dict.isEmpty else { return .empty }
+        var resolved: [HeliumFeatureFlag: Bool] = [:]
+        for flag in HeliumFeatureFlag.allCases {
+            guard let element = dict[flag.rawValue] else { continue }
+            if element.type == .bool {
+                resolved[flag] = element.boolValue
+            } else {
+                HeliumLogger.log(
+                    .warn,
+                    category: .config,
+                    "Helium feature flag '\(flag.rawValue)' has non-boolean value (\(element)); treating it as off."
+                )
+            }
+        }
+        return HeliumFeatureFlags(resolved: resolved)
+    }
+}

--- a/Sources/Helium/HeliumCore/HeliumFeatureFlags.swift
+++ b/Sources/Helium/HeliumCore/HeliumFeatureFlags.swift
@@ -5,10 +5,9 @@ import Foundation
 /// The server delivers flags in the on-launch response's `featureFlags` map. Every
 /// flag is off unless the server sends `true`.
 enum HeliumFeatureFlag: String, CaseIterable {
-    /// Gates JS-crash detection at its root: the error hook is only injected into
-    /// paywall bundles when enabled, so probes and fallback recovery can never fire
-    /// without it. WebContent-process-death handling is deliberately not gated —
-    /// that is a definitive OS signal, not a heuristic.
+    /// Gates every action the crash-detection paths can take on a paywall: error-hook
+    /// injection (and with it probes and fallback recovery) and the reload reaction to
+    /// WebContent-process death. Their telemetry stays unconditional.
     case jsCrashFallback
 }
 

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -234,6 +234,11 @@ public class HeliumFetchedConfigManager {
     
     @HeliumAtomic private(set) var fetchedConfig: HeliumFetchedConfig?
     @HeliumAtomic private(set) var fetchedConfigJSON: JSON?
+
+    /// Resolved on access from the current config so every set/reset path is covered.
+    func isFeatureEnabled(_ flag: HeliumFeatureFlag) -> Bool {
+        HeliumFeatureFlags.from(fetchedConfig?.featureFlags).isEnabled(flag)
+    }
     @HeliumAtomic private(set) var triggersWithSkippedBundleAndReason: [(trigger: String, reason: PaywallUnavailableReason)] = []
     @HeliumAtomic private var localizedPriceMap: [String: LocalizedPrice] = [:]
     

--- a/Sources/Helium/HeliumCore/Models.swift
+++ b/Sources/Helium/HeliumCore/Models.swift
@@ -134,7 +134,6 @@ public struct HeliumFetchedConfig: Codable {
 
     var paddleClientToken: String?
 
-    /// Server-driven feature flags; see `HeliumFeatureFlag` for the declared keys.
     var featureFlags: JSON?
     
     /// Extract experiment info for a specific trigger

--- a/Sources/Helium/HeliumCore/Models.swift
+++ b/Sources/Helium/HeliumCore/Models.swift
@@ -133,6 +133,9 @@ public struct HeliumFetchedConfig: Codable {
     var paddleCustomerId: String?
 
     var paddleClientToken: String?
+
+    /// Server-driven feature flags; see `HeliumFeatureFlag` for the declared keys.
+    var featureFlags: JSON?
     
     /// Extract experiment info for a specific trigger
     /// - Parameter trigger: The trigger name to extract experiment info for

--- a/Tests/helium-swiftTests/HeliumFeatureFlagsTests.swift
+++ b/Tests/helium-swiftTests/HeliumFeatureFlagsTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import Helium
+
+/// Mirrors the Android SDK's flag semantics: strict boolean coercion, undeclared
+/// keys ignored, and every flag off unless the server sends `true`.
+final class HeliumFeatureFlagsTests: XCTestCase {
+
+    func testTrueBooleanEnablesTheFlag() {
+        let flags = HeliumFeatureFlags.from(JSON(["jsCrashFallback": true]))
+
+        XCTAssertTrue(flags.isEnabled(.jsCrashFallback))
+    }
+
+    func testFalseBooleanDisablesTheFlag() {
+        let flags = HeliumFeatureFlags.from(JSON(["jsCrashFallback": false]))
+
+        XCTAssertFalse(flags.isEnabled(.jsCrashFallback))
+    }
+
+    func testAbsentKeyIsOff() {
+        let flags = HeliumFeatureFlags.from(JSON(["someOtherKey": true]))
+
+        XCTAssertFalse(flags.isEnabled(.jsCrashFallback))
+    }
+
+    func testStringTrueIsRejectedAndStaysOff() {
+        let flags = HeliumFeatureFlags.from(JSON(["jsCrashFallback": "true"]))
+
+        XCTAssertFalse(flags.isEnabled(.jsCrashFallback))
+    }
+
+    func testNumericValueIsRejectedAndStaysOff() {
+        let flags = HeliumFeatureFlags.from(JSON(["jsCrashFallback": 1]))
+
+        XCTAssertFalse(flags.isEnabled(.jsCrashFallback))
+    }
+
+    func testNilMapMeansEveryFlagIsOff() {
+        let flags = HeliumFeatureFlags.from(nil)
+
+        for flag in HeliumFeatureFlag.allCases {
+            XCTAssertFalse(flags.isEnabled(flag))
+        }
+    }
+
+    func testEmptyMeansEveryFlagIsOff() {
+        for flag in HeliumFeatureFlag.allCases {
+            XCTAssertFalse(HeliumFeatureFlags.empty.isEnabled(flag))
+        }
+    }
+}

--- a/Tests/helium-swiftTests/OnLaunchResponseDecodingTests.swift
+++ b/Tests/helium-swiftTests/OnLaunchResponseDecodingTests.swift
@@ -56,4 +56,25 @@ final class OnLaunchResponseDecodingTests: XCTestCase {
 
         XCTAssertNil(decoded.paywallDiagnosticModalAllowedInTestFlight)
     }
+
+    // ---------- featureFlags contract ----------
+
+    func testFeatureFlagsDecodeFromJSON() throws {
+        let json = try makeOnLaunchJSON(extras: [
+            "featureFlags": ["jsCrashFallback": true],
+        ])
+
+        let decoded = try JSONDecoder().decode(HeliumFetchedConfig.self, from: json)
+
+        XCTAssertTrue(HeliumFeatureFlags.from(decoded.featureFlags).isEnabled(.jsCrashFallback))
+    }
+
+    func testFeatureFlagsAreNilWhenAbsent() throws {
+        let json = try makeOnLaunchJSON(extras: [:])
+
+        let decoded = try JSONDecoder().decode(HeliumFetchedConfig.self, from: json)
+
+        XCTAssertNil(decoded.featureFlags)
+        XCTAssertFalse(HeliumFeatureFlags.from(decoded.featureFlags).isEnabled(.jsCrashFallback))
+    }
 }


### PR DESCRIPTION
## Why

The JS-crash detection that landed in #326 runs unconditionally on every render, and its recovery path can replace a showing paywall based on a heuristic — the review asked for a server-controlled kill-switch so a false-positive pattern in production can be disabled remotely instead of requiring an SDK release. Android already consumes the server's `featureFlags` map; iOS had no flag plumbing at all.

## What

- **`HeliumFeatureFlags`** — resolves the on-launch response's `featureFlags` map (served by cloudcaptainai/bandit-server-lite-phoenix#138), mirroring the Android SDK's semantics exactly: strict boolean coercion (string `"true"`, numbers, null and structures are logged and treated as off), undeclared keys ignored, and no client-side defaults — every flag is off unless the server sends `true`.
- **`jsCrashFallback` gate** — `DynamicWebView` only builds and injects the error hook when the flag is enabled, gating the whole detection path (hook → bridge → probes → recovery) at its root. WebContent-process-death handling stays ungated: that's a definitive OS signal, not a heuristic.
- Only `jsCrashFallback` is declared on iOS; Android's other flags map to concepts iOS already handles through existing config fields.

Matches the Android twin (cloudcaptainai/helium-android#336, which carries the same gate plus the no-defaults simplification).

## Testing

- 424 tests green, 9 new: flag-resolution semantics mirroring the Android suite (strict coercion, absent keys, empty/nil maps) and the on-launch decode contract for `featureFlags`.
- Rollout shape this enables: releases ship with detection dark, it's enabled server-side per org once validated, and can be killed remotely if `paywall_js_error_detected` outcomes show false positives.

HEL-6594

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall WebView failure and recovery paths behind a server flag; misconfiguration or rollout could leave users without automatic fallback while telemetry still fires.
> 
> **Overview**
> Adds **server-driven feature flags** from the on-launch `featureFlags` map, with strict boolean-only resolution (flags default off; invalid types are logged and treated as off).
> 
> **`jsCrashFallback`** is the first declared flag and acts as a remote kill-switch for paywall crash **recovery** behavior in `DynamicWebView`: the JS error-hook user script is only injected when enabled, and WebContent process termination no longer triggers `webViewLoadFail` reload/fallback unless the flag is on. Related **telemetry** (e.g. process-terminated tracking) remains emitted regardless of the flag.
> 
> Config plumbing includes `featureFlags` on `HeliumFetchedConfig` and `HeliumFetchedConfigManager.isFeatureEnabled(_:)`, plus unit tests for flag parsing and decode contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82a3e8da1a95d5d80ba8b2351e324575f3e834d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-controlled feature flags, including support for enabling or disabling JavaScript crash recovery.
  * Feature flags default to disabled and accept only valid Boolean values.
  * Added support for receiving feature flag settings from launch configuration.
* **Bug Fixes**
  * JavaScript error handling and web-content recovery now activate only when enabled.
* **Tests**
  * Added coverage for enabled, disabled, missing, invalid, and unknown feature flag values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->