### PR TITLE
Release 4.7.0

### DIFF
--- a/Sources/Helium/HeliumCore/BuildConstants.swift
+++ b/Sources/Helium/HeliumCore/BuildConstants.swift
@@ -8,5 +8,5 @@
  */
 public struct BuildConstants {
     /// Current SDK version
-    public static let version = "4.6.0"
+    public static let version = "4.7.0"
 }


### PR DESCRIPTION
Cuts the 4.7.0 release. The headline is render-failure recovery: paywall bundles that crash during render or lose their WebContent process are now detected and recovered to the fallback paywall, gated behind a server flag.

## Changes

**JS-crash detection and recovery** (#326)
- `window.onerror`/`unhandledrejection` hooks injected into paywall bundles report uncaught errors; a double blank-screen probe confirms nothing rendered before the existing load ladder swaps in the fallback bundle. `webViewWebContentProcessDidTerminate` is now handled (previously a permanent blank screen with no events). New internal observability: `paywall_js_error_detected`, `paywall_web_process_terminated`.

**Server-driven feature flags** (#332)
- The on-launch response's `featureFlags` map is now resolved (strict boolean coercion, everything off unless the server sends `true`). All new detection behavior — hook injection and the process-termination reload — sits behind `jsCrashFallback`, so this release ships with it dark until enabled per org; telemetry stays on regardless.

**Paywall previews** (#328, #331)
- Second-try paywall preview support and preview diagnostic trigger checks. (Preview server product details, #329, ships in the next release.)

**Paywall links** (#322, #324)
- Navigate-action links open in-app (SFSafariViewController) by default with observability on every open attempt; success/cancel redirect URLs may now be identical for Paddle/Stripe web checkout.

**Smaller changes** (#320, #321, #327)
- Triple-tap paywall navigation ignores scroll lock, softened default restore-dialog wording, haptics throttling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single version constant change with no runtime logic; standard release tagging step.
> 
> **Overview**
> Bumps the SDK release version in `BuildConstants.version` from **4.6.0** to **4.7.0**. That constant is the package/pod version source of truth and is what release automation uses to cut the **4.7.0** release (including render-failure recovery, feature flags, previews, and paywall-link behavior described for this release).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a9c2494e07aa7ba1b1d7de2dbccd2c3f0719bbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->