### PR TITLE
Change openPaywallLinksInApp default to false

### DIFF
--- a/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/WebViewMessageHandler.swift
@@ -170,8 +170,8 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
     }
     
     /// Opens a link from the paywall. A navigate-sourced link is shown in an in-app browser
-    /// presented over the paywall when `Helium.config.openPaywallLinksInApp` is enabled (the
-    /// default) and the URL is http/https; every other link opens externally.
+    /// presented over the paywall when `Helium.config.openPaywallLinksInApp` is enabled and the
+    /// URL is http/https; every other link opens externally.
     @MainActor
     func openPaywallLink(_ url: URL, source: PaywallLinkSource) {
         let scope = delegateWrapper?.observabilityScope

--- a/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
+++ b/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
@@ -242,8 +242,8 @@ enum PaywallLinkSource: String {
 
 /// A link in paywall content was handed off to an in-app browser
 /// (`SFSafariViewController`) or an external app — in-app when the source is navigate,
-/// `openPaywallLinksInApp` is enabled (the default), and the URL is a web URL; external
-/// otherwise (including non-web schemes like `mailto:` and `tel:`). The reported URL is
+/// `openPaywallLinksInApp` is enabled, and the URL is a web URL; external otherwise
+/// (including non-web schemes like `mailto:` and `tel:`). The reported URL is
 /// cut at its query/fragment, which can carry user data.
 struct PaywallLinkOpenAttempted: HeliumObservabilityEvent {
     let source: PaywallLinkSource

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -727,8 +727,8 @@ public class HeliumConfig {
     /// Links with other schemes (e.g. `mailto:`, `tel:`, custom app schemes) always open
     /// externally, as does direct HTML navigation in paywall content.
     ///
-    /// Defaults to `true`. Set to `false` to open navigate links in the external browser instead.
-    public var openPaywallLinksInApp: Bool = true
+    /// Defaults to `false`. Set to `true` to open navigate links in an in-app browser instead.
+    public var openPaywallLinksInApp: Bool = false
 
     // MARK: - External Web Checkout Configuration
 


### PR DESCRIPTION
`Helium.config.openPaywallLinksInApp` shipped defaulting to `true`, which silently changes link behavior for existing apps on upgrade. This flips the default back to `false`, so navigate links open in the external browser unless an app opts in.

Behavior when the flag is explicitly set is unchanged, as is the handling of non-web schemes (`mailto:`, `tel:`) and direct HTML anchor taps, which always open externally. Docstrings that described in-app as "the default" were updated to match.

This was never included in a released tag on iOS, so there is no user-visible behavior change here.

Testing: `xcodebuild -scheme helium-swift -destination 'generic/platform=iOS' build` succeeds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4c1699dc99b7c60027f7bf5dea6b87d7b02a1f57. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Paywall links now open externally by default.
  * In-app paywall link presentation requires explicitly enabling the relevant configuration option.
  * Only HTTP and HTTPS links can be presented in-app; other links continue to open externally.

* **Documentation**
  * Updated configuration and event documentation to clarify paywall link handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->