### PR TITLE
Bump version to 4.8.0

### DIFF
--- a/Sources/Helium/HeliumCore/BuildConstants.swift
+++ b/Sources/Helium/HeliumCore/BuildConstants.swift
@@ -8,5 +8,5 @@
  */
 public struct BuildConstants {
     /// Current SDK version
-    public static let version = "4.7.1"
+    public static let version = "4.8.0"
 }


### PR DESCRIPTION
Release 4.8.0.

Changes since 4.7.1:

- `openPaywallLinksInApp` now defaults to `false`. Navigate links in paywall
  content open in the external browser unless the integrator opts into the
  in-app browser. Links with non-web schemes (`mailto:`, `tel:`, custom app
  schemes) and direct HTML navigation are unaffected.
- The SDK's California ip_geo ZIP block is gated behind the new
  `caConsentModalEnabled` server feature flag. Off (the default) preserves the
  existing block; on lets the buyer reach the bundle's consent modal.
- Added ramp observability for the above: `californiaDetected`,
  `caConsentModalEnabled`, and `consentRequired` on
  `paddle_prefetch_outcome_finalized`, a `caBlocked` outcome kind, and
  `caBlockedCount` on `paddle_prefetch_await_resolved`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 82a89bc3717df62e6d638f07949088146efecfb3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->