### PR TITLE
Pass preview config and environment into the external checkout

### DIFF
--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
@@ -6,6 +6,9 @@ struct HeliumControlPanelResponse: Codable {
     let stripeProducts: [String: ServerProductPrice]?
     let paddleProducts: [String: ServerProductPrice]?
     let paddleClientToken: String?
+    /// Whether this device is not cleared for a real external checkout, so previews
+    /// should default to a simulated purchase. Optional: readers treat absent as true.
+    let forceExternalCheckoutSimulation: Bool?
 }
 
 struct HeliumPaywallPreviewEntry: Codable, Identifiable {

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
@@ -9,6 +9,9 @@ struct HeliumControlPanelResponse: Codable {
     /// Whether this device is not cleared for a real external checkout, so previews
     /// should default to a simulated purchase. Optional: readers treat absent as true.
     let forceExternalCheckoutSimulation: Bool?
+    /// A verified US-California device: real checkout is allowed, but showing the CA
+    /// consent modal is a hard precondition for a Paddle purchase. Absent reads false.
+    let forcePaddleCaConsentModal: Bool?
 }
 
 struct HeliumPaywallPreviewEntry: Codable, Identifiable {

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelService.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelService.swift
@@ -91,7 +91,20 @@ class HeliumControlPanelService {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.timeoutInterval = 15
 
-        let body: [String: Any] = ["apiKey": apiKey, "platform": "ios"]
+        await AppStoreCountryHelper.shared.fetchStoreCountryCode()
+        var locale: [String: Any] = [:]
+        if let currentCountry = Locale.current.regionCode {
+            locale["currentCountry"] = currentCountry
+        }
+        if let storeCountryCode = AppStoreCountryHelper.shared.getStoreCountryCode() {
+            locale["storeCountryCode"] = storeCountryCode
+        }
+
+        let body: [String: Any] = [
+            "apiKey": apiKey,
+            "platform": "ios",
+            "userContext": ["locale": locale],
+        ]
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
         let (data, response): (Data, URLResponse)

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
@@ -349,12 +349,13 @@ struct HeliumControlPanelView: View {
         do {
             let response = try await HeliumControlPanelService.shared.fetchPreviewPaywalls()
 
-            previewSettings.forceExternalCheckoutSimulation = response.forceExternalCheckoutSimulation ?? true
-
             // Fetch all products data
             await HeliumFetchedConfigManager.shared.buildLocalizedPriceMap(response.productIds)
 
             guard HeliumControlPanelService.shared.applyServerProducts(from: response) else { return }
+
+            previewSettings.forceExternalCheckoutSimulation = response.forceExternalCheckoutSimulation ?? true
+            previewSettings.forcePaddleCaConsentModal = response.forcePaddleCaConsentModal ?? false
 
             state = .loaded(response)
         } catch {

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
@@ -349,6 +349,8 @@ struct HeliumControlPanelView: View {
         do {
             let response = try await HeliumControlPanelService.shared.fetchPreviewPaywalls()
 
+            previewSettings.forceExternalCheckoutSimulation = response.forceExternalCheckoutSimulation ?? true
+
             // Fetch all products data
             await HeliumFetchedConfigManager.shared.buildLocalizedPriceMap(response.productIds)
 

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumPreviewConfigurationModels.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumPreviewConfigurationModels.swift
@@ -53,7 +53,16 @@ final class HeliumPreviewConfigurationStore: ObservableObject {
     /// unparsed signal keeps previews on the simulated path.
     @Published var forceExternalCheckoutSimulation = true
 
-    @Published var showCaliforniaConsentModal = false
+    /// California eligibility from `/preview-paywalls`: the device may purchase for
+    /// real, but only through the consent modal, so the toggle is forced on.
+    @Published var forcePaddleCaConsentModal = false
+
+    @Published private var chosenShowCaliforniaConsentModal = false
+
+    var showCaliforniaConsentModal: Bool {
+        get { forcePaddleCaConsentModal || chosenShowCaliforniaConsentModal }
+        set { chosenShowCaliforniaConsentModal = newValue }
+    }
 
     @Published private var chosenPurchaseMode: HeliumPreviewPurchaseMode?
 

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumPreviewConfigurationView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumPreviewConfigurationView.swift
@@ -190,7 +190,7 @@ struct HeliumPreviewConfigurationView: View {
                 .toggleStyle(SwitchToggleStyle(tint: .blue))
                 .disabled(store.forcePaddleCaConsentModal)
                 if store.forcePaddleCaConsentModal {
-                    Label("Your device is in California, so the consent modal always shows.", systemImage: "lock.fill")
+                    Label("Paddle checkouts only. Your device is in California, so the consent modal always shows.", systemImage: "lock.fill")
                         .font(.caption)
                         .foregroundColor(.secondary)
                         .fixedSize(horizontal: false, vertical: true)

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumPreviewConfigurationView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumPreviewConfigurationView.swift
@@ -188,6 +188,7 @@ struct HeliumPreviewConfigurationView: View {
                         .foregroundColor(.primary)
                 }
                 .toggleStyle(SwitchToggleStyle(tint: .blue))
+                .disabled(store.forcePaddleCaConsentModal)
                 Text("Paddle checkouts only. Real purchases from California always show the modal.")
                     .font(.caption)
                     .foregroundColor(.secondary)

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumPreviewConfigurationView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumPreviewConfigurationView.swift
@@ -189,10 +189,17 @@ struct HeliumPreviewConfigurationView: View {
                 }
                 .toggleStyle(SwitchToggleStyle(tint: .blue))
                 .disabled(store.forcePaddleCaConsentModal)
-                Text("Paddle checkouts only. Real purchases from California always show the modal.")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                if store.forcePaddleCaConsentModal {
+                    Label("Your device is in California, so the consent modal always shows.", systemImage: "lock.fill")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                } else {
+                    Text("Paddle checkouts only. Real purchases from California always show the modal.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 10)

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -315,12 +315,13 @@ public class ExternalWebCheckoutManager: NSObject {
 
         ctx["iosBundleId"] = Bundle.main.bundleIdentifier ?? "unknown"
 
-        let isPreviewRun = HeliumFetchedConfigManager.isPreviewTrigger(triggerName)
-        ctx["environment"] = isPreviewRun ? "preview" : "production"
+        ctx["environment"] = AppReceiptsHelper.shared.environment.rawValue.uppercased()
+        ctx["trigger"] = triggerName
 
+        let isPreviewRun = HeliumFetchedConfigManager.isPreviewTrigger(triggerName)
         let previewConfiguration = isPreviewRun ? HeliumPreviewConfigurationStore.shared.configuration : nil
         if let previewConfiguration {
-            ctx["simulatePurchase"] = previewConfiguration.purchaseMode == .simulated
+            ctx["forceSimulatedFlow"] = previewConfiguration.purchaseMode == .simulated
         }
 
         let baseBody = try HeliumPaymentAPIClient.shared.baseRequestBody(provider: provider)

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -315,6 +315,14 @@ public class ExternalWebCheckoutManager: NSObject {
 
         ctx["iosBundleId"] = Bundle.main.bundleIdentifier ?? "unknown"
 
+        let isPreviewRun = HeliumFetchedConfigManager.isPreviewTrigger(triggerName)
+        ctx["environment"] = isPreviewRun ? "preview" : "production"
+
+        let previewConfiguration = isPreviewRun ? HeliumPreviewConfigurationStore.shared.configuration : nil
+        if let previewConfiguration {
+            ctx["simulatePurchase"] = previewConfiguration.purchaseMode == .simulated
+        }
+
         let baseBody = try HeliumPaymentAPIClient.shared.baseRequestBody(provider: provider)
         for (key, value) in baseBody where key != "apiKey" {
             if let stringValue = value as? String {
@@ -339,6 +347,11 @@ public class ExternalWebCheckoutManager: NSObject {
         if !queryItems.contains(where: { $0.name == "helium_ios_bundle_id" }) {
             let bundleId = Bundle.main.bundleIdentifier ?? "unknown"
             queryItems.append(URLQueryItem(name: "helium_ios_bundle_id", value: bundleId))
+        }
+        if let previewConfiguration,
+           previewConfiguration.showCaliforniaConsentModal,
+           provider.kind == .paddle {
+            queryItems.append(URLQueryItem(name: "helium_force_california", value: "true"))
         }
         // Cache-bust per open: a fragment-only change doesn't reload the page,
         // so if the bundle is already open from a prior tap it would render

--- a/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/PaddleCheckoutPrefetchCoordinator.swift
@@ -110,6 +110,7 @@ final class PaddleCheckoutPrefetchCoordinator {
     ) {
         let sessionId = paywallSession.sessionId
         let scope = paywallSession.observabilityScope
+        let isPreviewRun = HeliumFetchedConfigManager.isPreviewTrigger(paywallSession.trigger)
         var startedPriceIds: [String] = []
         for priceId in priceIds {
             let key = CacheKey(sessionId: sessionId, priceId: priceId)
@@ -125,6 +126,7 @@ final class PaddleCheckoutPrefetchCoordinator {
                     discountId: discountId,
                     paddleClientToken: paddleClientToken,
                     iosBundleId: iosBundleId,
+                    isPreviewRun: isPreviewRun,
                     banditClient: bandit,
                     bffClient: bff,
                     scope: scope
@@ -457,6 +459,7 @@ final class PaddleCheckoutPrefetchCoordinator {
         discountId: String?,
         paddleClientToken: String,
         iosBundleId: String?,
+        isPreviewRun: Bool,
         banditClient: HeliumPaymentAPIClient,
         bffClient: PaddleBFFClient,
         scope: PaywallObservabilityScope
@@ -493,7 +496,8 @@ final class PaddleCheckoutPrefetchCoordinator {
             )
             // While the consent modal is disabled, block California buyers by ip_geo
             // ZIP before checkout. When the flag is on, they proceed to the modal.
-            if !caModalEnabled,
+            // Previews always proceed so testers can exercise the modal and checkout.
+            if !caModalEnabled, !isPreviewRun,
                let caPostal = Self.californiaPostalCode(in: paddleResult.rawBody) {
                 trackBffCompletion(priceId: priceId, transactionId: banditResponse.transactionId, scope: scope, startedAt: bffStart, chainStartedAt: chainStart, result: .caBlocked(rawBody: paddleResult.rawBody), caConsentModalEnabled: caModalEnabled)
                 return .failed(error: PaddleCaliforniaBlocked(postalCode: caPostal))

--- a/Tests/helium-swiftTests/PreviewServerProductsTests.swift
+++ b/Tests/helium-swiftTests/PreviewServerProductsTests.swift
@@ -189,7 +189,8 @@ final class PreviewServerProductsTests: XCTestCase {
             paywalls: [],
             stripeProducts: stripe,
             paddleProducts: nil,
-            paddleClientToken: paddleClientToken
+            paddleClientToken: paddleClientToken,
+            forceExternalCheckoutSimulation: nil
         )
     }
 

--- a/Tests/helium-swiftTests/PreviewServerProductsTests.swift
+++ b/Tests/helium-swiftTests/PreviewServerProductsTests.swift
@@ -190,7 +190,8 @@ final class PreviewServerProductsTests: XCTestCase {
             stripeProducts: stripe,
             paddleProducts: nil,
             paddleClientToken: paddleClientToken,
-            forceExternalCheckoutSimulation: nil
+            forceExternalCheckoutSimulation: nil,
+            forcePaddleCaConsentModal: nil
         )
     }
 

--- a/Tests/helium-swiftTests/WebCheckoutPreviewConfigTests.swift
+++ b/Tests/helium-swiftTests/WebCheckoutPreviewConfigTests.swift
@@ -1,0 +1,190 @@
+import XCTest
+import Compression
+@testable import Helium
+
+final class WebCheckoutPreviewConfigTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        Helium.lastApiKeyUsed = "test_api_key_preview_config"
+        resetStore()
+    }
+
+    override func tearDown() {
+        Helium.lastApiKeyUsed = nil
+        resetStore()
+        super.tearDown()
+    }
+
+    private func resetStore() {
+        let store = HeliumPreviewConfigurationStore.shared
+        store.forceExternalCheckoutSimulation = true
+        store.showCaliforniaConsentModal = false
+        store.configureBeforeEachPreview = false
+        store.purchaseMode = .simulated
+    }
+
+    private func buildURL(
+        provider: PaymentProviderConfig,
+        triggerName: String,
+        baseURL: URL = URL(string: "https://bundles-staging.clickthrough.to/o/p/bundle.html")!
+    ) throws -> URL {
+        let manager = ExternalWebCheckoutManager(
+            provider: provider,
+            entitlementsSource: HeliumPaymentEntitlementsSource(provider: provider)
+        )
+        let templateEvent = PurchaseSucceededEvent(
+            productId: "", triggerName: triggerName, paywallName: "P",
+            storeKitTransactionId: nil, storeKitOriginalTransactionId: nil,
+            paymentProcessor: provider.kind
+        )
+        let analyticsEvent = HeliumAnalyticsManager.shared.buildLoggedEvent(
+            for: templateEvent,
+            paywallSession: PaywallSession(trigger: triggerName, paywallInfo: nil, fallbackType: .notFallback, presentationContext: .empty)
+        )
+        return try manager.buildEnrichedCheckoutURL(
+            baseURL: baseURL, analyticsEvent: analyticsEvent,
+            productKey: "pro_x:pri_y", triggerName: triggerName,
+            successURL: "myapp://ok", cancelURL: "myapp://cancel",
+            introOfferEligible: true, paddleBootstraps: nil
+        )
+    }
+
+    private func decodedCtx(from url: URL) throws -> [String: Any] {
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let fragment = try XCTUnwrap(components.fragment)
+        XCTAssertTrue(fragment.hasPrefix("ctx="))
+        let compressed = try XCTUnwrap(base64URLDecode(String(fragment.dropFirst("ctx=".count))))
+        let decompressed = try decompressWithAppleZlib(compressed, originalSize: 16384)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: decompressed) as? [String: Any])
+    }
+
+    private func queryNames(of url: URL) throws -> [String] {
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        return (components.queryItems ?? []).map { $0.name }
+    }
+
+    // MARK: - Environment
+
+    func testProductionTrigger_setsProductionEnvironmentAndNoPreviewFields() throws {
+        let url = try buildURL(provider: .paddle, triggerName: "onboarding")
+        let ctx = try decodedCtx(from: url)
+
+        XCTAssertEqual(ctx["environment"] as? String, "production")
+        XCTAssertNil(ctx["simulatePurchase"])
+        XCTAssertFalse(try queryNames(of: url).contains("helium_force_california"))
+    }
+
+    func testPreviewTrigger_setsPreviewEnvironment() throws {
+        let url = try buildURL(provider: .paddle, triggerName: HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER)
+        let ctx = try decodedCtx(from: url)
+
+        XCTAssertEqual(ctx["environment"] as? String, "preview")
+    }
+
+    // MARK: - Purchase simulation
+
+    func testPreviewTrigger_simulatedModeSetsSimulatePurchaseTrue() throws {
+        let url = try buildURL(provider: .paddle, triggerName: HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER)
+        let ctx = try decodedCtx(from: url)
+
+        XCTAssertEqual(ctx["simulatePurchase"] as? Bool, true)
+    }
+
+    func testPreviewTrigger_realModeSetsSimulatePurchaseFalse() throws {
+        let store = HeliumPreviewConfigurationStore.shared
+        store.forceExternalCheckoutSimulation = false
+        store.purchaseMode = .real
+
+        let url = try buildURL(provider: .paddle, triggerName: HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER)
+        let ctx = try decodedCtx(from: url)
+
+        XCTAssertEqual(ctx["simulatePurchase"] as? Bool, false)
+    }
+
+    func testForceExternalCheckoutSimulation_overridesRealSelection() throws {
+        let store = HeliumPreviewConfigurationStore.shared
+        store.purchaseMode = .real
+        store.forceExternalCheckoutSimulation = true
+
+        let url = try buildURL(provider: .paddle, triggerName: HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER)
+        let ctx = try decodedCtx(from: url)
+
+        XCTAssertEqual(ctx["simulatePurchase"] as? Bool, true)
+    }
+
+    // MARK: - California force flag
+
+    func testPreviewTrigger_paddleWithCaToggleAppendsForceCaliforniaParam() throws {
+        HeliumPreviewConfigurationStore.shared.showCaliforniaConsentModal = true
+
+        let url = try buildURL(provider: .paddle, triggerName: HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER)
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let item = try XCTUnwrap((components.queryItems ?? []).first { $0.name == "helium_force_california" })
+
+        XCTAssertEqual(item.value, "true")
+    }
+
+    func testPreviewTrigger_stripeWithCaToggleDoesNotAppendParam() throws {
+        HeliumPreviewConfigurationStore.shared.showCaliforniaConsentModal = true
+
+        let url = try buildURL(provider: .stripe, triggerName: HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER)
+
+        XCTAssertFalse(try queryNames(of: url).contains("helium_force_california"))
+    }
+
+    func testPreviewTrigger_caToggleOffLeavesQueryUnchanged() throws {
+        let url = try buildURL(provider: .paddle, triggerName: HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER)
+
+        XCTAssertFalse(try queryNames(of: url).contains("helium_force_california"))
+    }
+
+    // MARK: - Response decoding
+
+    func testDecodesForceExternalCheckoutSimulation() throws {
+        let json = """
+        {"productIds": [], "paywalls": [], "forceExternalCheckoutSimulation": false}
+        """
+        let response = try JSONDecoder().decode(HeliumControlPanelResponse.self, from: Data(json.utf8))
+
+        XCTAssertEqual(response.forceExternalCheckoutSimulation, false)
+    }
+
+    func testMissingForceExternalCheckoutSimulationDecodesAsNil() throws {
+        let json = """
+        {"productIds": [], "paywalls": []}
+        """
+        let response = try JSONDecoder().decode(HeliumControlPanelResponse.self, from: Data(json.utf8))
+
+        XCTAssertNil(response.forceExternalCheckoutSimulation)
+    }
+
+    // MARK: - Helpers
+
+    private func base64URLDecode(_ encoded: String) -> Data? {
+        var s = encoded.replacingOccurrences(of: "-", with: "+")
+                       .replacingOccurrences(of: "_", with: "/")
+        let padNeeded = (4 - (s.count % 4)) % 4
+        s += String(repeating: "=", count: padNeeded)
+        return Data(base64Encoded: s)
+    }
+
+    private func decompressWithAppleZlib(_ data: Data, originalSize: Int) throws -> Data {
+        let capacity = max(originalSize, 64) * 2 + 64
+        var dst = [UInt8](repeating: 0, count: capacity)
+        let decoded = data.withUnsafeBytes { (srcPtr: UnsafeRawBufferPointer) -> Int in
+            guard let baseAddr = srcPtr.baseAddress else { return 0 }
+            return compression_decode_buffer(
+                &dst, capacity,
+                baseAddr.assumingMemoryBound(to: UInt8.self), data.count,
+                nil,
+                COMPRESSION_ZLIB
+            )
+        }
+        guard decoded > 0 || originalSize == 0 else {
+            throw NSError(domain: "WebCheckoutPreviewConfigTests", code: 0,
+                          userInfo: [NSLocalizedDescriptionKey: "Apple's compression_decode_buffer failed to decode (returned \(decoded))"])
+        }
+        return Data(dst.prefix(decoded))
+    }
+}

--- a/Tests/helium-swiftTests/WebCheckoutPreviewConfigTests.swift
+++ b/Tests/helium-swiftTests/WebCheckoutPreviewConfigTests.swift
@@ -64,34 +64,38 @@ final class WebCheckoutPreviewConfigTests: XCTestCase {
         return (components.queryItems ?? []).map { $0.name }
     }
 
-    // MARK: - Environment
+    // MARK: - Environment and trigger
 
-    func testProductionTrigger_setsProductionEnvironmentAndNoPreviewFields() throws {
+    func testProductionTrigger_setsEnvironmentAndTriggerAndNoPreviewFields() throws {
         let url = try buildURL(provider: .paddle, triggerName: "onboarding")
         let ctx = try decodedCtx(from: url)
 
-        XCTAssertEqual(ctx["environment"] as? String, "production")
-        XCTAssertNil(ctx["simulatePurchase"])
+        XCTAssertEqual(
+            ctx["environment"] as? String,
+            AppReceiptsHelper.shared.environment.rawValue.uppercased()
+        )
+        XCTAssertEqual(ctx["trigger"] as? String, "onboarding")
+        XCTAssertNil(ctx["forceSimulatedFlow"])
         XCTAssertFalse(try queryNames(of: url).contains("helium_force_california"))
     }
 
-    func testPreviewTrigger_setsPreviewEnvironment() throws {
+    func testPreviewTrigger_setsTriggerInCtx() throws {
         let url = try buildURL(provider: .paddle, triggerName: HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER)
         let ctx = try decodedCtx(from: url)
 
-        XCTAssertEqual(ctx["environment"] as? String, "preview")
+        XCTAssertEqual(ctx["trigger"] as? String, HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER)
     }
 
     // MARK: - Purchase simulation
 
-    func testPreviewTrigger_simulatedModeSetsSimulatePurchaseTrue() throws {
+    func testPreviewTrigger_simulatedModeSetsForceSimulatedFlowTrue() throws {
         let url = try buildURL(provider: .paddle, triggerName: HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER)
         let ctx = try decodedCtx(from: url)
 
-        XCTAssertEqual(ctx["simulatePurchase"] as? Bool, true)
+        XCTAssertEqual(ctx["forceSimulatedFlow"] as? Bool, true)
     }
 
-    func testPreviewTrigger_realModeSetsSimulatePurchaseFalse() throws {
+    func testPreviewTrigger_realModeSetsForceSimulatedFlowFalse() throws {
         let store = HeliumPreviewConfigurationStore.shared
         store.forceExternalCheckoutSimulation = false
         store.purchaseMode = .real
@@ -99,7 +103,7 @@ final class WebCheckoutPreviewConfigTests: XCTestCase {
         let url = try buildURL(provider: .paddle, triggerName: HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER)
         let ctx = try decodedCtx(from: url)
 
-        XCTAssertEqual(ctx["simulatePurchase"] as? Bool, false)
+        XCTAssertEqual(ctx["forceSimulatedFlow"] as? Bool, false)
     }
 
     func testForceExternalCheckoutSimulation_overridesRealSelection() throws {
@@ -110,7 +114,7 @@ final class WebCheckoutPreviewConfigTests: XCTestCase {
         let url = try buildURL(provider: .paddle, triggerName: HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER)
         let ctx = try decodedCtx(from: url)
 
-        XCTAssertEqual(ctx["simulatePurchase"] as? Bool, true)
+        XCTAssertEqual(ctx["forceSimulatedFlow"] as? Bool, true)
     }
 
     // MARK: - California force flag

--- a/Tests/helium-swiftTests/WebCheckoutPreviewConfigTests.swift
+++ b/Tests/helium-swiftTests/WebCheckoutPreviewConfigTests.swift
@@ -19,6 +19,7 @@ final class WebCheckoutPreviewConfigTests: XCTestCase {
     private func resetStore() {
         let store = HeliumPreviewConfigurationStore.shared
         store.forceExternalCheckoutSimulation = true
+        store.forcePaddleCaConsentModal = false
         store.showCaliforniaConsentModal = false
         store.configureBeforeEachPreview = false
         store.purchaseMode = .simulated
@@ -143,6 +144,16 @@ final class WebCheckoutPreviewConfigTests: XCTestCase {
         XCTAssertFalse(try queryNames(of: url).contains("helium_force_california"))
     }
 
+    func testForcedCaConsentModal_appendsParamEvenWithToggleOff() throws {
+        let store = HeliumPreviewConfigurationStore.shared
+        store.showCaliforniaConsentModal = false
+        store.forcePaddleCaConsentModal = true
+
+        let url = try buildURL(provider: .paddle, triggerName: HeliumFetchedConfigManager.HELIUM_PREVIEW_TRIGGER)
+
+        XCTAssertTrue(try queryNames(of: url).contains("helium_force_california"))
+    }
+
     // MARK: - Response decoding
 
     func testDecodesForceExternalCheckoutSimulation() throws {
@@ -161,6 +172,16 @@ final class WebCheckoutPreviewConfigTests: XCTestCase {
         let response = try JSONDecoder().decode(HeliumControlPanelResponse.self, from: Data(json.utf8))
 
         XCTAssertNil(response.forceExternalCheckoutSimulation)
+        XCTAssertNil(response.forcePaddleCaConsentModal)
+    }
+
+    func testDecodesForcePaddleCaConsentModal() throws {
+        let json = """
+        {"productIds": [], "paywalls": [], "forcePaddleCaConsentModal": true}
+        """
+        let response = try JSONDecoder().decode(HeliumControlPanelResponse.self, from: Data(json.utf8))
+
+        XCTAssertEqual(response.forcePaddleCaConsentModal, true)
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
Stacked on the preview-settings branch — this diff is only the checkout wiring. GitHub will retarget once that PR merges.

- Parses top-level `forceExternalCheckoutSimulation` from `/preview-paywalls` (absent → true) to seed and lock the purchase-flow selection, and sends `userContext.locale.{currentCountry, storeCountryCode}` on the request so the server can evaluate the same signals on-launch uses.
- ctx now always carries `environment` (the app-receipt environment, verbatim: DEBUG / SANDBOX / PRODUCTION) and the `trigger` name; preview runs add `forceSimulatedFlow` from the selection. Field names match the bundler contract in cloudcaptainai/bundler-service#126.
- A Paddle preview with the CA toggle on appends `helium_force_california=true` to the checkout URL (the bundle gates on the param's presence); toggle off leaves the URL byte-identical.

The bundle acts on these once bundler-service#125/#126 deploy; unknown ctx fields pass through harmlessly today.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkout ctx/query for all external opens (not only previews) and touches California compliance paths in Paddle prefetch and preview URL building.
> 
> **Overview**
> Extends **control-panel preview paywalls** so the server can drive eligibility: `/preview-paywalls` responses decode **`forceExternalCheckoutSimulation`** (missing → simulated) and **`forcePaddleCaConsentModal`**, and the fetch POST now includes **`userContext.locale`** with device region and App Store country. Those flags seed **`HeliumPreviewConfigurationStore`**, including locking the California consent toggle when the server marks a CA device.
> 
> **External web checkout** always embeds **`environment`** (receipt environment) and **`trigger`** in compressed ctx. Preview runs also set **`forceSimulatedFlow`** from the tester’s purchase mode, and Paddle previews with CA consent enabled append **`helium_force_california=true`** on the URL. **Paddle prefetch** skips the California IP block when the run is a preview so testers can exercise consent and checkout.
> 
> Adds **`WebCheckoutPreviewConfigTests`** and updates response fixtures for the new model fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9398d1a6472cfad71529e95a2e86dac9f540616d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->