### PR TITLE
send appEnvironment with observability events

### DIFF
--- a/Sources/Helium/HeliumCore/HeliumAnalyticsMapper.swift
+++ b/Sources/Helium/HeliumCore/HeliumAnalyticsMapper.swift
@@ -225,6 +225,7 @@ extension PurchaseRestoredEvent {
     public func analyticsPayload() -> [String: Any] {
         var payload = productAnalyticsPayload()
         payload["restoreOrigin"] = restoreOrigin.rawValue
+        payload["paymentProcessor"] = paymentProcessor.rawValue
         return payload
     }
 }
@@ -253,7 +254,9 @@ extension PurchasePendingEvent {
     public var analyticsEventName: String { "subscriptionPending" }
 
     public func analyticsPayload() -> [String: Any] {
-        productAnalyticsPayload()
+        var payload = productAnalyticsPayload()
+        payload["paymentProcessor"] = paymentProcessor.rawValue
+        return payload
     }
 }
 

--- a/Sources/Helium/HeliumCore/Observability/HeliumObservabilityManager.swift
+++ b/Sources/Helium/HeliumCore/Observability/HeliumObservabilityManager.swift
@@ -78,6 +78,7 @@ class HeliumObservabilityManager {
         }
         p["platform"] = "ios"
         p["osVersion"] = UIDevice.current.systemVersion
+        p["appEnvironment"] = AppReceiptsHelper.shared.getEnvironment().uppercased()
         p["timestamp"] = formatAsTimestamp(date: Date())
         return p
     }

--- a/Tests/helium-swiftTests/AnalyticsPayloadMappingTests.swift
+++ b/Tests/helium-swiftTests/AnalyticsPayloadMappingTests.swift
@@ -313,11 +313,10 @@ final class AnalyticsPayloadMappingTests: XCTestCase {
     }
 
     func testPurchaseRestoredPayload() throws {
-        // The subscriptionRestored wire format does not carry paymentProcessor.
         try assertWirePayload(
             PurchaseRestoredEvent(
                 productId: "com.test.product", triggerName: "onboarding", paywallName: "spring_sale",
-                restoreOrigin: .restorePurchases, paymentProcessor: .appStore
+                restoreOrigin: .restorePurchases, paymentProcessor: .paddle
             ),
             equals: [
                 "type": "subscriptionRestored",
@@ -325,6 +324,7 @@ final class AnalyticsPayloadMappingTests: XCTestCase {
                 "triggerName": "onboarding",
                 "paywallTemplateName": "spring_sale",
                 "restoreOrigin": "restorePurchases",
+                "paymentProcessor": "paddle",
             ]
         )
     }
@@ -371,7 +371,6 @@ final class AnalyticsPayloadMappingTests: XCTestCase {
     }
 
     func testPurchasePendingPayload() throws {
-        // The subscriptionPending wire format does not carry paymentProcessor.
         try assertWirePayload(
             PurchasePendingEvent(productId: "com.test.product", triggerName: "onboarding", paywallName: "spring_sale", paymentProcessor: .appStore),
             equals: [
@@ -379,6 +378,7 @@ final class AnalyticsPayloadMappingTests: XCTestCase {
                 "productKey": "com.test.product",
                 "triggerName": "onboarding",
                 "paywallTemplateName": "spring_sale",
+                "paymentProcessor": "appStore",
             ]
         )
     }


### PR DESCRIPTION
Send appEnvironment with observability events. This is a gap I missed with the original implementation. (https://github.com/cloudcaptainai/helium-jitsu-functions/pull/8/changes#diff-d647bced09c5951b8228c47682ed9d7ff0cfc2bd45f69c00b1a51378b0df652f looks for `appEnvironment`)

Also adding payment processor to pending and restore events, which we set property for but have never actually emitted to analytics pipeline.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive analytics and observability fields only; no auth or purchase-flow logic changes, though backend consumers must tolerate the new keys.
> 
> **Overview**
> Observability events now include **`appEnvironment`** (uppercased App Store receipt environment from `AppReceiptsHelper`) on every enriched track, aligning the iOS SDK with downstream pipelines that already expect this field.
> 
> **Analytics wire format** updates: **`subscriptionRestored`** and **`subscriptionPending`** payloads now emit **`paymentProcessor`**, matching other purchase events where the property was already modeled but omitted from the mapper. Golden tests in `AnalyticsPayloadMappingTests` were updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbd8808dd70ff44dd2d47cd4d9695738573cd803. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Analytics

* Purchase restoration and pending transaction events now include the payment processor, improving reporting across payment platforms.
* Receipt environment information is now reported in a consistent uppercase format for clearer analytics and monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->