### PR TITLE
[HEL-6745] | Recognize web paywall previews when the server omits isWeb

### DIFF
--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
@@ -17,7 +17,20 @@ struct HeliumPaywallPreviewEntry: Codable, Identifiable {
     var id: String { paywallUuid }
 
     /// Web paywalls render in a browser, not in-app; previews open them there.
-    var isWebPaywall: Bool { isWeb == true }
+    var isWebPaywall: Bool {
+        if let isWeb { return isWeb }
+        return versions.contains { version in
+            guard let bundleUrl = version.bundleUrl, let host = URL(string: bundleUrl)?.host else {
+                return false
+            }
+            return Self.webPaywallBundleHosts.contains(host)
+        }
+    }
+
+    private static let webPaywallBundleHosts: Set<String> = [
+        "bundles.clickthrough.to",
+        "bundles-staging.clickthrough.to",
+    ]
 }
 
 /// The resolved second try paywall served with a preview entry. Paywall-level, not per-version:

--- a/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
+++ b/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
@@ -426,6 +426,7 @@ final class PreviewTriggerConfigTests: XCTestCase {
         XCTAssertEqual(versions[0].shouldEnableScroll, false)
         XCTAssertNil(versions[1].webPaywallBundleUrl)
         XCTAssertNil(versions[1].shouldEnableScroll)
+        XCTAssertFalse(response.paywalls[0].isWebPaywall)
     }
 
     func testDecodesLegacyPreviewsResponseWithoutNewFields() throws {
@@ -556,5 +557,73 @@ final class PreviewTriggerConfigTests: XCTestCase {
             "https://bundles-staging.clickthrough.to/x/bundle_1778610753360.html"
         )
         XCTAssertFalse(response.paywalls[1].isWebPaywall)
+    }
+
+    func testRecognizesWebPaywallByBundleHostWhenIsWebIsMissing() throws {
+        let json = """
+        {
+          "productIds": [],
+          "paywalls": [
+            {
+              "paywallUuid": "0b7f5c1a-1111-4222-8333-444455556666",
+              "paywallName": "Web Checkout Paywall",
+              "versions": [
+                {
+                  "versionId": "9d8c7b6a-aaaa-4bbb-8ccc-dddeeefff000",
+                  "versionStatus": "published",
+                  "versionNumber": 3,
+                  "bundleUrl": "https://bundles.clickthrough.to/x/bundle_1778610753360.html",
+                  "previewUrl": null,
+                  "productIds": [],
+                  "stripeProductIds": [],
+                  "paddleProductIds": ["pro_web:pri_web"],
+                  "lastSavedAt": null
+                }
+              ]
+            },
+            {
+              "paywallUuid": "1c8d6e2b-7777-4888-9999-000011112222",
+              "paywallName": "Native Paywall",
+              "versions": [
+                {
+                  "versionId": "32a1d295-60e1-425a-a4f7-c566e31a9f9c",
+                  "versionStatus": "published",
+                  "versionNumber": 1,
+                  "bundleUrl": "https://bundles.heliumpaywall.com/x/bundle_1.html",
+                  "previewUrl": null,
+                  "productIds": ["yearly_2999"],
+                  "stripeProductIds": [],
+                  "lastSavedAt": null
+                }
+              ]
+            },
+            {
+              "paywallUuid": "2d9e7f3c-8888-4999-aaaa-bbbbccccdddd",
+              "paywallName": "Server Says Native",
+              "isWeb": false,
+              "versions": [
+                {
+                  "versionId": "43b2e3a6-71f2-4b36-b5c8-d77f42c0a1b2",
+                  "versionStatus": "published",
+                  "versionNumber": 2,
+                  "bundleUrl": "https://bundles.clickthrough.to/x/bundle_2.html",
+                  "previewUrl": null,
+                  "productIds": [],
+                  "stripeProductIds": [],
+                  "lastSavedAt": null
+                }
+              ]
+            }
+          ]
+        }
+        """
+        let response = try JSONDecoder().decode(
+            HeliumControlPanelResponse.self,
+            from: Data(json.utf8)
+        )
+
+        XCTAssertTrue(response.paywalls[0].isWebPaywall)
+        XCTAssertFalse(response.paywalls[1].isWebPaywall)
+        XCTAssertFalse(response.paywalls[2].isWebPaywall)
     }
 }


### PR DESCRIPTION
## What

Web paywalls in the triple-tap previews list open in the browser again — badge, confirmation dialog, external browser — even when the `/paywall-previews` response has no `isWeb` field. Previously those entries were treated as native and their web bundle rendered in-app.

## Why (root cause)

The browser-open flow keys entirely on the response's optional `isWeb` flag, and the endpoint doesn't send that field, so every web paywall decoded as native and took the in-app preview path.

## Fix

`isWebPaywall` still trusts an explicit `isWeb` when present. When the field is missing, an entry is recognized as web when any version's `bundleUrl` is hosted on the web paywall bundle origins (`bundles.clickthrough.to` / `bundles-staging.clickthrough.to`), the same origins the web checkout flow already uses. Detection keys on the version's own `bundleUrl` only, so a native paywall linking a web paywall via `webPaywallBundleUrl` stays native.

## Tests

- `testRecognizesWebPaywallByBundleHostWhenIsWebIsMissing`: web host without `isWeb` → web; native host → native; explicit `isWeb: false` overrides the host signal.
- `isWebPaywall` assertion added to the app2web fixture test.
- `PreviewTriggerConfigTests`: 26/26 pass (iPhone 17 Pro simulator).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized control-panel preview routing with explicit server override and host allowlist; covered by decoding tests.
> 
> **Overview**
> **Web paywall detection in the triple-tap preview list** no longer depends solely on the optional `isWeb` field from `/paywall-previews`. When `isWeb` is absent, `HeliumPaywallPreviewEntry.isWebPaywall` treats an entry as web if any version’s **`bundleUrl`** host is `bundles.clickthrough.to` or `bundles-staging.clickthrough.to`; an explicit `isWeb` (including `false`) still wins. That restores the browser preview path (badge, confirmation, external open) for web checkout paywalls the API doesn’t flag, without classifying native paywalls that only reference web bundles via `webPaywallBundleUrl`.
> 
> Tests add **`testRecognizesWebPaywallByBundleHostWhenIsWebIsMissing`** and assert a native app2web fixture stays non-web when only `webPaywallBundleUrl` points at clickthrough hosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a29dc728419fa613dce09aad4a869a82156d60e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved web paywall detection when explicit web status is unavailable by recognizing supported bundle URLs.
  - Explicitly marked non-web paywalls continue to take precedence over URL-based detection.
  - Corrected classification for paywalls with bundle URLs that do not indicate a web paywall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->