### PR TITLE
Gate app2web previews on checkout bundle freshness

### DIFF
--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
@@ -369,6 +369,12 @@ struct HeliumControlPanelView: View {
     /// screen first only when the tester has turned that step on.
     private func configurePreview(for version: HeliumPaywallPreviewVersion, paywall: HeliumPaywallPreviewEntry) {
         guard activity == .idle else { return }
+        // Withhold the entire preview (not just the purchase step) when the checkout bundle is
+        // too old to honor the simulated flag; re-saving the paywall rebuilds it.
+        if version.isApp2webCapable && !version.isApp2webBundleFresh {
+            paywallLoadError = "You can't preview this paywall yet — re-save it in your Helium dashboard, then reload."
+            return
+        }
         if version.isApp2webCapable && previewSettings.configureBeforeEachPreview {
             pendingConfiguration = HeliumPreviewConfigurationRequest(target: .version(version, paywall: paywall))
         } else {

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
@@ -67,7 +67,7 @@ struct HeliumControlPanelView: View {
                 }
             }
         }
-        .alert("Error", isPresented: Binding(
+        .alert("Preview Could Not Open", isPresented: Binding(
             get: { paywallLoadError != nil },
             set: { if !$0 { paywallLoadError = nil } }
         )) {
@@ -369,10 +369,8 @@ struct HeliumControlPanelView: View {
     /// screen first only when the tester has turned that step on.
     private func configurePreview(for version: HeliumPaywallPreviewVersion, paywall: HeliumPaywallPreviewEntry) {
         guard activity == .idle else { return }
-        // Withhold the entire preview (not just the purchase step) when the checkout bundle is
-        // too old to honor the simulated flag; re-saving the paywall rebuilds it.
         if version.isApp2webCapable && !version.isApp2webBundleFresh {
-            paywallLoadError = "You can't preview this paywall yet — re-save it in your Helium dashboard, then reload."
+            paywallLoadError = "Your paywall needs an update. Re-save it in your Helium dashboard, then reload."
             return
         }
         if version.isApp2webCapable && previewSettings.configureBeforeEachPreview {

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumPreviewConfigurationModels.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumPreviewConfigurationModels.swift
@@ -136,6 +136,13 @@ struct HeliumPreviewConfigurationRequest: Identifiable {
     }
 }
 
+/// App2web checkout bundles built before the simulated-purchase flow ignore the simulated flag
+/// and would charge a real card in a preview, so previews are gated on the bundle's build time
+/// (stamped in its filename) being at or after this cutoff, in epoch ms.
+enum HeliumPreviewBundleFreshness {
+    static let app2webCutoffMs: Int64 = 1787881704000
+}
+
 extension HeliumPaywallPreviewVersion {
     var hasApp2webPaddle: Bool {
         webPaywallBundleUrl != nil && !(webPaddleProductIds ?? []).isEmpty
@@ -146,6 +153,17 @@ extension HeliumPaywallPreviewVersion {
     }
 
     var isApp2webCapable: Bool { hasApp2webPaddle || hasApp2webStripe }
+
+    /// Reads the build time from the checkout bundle's `bundle_<ms>.html` filename; a missing or
+    /// unparseable stamp fails closed (treated as too old).
+    var isApp2webBundleFresh: Bool {
+        guard let webPaywallBundleUrl,
+              let bundleId = HeliumAssetManager.shared.getBundleIdFromURL(webPaywallBundleUrl),
+              let builtAtMs = Int64(bundleId) else {
+            return false
+        }
+        return builtAtMs >= HeliumPreviewBundleFreshness.app2webCutoffMs
+    }
 }
 
 extension HeliumPaywallPreviewEntry {

--- a/Tests/helium-swiftTests/PreviewBundleFreshnessTests.swift
+++ b/Tests/helium-swiftTests/PreviewBundleFreshnessTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import Helium
+
+final class PreviewBundleFreshnessTests: XCTestCase {
+
+    private let cutoff = HeliumPreviewBundleFreshness.app2webCutoffMs
+
+    private func makeVersion(webPaywallBundleUrl: String?) throws -> HeliumPaywallPreviewVersion {
+        var object: [String: Any] = ["versionId": "v1", "versionStatus": "draft"]
+        if let webPaywallBundleUrl { object["webPaywallBundleUrl"] = webPaywallBundleUrl }
+        let data = try JSONSerialization.data(withJSONObject: object)
+        return try JSONDecoder().decode(HeliumPaywallPreviewVersion.self, from: data)
+    }
+
+    private func bundleURL(builtAtMs: Int64) -> String {
+        "https://bundles.t3.storage.dev/org/paywall/bundle_\(builtAtMs).html"
+    }
+
+    func testFreshWhenBuiltAfterCutoff() throws {
+        let version = try makeVersion(webPaywallBundleUrl: bundleURL(builtAtMs: cutoff + 60_000))
+        XCTAssertTrue(version.isApp2webBundleFresh)
+    }
+
+    func testStaleWhenBuiltBeforeCutoff() throws {
+        let version = try makeVersion(webPaywallBundleUrl: bundleURL(builtAtMs: cutoff - 60_000))
+        XCTAssertFalse(version.isApp2webBundleFresh)
+    }
+
+    // Cutoff is inclusive: a bundle stamped exactly at it is fresh.
+    func testFreshAtExactCutoff() throws {
+        let version = try makeVersion(webPaywallBundleUrl: bundleURL(builtAtMs: cutoff))
+        XCTAssertTrue(version.isApp2webBundleFresh)
+    }
+
+    func testStaleWhenBundleUrlMissing() throws {
+        let version = try makeVersion(webPaywallBundleUrl: nil)
+        XCTAssertFalse(version.isApp2webBundleFresh)
+    }
+
+    func testStaleWhenTimestampUnparseable() throws {
+        let version = try makeVersion(
+            webPaywallBundleUrl: "https://bundles.t3.storage.dev/org/paywall/bundle_draft.html"
+        )
+        XCTAssertFalse(version.isApp2webBundleFresh)
+    }
+}


### PR DESCRIPTION
## Problem

Paywall bundles that were built before the app2web simulated-purchase flow shipped don't understand the `forceSimulatedFlow` flag. The SDK still sends the flag on a simulated preview run, but an old bundle ignores it and runs a **real charge** — so a QA tester previewing a not-yet-rebundled paywall could get charged.

The SDK can't fix an already-deployed bundle, so it has to be the gate.

## Approach

Every paywall save re-bundles, and each build uploads to `…/bundle_<ms>.html` where the filename is the build's epoch-ms timestamp. That stamp identifies the exact artifact that will load, so the SDK gates on it directly:

- `HeliumPaywallPreviewVersion.isApp2webBundleFresh` parses the timestamp off `webPaywallBundleUrl` and compares it to `HeliumPreviewBundleFreshness.app2webCutoffMs`. A missing or unparseable stamp **fails closed** (treated as too old).
- `HeliumControlPanelView.configurePreview` withholds the **entire** preview (not just the purchase step) for a stale app2web bundle, showing a re-save prompt. Re-saving the paywall rebuilds the bundle and clears the gate.
- Scoped to app2web-capable versions only — display-only web paywalls (browser, no purchase) and pure-native previews are untouched.

We block the whole preview rather than just the simulated purchase because it's simpler and strictly safer, and re-saving is cheap for the customer.

### Why the bundle-URL timestamp, not `lastSavedAt`

`lastSavedAt` in the previews response resolves to the version's `published_at` (published) or `created_at` (draft). Since **publish doesn't re-bundle**, a bundle built before the cutoff but published after it would carry a fresh `lastSavedAt` over a stale bundle — a false "safe" read that charges the card. The URL timestamp reflects the real build, is refreshed on every save (so the re-save remedy actually clears the gate), and shares the bundler's build clock with the cutoff.

## Cutoff caveat

`app2webCutoffMs` must be **≥ the time the new bundler code is fully live in prod**. It's currently set past the expected rollout so nothing built mid-deploy is trusted; bump it if the bundler rollout runs long.

## Testing

`Tests/helium-swiftTests/PreviewBundleFreshnessTests.swift` — fresh-after-cutoff, stale-before, inclusive-at-cutoff, missing URL → stale, unparseable stamp → stale. All green on the iOS 17 Pro simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches preview gating around app2web checkout bundles and a hardcoded epoch cutoff; misconfiguration could block valid previews or briefly trust stale bundles, but only in debug/TestFlight preview flows—not production paywall presentation.
> 
> **Overview**
> **Prevents accidental real charges** when QA opens app2web paywall previews from the control panel. Older checkout bundles ignore simulated purchase flags, so the SDK now blocks the whole preview for app2web-capable versions whose `webPaywallBundleUrl` points at a bundle built before a fixed cutoff.
> 
> Freshness comes from the `bundle_<epochMs>.html` filename (via existing `getBundleIdFromURL` parsing), compared to `HeliumPreviewBundleFreshness.app2webCutoffMs`; missing or unparseable stamps are treated as stale. Stale attempts set `paywallLoadError` with a re-save-in-dashboard message and use the **Preview Could Not Open** alert title instead of generic **Error**. Native and display-only web previews are unchanged.
> 
> Unit tests cover fresh/stale/cutoff-edge, missing URL, and invalid filename cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3a0ccadba760984ce7cd0baee7212736d763efb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented previews from loading when the app2web bundle is outdated or invalid.
  * Updated the alert title to “Preview Could Not Open” for clearer guidance.
  * Added an instructional message telling testers to re-save the paywall in the dashboard and reload.
  * Preview bundles are validated against the freshness cutoff, including missing and unparseable bundle IDs.

* **Tests**
  * Added coverage for fresh, stale, cutoff, missing, and invalid preview bundle timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->