### PR TITLE
HEL-6790 Send customPaywallTraits to external web checkout ctx (flagged)

### DIFF
--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -230,16 +230,17 @@ struct DynamicWebView: View {
             
             _ = Date()
             var mergedContext = contextJSON
-            // Always include "trigger" in customPaywallTraits (can be overridden by provided values though).
-            // customPaywallTraits are key/values that Helium customer can direct paywall editor to read.
-            var combinedTraits = HeliumUserTraits(["trigger": triggerName ?? ""])
-            combinedTraits.merge(HeliumIdentityManager.shared.getUserTraits())
             // Prefer the live environment traits so a paywall constructed off-screen still injects the latest
             // traits at display time; the frozen session value is the safety net (and covers the presented path,
             // which does not set the environment).
-            if let paywallTraits = dynamicPaywallTraits ?? paywallSession?.presentationContext.customPaywallTraits {
-                combinedTraits.merge(paywallTraits)
-            }
+            let presentationTraits = dynamicPaywallTraits ?? paywallSession?.presentationContext.customPaywallTraits
+            // Hand the resolved traits to the delegate so an external web checkout launched from this
+            // paywall sends the exact same customPaywallTraits it injected here.
+            actionsDelegate.setResolvedPaywallTraits(presentationTraits)
+            let combinedTraits = HeliumUserTraits.forPaywall(
+                triggerName: triggerName,
+                presentationTraits: presentationTraits
+            )
             let combinedTraitsData = try JSONEncoder().encode(combinedTraits)
             mergedContext["customPaywallTraits"] = try JSON(data: combinedTraitsData)
             

--- a/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
+++ b/Sources/Helium/HeliumCore/Components/Web/DynamicWebView.swift
@@ -234,15 +234,14 @@ struct DynamicWebView: View {
             // traits at display time; the frozen session value is the safety net (and covers the presented path,
             // which does not set the environment).
             let presentationTraits = dynamicPaywallTraits ?? paywallSession?.presentationContext.customPaywallTraits
-            // Hand the resolved traits to the delegate so an external web checkout launched from this
-            // paywall sends the exact same customPaywallTraits it injected here.
-            actionsDelegate.setResolvedPaywallTraits(presentationTraits)
             let combinedTraits = HeliumUserTraits.forPaywall(
                 triggerName: triggerName,
                 presentationTraits: presentationTraits
             )
-            let combinedTraitsData = try JSONEncoder().encode(combinedTraits)
-            mergedContext["customPaywallTraits"] = try JSON(data: combinedTraitsData)
+            // Freeze the fully assembled display-time traits for the session so an external web
+            // checkout launched from this paywall sends the exact same customPaywallTraits.
+            actionsDelegate.setResolvedPaywallTraits(combinedTraits)
+            mergedContext["customPaywallTraits"] = JSON(try combinedTraits.jsonObject())
             
             // Get localized prices from HeliumFetchedConfigManager
             // Only fetch prices for products associated with this trigger

--- a/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
@@ -109,7 +109,7 @@ class HeliumActionsDelegate: ObservableObject {
     private var isLoading: Bool = false
     private var lastShownSecondTryTrigger: String? = nil
 
-    // The traits the webview actually injected; can differ from the frozen session value.
+    // The fully assembled traits the webview injected, frozen at display time.
     private var resolvedPaywallTraits: HeliumUserTraits?
     
     var dismissAction: (() -> Void)?
@@ -238,7 +238,11 @@ class HeliumActionsDelegate: ObservableObject {
 
         isLoading = true
         defer { isLoading = false }
-        return await HeliumPaywallDelegateWrapper.shared.handlePurchase(productKey: selectedProductId, triggerName: trigger, paywallTemplateName: paywallInfo.paywallTemplateName, paywallSession: paywallSession, presentationTraits: resolvedPaywallTraits ?? paywallSession.presentationContext.customPaywallTraits)
+        let paywallTraits = resolvedPaywallTraits ?? HeliumUserTraits.forPaywall(
+            triggerName: trigger,
+            presentationTraits: paywallSession.presentationContext.customPaywallTraits
+        )
+        return await HeliumPaywallDelegateWrapper.shared.handlePurchase(productKey: selectedProductId, triggerName: trigger, paywallTemplateName: paywallInfo.paywallTemplateName, paywallSession: paywallSession, paywallTraits: paywallTraits)
     }
     
     @MainActor

--- a/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
@@ -66,7 +66,11 @@ class ActionsDelegateWrapper: ObservableObject {
     func selectProduct(productId: String) {
         delegate.selectProduct(productId: productId)
     }
-    
+
+    func setResolvedPaywallTraits(_ traits: HeliumUserTraits?) {
+        delegate.setResolvedPaywallTraits(traits)
+    }
+
     func logRenderTime(timeTakenMS: UInt64, isFallback: Bool) {
         delegate.logRenderTime(timeTakenMS: timeTakenMS, isFallback: isFallback);
     }
@@ -104,6 +108,9 @@ class HeliumActionsDelegate: ObservableObject {
     private var selectedProductId: String
     private var isLoading: Bool = false
     private var lastShownSecondTryTrigger: String? = nil
+
+    // The traits the webview actually injected; can differ from the frozen session value.
+    private var resolvedPaywallTraits: HeliumUserTraits?
     
     var dismissAction: (() -> Void)?
     
@@ -213,7 +220,11 @@ class HeliumActionsDelegate: ObservableObject {
     func selectProduct(productId: String) {
         selectedProductId = productId
     }
-    
+
+    func setResolvedPaywallTraits(_ traits: HeliumUserTraits?) {
+        resolvedPaywallTraits = traits
+    }
+
     func makePurchase() async -> HeliumPaywallTransactionStatus {
         HeliumLogger.log(.info, category: .core, "makePurchase called", metadata: ["productId": selectedProductId, "trigger": trigger])
         // Use new typed event
@@ -227,7 +238,7 @@ class HeliumActionsDelegate: ObservableObject {
 
         isLoading = true
         defer { isLoading = false }
-        return await HeliumPaywallDelegateWrapper.shared.handlePurchase(productKey: selectedProductId, triggerName: trigger, paywallTemplateName: paywallInfo.paywallTemplateName, paywallSession: paywallSession)
+        return await HeliumPaywallDelegateWrapper.shared.handlePurchase(productKey: selectedProductId, triggerName: trigger, paywallTemplateName: paywallInfo.paywallTemplateName, paywallSession: paywallSession, presentationTraits: resolvedPaywallTraits ?? paywallSession.presentationContext.customPaywallTraits)
     }
     
     @MainActor

--- a/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumActionsDelegate.swift
@@ -238,10 +238,19 @@ class HeliumActionsDelegate: ObservableObject {
 
         isLoading = true
         defer { isLoading = false }
-        let paywallTraits = resolvedPaywallTraits ?? HeliumUserTraits.forPaywall(
-            triggerName: trigger,
-            presentationTraits: paywallSession.presentationContext.customPaywallTraits
-        )
+        let paywallTraits: HeliumUserTraits
+        if let resolvedPaywallTraits {
+            paywallTraits = resolvedPaywallTraits
+        } else {
+            HeliumObservabilityManager.shared.track(
+                PaywallTraitsFreezeMissingAtMakePurchase(productId: selectedProductId),
+                scope: paywallSession.observabilityScope
+            )
+            paywallTraits = HeliumUserTraits.forPaywall(
+                triggerName: trigger,
+                presentationTraits: paywallSession.presentationContext.customPaywallTraits
+            )
+        }
         return await HeliumPaywallDelegateWrapper.shared.handlePurchase(productKey: selectedProductId, triggerName: trigger, paywallTemplateName: paywallInfo.paywallTemplateName, paywallSession: paywallSession, paywallTraits: paywallTraits)
     }
     

--- a/Sources/Helium/HeliumCore/HeliumFeatureFlags.swift
+++ b/Sources/Helium/HeliumCore/HeliumFeatureFlags.swift
@@ -13,6 +13,11 @@ enum HeliumFeatureFlag: String, CaseIterable {
     /// Gates the SDK's California ip_geo ZIP block only. Off (default) blocks a
     /// CA-range postal; on lets the buyer reach the bundle's consent modal.
     case caConsentModalEnabled
+
+    /// Gates emitting `customPaywallTraits` into the external web checkout ctx so a
+    /// browser-opened paywall reads the same traits it would in-app. Off (default)
+    /// omits the key while the web checkout bundle rolls out support for it.
+    case webCheckoutPaywallTraits
 }
 
 /// Immutable resolved view of the server's `featureFlags` map.

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -64,7 +64,7 @@ class HeliumPaywallDelegateWrapper {
         return Helium.config.purchaseDelegate
     }
     
-    func handlePurchase(productKey: String, triggerName: String, paywallTemplateName: String, paywallSession: PaywallSession) async -> HeliumPaywallTransactionStatus {
+    func handlePurchase(productKey: String, triggerName: String, paywallTemplateName: String, paywallSession: PaywallSession, presentationTraits: HeliumUserTraits? = nil) async -> HeliumPaywallTransactionStatus {
         let hadEntitlementBeforePurchase = await withTimeoutOrNil(milliseconds: 500) {
             await HeliumEntitlementsManager.shared.hasPersonallyPurchased(productId: productKey)
         } ?? false
@@ -85,7 +85,8 @@ class HeliumPaywallDelegateWrapper {
                     let outcome = try await StripeCheckoutManager.shared.startCheckoutFlow(
                         for: productKey,
                         triggerName: triggerName,
-                        paywallSession: paywallSession
+                        paywallSession: paywallSession,
+                        presentationTraits: presentationTraits
                     )
                     transactionStatus = outcome.transactionStatus
                 } catch {
@@ -96,7 +97,8 @@ class HeliumPaywallDelegateWrapper {
                     let outcome = try await PaddleCheckoutManager.shared.startCheckoutFlow(
                         for: productKey,
                         triggerName: triggerName,
-                        paywallSession: paywallSession
+                        paywallSession: paywallSession,
+                        presentationTraits: presentationTraits
                     )
                     transactionStatus = outcome.transactionStatus
                 } catch {

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -64,7 +64,7 @@ class HeliumPaywallDelegateWrapper {
         return Helium.config.purchaseDelegate
     }
     
-    func handlePurchase(productKey: String, triggerName: String, paywallTemplateName: String, paywallSession: PaywallSession, presentationTraits: HeliumUserTraits? = nil) async -> HeliumPaywallTransactionStatus {
+    func handlePurchase(productKey: String, triggerName: String, paywallTemplateName: String, paywallSession: PaywallSession, paywallTraits: HeliumUserTraits? = nil) async -> HeliumPaywallTransactionStatus {
         let hadEntitlementBeforePurchase = await withTimeoutOrNil(milliseconds: 500) {
             await HeliumEntitlementsManager.shared.hasPersonallyPurchased(productId: productKey)
         } ?? false
@@ -86,7 +86,7 @@ class HeliumPaywallDelegateWrapper {
                         for: productKey,
                         triggerName: triggerName,
                         paywallSession: paywallSession,
-                        presentationTraits: presentationTraits
+                        paywallTraits: paywallTraits
                     )
                     transactionStatus = outcome.transactionStatus
                 } catch {
@@ -98,7 +98,7 @@ class HeliumPaywallDelegateWrapper {
                         for: productKey,
                         triggerName: triggerName,
                         paywallSession: paywallSession,
-                        presentationTraits: presentationTraits
+                        paywallTraits: paywallTraits
                     )
                     transactionStatus = outcome.transactionStatus
                 } catch {

--- a/Sources/Helium/HeliumCore/HeliumUserTraits.swift
+++ b/Sources/Helium/HeliumCore/HeliumUserTraits.swift
@@ -184,6 +184,11 @@ extension HeliumUserTraits {
         }
         return combined
     }
+
+    func jsonObject() throws -> [String: Any] {
+        let data = try JSONEncoder().encode(self)
+        return try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
+    }
 }
 
 // MARK: - Type-specific convenience constructors

--- a/Sources/Helium/HeliumCore/HeliumUserTraits.swift
+++ b/Sources/Helium/HeliumCore/HeliumUserTraits.swift
@@ -171,6 +171,21 @@ extension HeliumUserTraits: Equatable {
     }
 }
 
+// MARK: - Paywall trait assembly
+extension HeliumUserTraits {
+    /// Assembles the `customPaywallTraits` for a paywall. Always carries "trigger", then
+    /// the identified user's traits, and finally `presentationTraits`, which win on key
+    /// conflicts. These are the keys a Helium customer can wire the paywall editor to read.
+    static func forPaywall(triggerName: String?, presentationTraits: HeliumUserTraits?) -> HeliumUserTraits {
+        var combined = HeliumUserTraits(["trigger": triggerName ?? ""])
+        combined.merge(HeliumIdentityManager.shared.getUserTraits())
+        if let presentationTraits {
+            combined.merge(presentationTraits)
+        }
+        return combined
+    }
+}
+
 // MARK: - Type-specific convenience constructors
 extension HeliumUserTraits {
     // Instead of having multiple init(_ traits:) with different types,

--- a/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
+++ b/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
@@ -370,6 +370,19 @@ struct PaywallWebProcessTerminated: HeliumObservabilityEvent {
     }
 }
 
+/// The paywall webview freezes the fully assembled traits at display time, and that
+/// always runs before a purchase can be triggered. A miss at purchase time therefore
+/// means that invariant broke, so the traits get reconstructed as a safety net (some
+/// traits over none) and this event flags the defect for investigation.
+struct PaywallTraitsFreezeMissingAtMakePurchase: HeliumObservabilityEvent {
+    let productId: String
+
+    var name: String { "paywall_traits_freeze_missing_at_make_purchase" }
+    var properties: [String: Any] {
+        ["productId": productId]
+    }
+}
+
 /// Reports the fallback bundle an app ships. The event's presence in the stream is
 /// itself the "this app has fallbacks configured" signal, so it is only emitted when
 /// a bundle was found and parsed.

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -68,14 +68,14 @@ public class ExternalWebCheckoutManager: NSObject {
         for productKey: String,
         triggerName: String,
         paywallSession: PaywallSession,
-        presentationTraits: HeliumUserTraits? = nil
+        paywallTraits: HeliumUserTraits? = nil
     ) async throws -> WebCheckoutOutcome {
         return try await withFlowTelemetry(productKey: productKey, paywallSession: paywallSession) {
             try await self.runCheckoutFlow(
                 for: productKey,
                 triggerName: triggerName,
                 paywallSession: paywallSession,
-                presentationTraits: presentationTraits
+                paywallTraits: paywallTraits
             )
         }
     }
@@ -85,7 +85,7 @@ public class ExternalWebCheckoutManager: NSObject {
         for productKey: String,
         triggerName: String,
         paywallSession: PaywallSession,
-        presentationTraits: HeliumUserTraits?
+        paywallTraits: HeliumUserTraits?
     ) async throws -> WebCheckoutOutcome {
         guard let resolvedSuccessURL = provider.getCheckoutSuccessURL(),
               let resolvedCancelURL = provider.getCheckoutCancelURL() else {
@@ -182,7 +182,7 @@ public class ExternalWebCheckoutManager: NSObject {
             stripeOfferTerms: buildStripeOfferTerms(paywallInfo: paywallSession.paywallInfoWithBackups),
             paddleBootstraps: paddleBootstrapsDict,
             paddleAlreadyEntitled: paddleAlreadyEntitledDict,
-            presentationTraits: presentationTraits
+            paywallTraits: paywallTraits
         )
 
         return try await openEnrichedCheckoutURL(enrichedURL, productKey: productKey, paywallSession: paywallSession)
@@ -284,7 +284,7 @@ public class ExternalWebCheckoutManager: NSObject {
         stripeOfferTerms: [String: Any]? = nil,
         paddleBootstraps: [String: Any]? = nil,
         paddleAlreadyEntitled: [String: Any]? = nil,
-        presentationTraits: HeliumUserTraits? = nil
+        paywallTraits: HeliumUserTraits? = nil
     ) throws -> URL {
         guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
             throw WebCheckoutError.invalidBaseURLForComponents
@@ -323,13 +323,11 @@ public class ExternalWebCheckoutManager: NSObject {
         ctx["environment"] = AppReceiptsHelper.shared.environment.rawValue.uppercased()
         ctx["trigger"] = triggerName
 
-        // Mirror the traits the in-app web bundle injects, so a paywall opened in the
-        // external browser reads the same customPaywallTraits it would in-app.
-        if HeliumFetchedConfigManager.shared.isFeatureEnabled(.webCheckoutPaywallTraits) {
-            ctx["customPaywallTraits"] = HeliumUserTraits.forPaywall(
-                triggerName: triggerName,
-                presentationTraits: presentationTraits
-            ).dictionaryRepresentation
+        // Emit the exact traits the in-app paywall injected (frozen at display time), so a
+        // paywall opened in the external browser reads the same customPaywallTraits.
+        if HeliumFetchedConfigManager.shared.isFeatureEnabled(.webCheckoutPaywallTraits),
+           let paywallTraits {
+            ctx["customPaywallTraits"] = try paywallTraits.jsonObject()
         }
 
         let isPreviewRun = HeliumFetchedConfigManager.isPreviewTrigger(triggerName)

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -67,13 +67,15 @@ public class ExternalWebCheckoutManager: NSObject {
     func startCheckoutFlow(
         for productKey: String,
         triggerName: String,
-        paywallSession: PaywallSession
+        paywallSession: PaywallSession,
+        presentationTraits: HeliumUserTraits? = nil
     ) async throws -> WebCheckoutOutcome {
         return try await withFlowTelemetry(productKey: productKey, paywallSession: paywallSession) {
             try await self.runCheckoutFlow(
                 for: productKey,
                 triggerName: triggerName,
-                paywallSession: paywallSession
+                paywallSession: paywallSession,
+                presentationTraits: presentationTraits
             )
         }
     }
@@ -82,7 +84,8 @@ public class ExternalWebCheckoutManager: NSObject {
     private func runCheckoutFlow(
         for productKey: String,
         triggerName: String,
-        paywallSession: PaywallSession
+        paywallSession: PaywallSession,
+        presentationTraits: HeliumUserTraits?
     ) async throws -> WebCheckoutOutcome {
         guard let resolvedSuccessURL = provider.getCheckoutSuccessURL(),
               let resolvedCancelURL = provider.getCheckoutCancelURL() else {
@@ -178,7 +181,8 @@ public class ExternalWebCheckoutManager: NSObject {
             introOfferEligible: await isIntroOfferEligibleForWebCheckout(paywallInfo: paywallSession.paywallInfoWithBackups),
             stripeOfferTerms: buildStripeOfferTerms(paywallInfo: paywallSession.paywallInfoWithBackups),
             paddleBootstraps: paddleBootstrapsDict,
-            paddleAlreadyEntitled: paddleAlreadyEntitledDict
+            paddleAlreadyEntitled: paddleAlreadyEntitledDict,
+            presentationTraits: presentationTraits
         )
 
         return try await openEnrichedCheckoutURL(enrichedURL, productKey: productKey, paywallSession: paywallSession)
@@ -279,7 +283,8 @@ public class ExternalWebCheckoutManager: NSObject {
         introOfferEligible: Bool,
         stripeOfferTerms: [String: Any]? = nil,
         paddleBootstraps: [String: Any]? = nil,
-        paddleAlreadyEntitled: [String: Any]? = nil
+        paddleAlreadyEntitled: [String: Any]? = nil,
+        presentationTraits: HeliumUserTraits? = nil
     ) throws -> URL {
         guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
             throw WebCheckoutError.invalidBaseURLForComponents
@@ -317,6 +322,13 @@ public class ExternalWebCheckoutManager: NSObject {
 
         ctx["environment"] = AppReceiptsHelper.shared.environment.rawValue.uppercased()
         ctx["trigger"] = triggerName
+
+        // Mirror the traits the in-app web bundle injects, so a paywall opened in the
+        // external browser reads the same customPaywallTraits it would in-app.
+        ctx["customPaywallTraits"] = HeliumUserTraits.forPaywall(
+            triggerName: triggerName,
+            presentationTraits: presentationTraits
+        ).dictionaryRepresentation
 
         let isPreviewRun = HeliumFetchedConfigManager.isPreviewTrigger(triggerName)
         let previewConfiguration = isPreviewRun ? HeliumPreviewConfigurationStore.shared.configuration : nil

--- a/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
+++ b/Sources/Helium/HeliumCore/StripeCheckout/ExternalWebCheckoutManager.swift
@@ -325,10 +325,12 @@ public class ExternalWebCheckoutManager: NSObject {
 
         // Mirror the traits the in-app web bundle injects, so a paywall opened in the
         // external browser reads the same customPaywallTraits it would in-app.
-        ctx["customPaywallTraits"] = HeliumUserTraits.forPaywall(
-            triggerName: triggerName,
-            presentationTraits: presentationTraits
-        ).dictionaryRepresentation
+        if HeliumFetchedConfigManager.shared.isFeatureEnabled(.webCheckoutPaywallTraits) {
+            ctx["customPaywallTraits"] = HeliumUserTraits.forPaywall(
+                triggerName: triggerName,
+                presentationTraits: presentationTraits
+            ).dictionaryRepresentation
+        }
 
         let isPreviewRun = HeliumFetchedConfigManager.isPreviewTrigger(triggerName)
         let previewConfiguration = isPreviewRun ? HeliumPreviewConfigurationStore.shared.configuration : nil

--- a/Tests/helium-swiftTests/CtxCompressionTests.swift
+++ b/Tests/helium-swiftTests/CtxCompressionTests.swift
@@ -275,6 +275,10 @@ final class CtxCompressionTests: XCTestCase {
         XCTAssertEqual(traits["isPro"] as? Bool, true)
         XCTAssertEqual(traits["trialCount"] as? Int, 3)
         XCTAssertEqual(traits["discountRatio"] as? Double, 0.25)
+        // `as? Int`/`as? Double` also accept a bool or the wrong numeric token, so pin the tokens.
+        XCTAssertTrue(isJSONNumber(traits["trialCount"]), "trialCount must be a number, not a bool")
+        XCTAssertFalse(isJSONFloatingPoint(traits["trialCount"]), "trialCount must stay an integer token")
+        XCTAssertTrue(isJSONFloatingPoint(traits["discountRatio"]), "discountRatio must stay a floating-point token")
     }
 
     func testBuildEnrichedCheckoutURL_omitsCustomPaywallTraitsWhenFlagOff() async throws {
@@ -410,6 +414,10 @@ final class CtxCompressionTests: XCTestCase {
         XCTAssertEqual(dict["discountRatio"] as? Double, 0.25)
         XCTAssertEqual(dict["tags"] as? [String], ["a", "b"])
         XCTAssertEqual((dict["nested"] as? [String: Any])?["k"] as? Int, 1)
+        // `as? Int`/`as? Double` also accept a bool or the wrong numeric token, so pin the tokens.
+        XCTAssertTrue(isJSONNumber(dict["trialCount"]), "trialCount must be a number, not a bool")
+        XCTAssertFalse(isJSONFloatingPoint(dict["trialCount"]), "trialCount must stay an integer token")
+        XCTAssertTrue(isJSONFloatingPoint(dict["discountRatio"]), "discountRatio must stay a floating-point token")
     }
 
     func testBuildEnrichedCheckoutURL_appendsHeliumIosBundleIdQueryParam() async throws {
@@ -797,6 +805,20 @@ final class CtxCompressionTests: XCTestCase {
     }
 
     // MARK: - Helpers
+
+    /// True iff the value is a JSON number (NSNumber) rather than a bool. `JSONSerialization`
+    /// maps JSON `true`/`false` → CFBoolean and numeric tokens → plain NSNumber, so this
+    /// separates a real number from a bool that would still satisfy `as? Int`/`as? Double`.
+    private func isJSONNumber(_ value: Any?) -> Bool {
+        guard let n = value as? NSNumber else { return false }
+        return CFGetTypeID(n) != CFBooleanGetTypeID()
+    }
+
+    /// True iff the value is a JSON floating-point token (objCType "d"), not an integer token.
+    private func isJSONFloatingPoint(_ value: Any?) -> Bool {
+        guard isJSONNumber(value), let n = value as? NSNumber else { return false }
+        return String(cString: n.objCType) == "d"
+    }
 
     private func base64URLDecode(_ encoded: String) -> Data? {
         var s = encoded.replacingOccurrences(of: "-", with: "+")

--- a/Tests/helium-swiftTests/CtxCompressionTests.swift
+++ b/Tests/helium-swiftTests/CtxCompressionTests.swift
@@ -210,7 +210,7 @@ final class CtxCompressionTests: XCTestCase {
             productKey: "pro_x:pri_y", triggerName: "onboarding",
             successURL: "myapp://ok", cancelURL: "myapp://cancel",
             introOfferEligible: true, paddleBootstraps: nil,
-            presentationTraits: HeliumUserTraits(["plan": "gold", "trigger": "overridden"])
+            paywallTraits: HeliumUserTraits(["plan": "gold", "trigger": "onboarding", "tier": "free"])
         )
 
         let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
@@ -222,13 +222,17 @@ final class CtxCompressionTests: XCTestCase {
         let traits = try XCTUnwrap(parsed["customPaywallTraits"] as? [String: Any],
                                    "ctx must carry customPaywallTraits")
         XCTAssertEqual(traits["plan"] as? String, "gold")
-        // Presentation traits win on key conflicts, including the default "trigger".
-        XCTAssertEqual(traits["trigger"] as? String, "overridden")
+        XCTAssertEqual(traits["trigger"] as? String, "onboarding")
+        XCTAssertEqual(traits["tier"] as? String, "free")
     }
 
     func testBuildEnrichedCheckoutURL_omitsCustomPaywallTraitsWhenFlagOff() async throws {
         Helium.lastApiKeyUsed = "test_api_key_for_traits_off"
-        defer { Helium.lastApiKeyUsed = nil }
+        HeliumFetchedConfigManager.shared.setFeatureFlagsForTesting(JSON(["webCheckoutPaywallTraits": false]))
+        defer {
+            Helium.lastApiKeyUsed = nil
+            HeliumFetchedConfigManager.shared.setFeatureFlagsForTesting(nil)
+        }
 
         let provider: PaymentProviderConfig = .paddle
         let entitlements = HeliumPaymentEntitlementsSource(provider: provider)
@@ -250,7 +254,7 @@ final class CtxCompressionTests: XCTestCase {
             productKey: "pro_x:pri_y", triggerName: "onboarding",
             successURL: "myapp://ok", cancelURL: "myapp://cancel",
             introOfferEligible: true, paddleBootstraps: nil,
-            presentationTraits: HeliumUserTraits(["plan": "gold"])
+            paywallTraits: HeliumUserTraits(["plan": "gold"])
         )
 
         let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
@@ -261,6 +265,80 @@ final class CtxCompressionTests: XCTestCase {
 
         XCTAssertNil(parsed["customPaywallTraits"],
                      "ctx must omit customPaywallTraits when the flag is off")
+    }
+
+    func testBuildEnrichedCheckoutURL_freezesTraitsAgainstLaterIdentityChanges() async throws {
+        Helium.lastApiKeyUsed = "test_api_key_for_traits_freeze"
+        HeliumFetchedConfigManager.shared.setFeatureFlagsForTesting(JSON(["webCheckoutPaywallTraits": true]))
+        let originalUserTraits = HeliumIdentityManager.shared.getUserTraits()
+        defer {
+            Helium.lastApiKeyUsed = nil
+            HeliumFetchedConfigManager.shared.setFeatureFlagsForTesting(nil)
+            HeliumIdentityManager.shared.setCustomUserTraits(originalUserTraits)
+        }
+
+        // Assemble the snapshot with the identity traits in effect at display time.
+        HeliumIdentityManager.shared.setCustomUserTraits(HeliumUserTraits(["tier": "free"]))
+        let displaySnapshot = HeliumUserTraits.forPaywall(
+            triggerName: "onboarding",
+            presentationTraits: HeliumUserTraits(["plan": "gold"])
+        )
+        // Identity changes before the user completes checkout.
+        HeliumIdentityManager.shared.setCustomUserTraits(HeliumUserTraits(["tier": "premium"]))
+
+        let provider: PaymentProviderConfig = .paddle
+        let entitlements = HeliumPaymentEntitlementsSource(provider: provider)
+        let manager = ExternalWebCheckoutManager(provider: provider, entitlementsSource: entitlements)
+
+        let baseURL = URL(string: "https://bundles-staging.heliumpaywall.com/o/p/bundle.html")!
+        let templateEvent = PurchaseSucceededEvent(
+            productId: "", triggerName: "onboarding", paywallName: "P",
+            storeKitTransactionId: nil, storeKitOriginalTransactionId: nil,
+            paymentProcessor: provider.kind
+        )
+        let analyticsEvent = HeliumAnalyticsManager.shared.buildLoggedEvent(
+            for: templateEvent,
+            paywallSession: PaywallSession(trigger: "onboarding", paywallInfo: nil, fallbackType: .notFallback, presentationContext: .empty)
+        )
+
+        let url = try manager.buildEnrichedCheckoutURL(
+            baseURL: baseURL, analyticsEvent: analyticsEvent,
+            productKey: "pro_x:pri_y", triggerName: "onboarding",
+            successURL: "myapp://ok", cancelURL: "myapp://cancel",
+            introOfferEligible: true, paddleBootstraps: nil,
+            paywallTraits: displaySnapshot
+        )
+
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let fragment = try XCTUnwrap(components.fragment)
+        let compressed = try XCTUnwrap(base64URLDecode(String(fragment.dropFirst("ctx=".count))))
+        let decompressed = try decompressWithAppleZlib(compressed, originalSize: 8192)
+        let parsed = try XCTUnwrap(JSONSerialization.jsonObject(with: decompressed) as? [String: Any])
+        let traits = try XCTUnwrap(parsed["customPaywallTraits"] as? [String: Any])
+
+        // The ctx reflects the display-time snapshot, not the later identity change.
+        XCTAssertEqual(traits["tier"] as? String, "free")
+        XCTAssertEqual(traits["plan"] as? String, "gold")
+        XCTAssertEqual(traits["trigger"] as? String, "onboarding")
+    }
+
+    func testForPaywall_mergesTriggerIdentityAndPresentationWithPresentationWinning() throws {
+        let originalUserTraits = HeliumIdentityManager.shared.getUserTraits()
+        defer { HeliumIdentityManager.shared.setCustomUserTraits(originalUserTraits) }
+
+        HeliumIdentityManager.shared.setCustomUserTraits(
+            HeliumUserTraits(["tier": "free", "plan": "identity_plan"])
+        )
+
+        let combined = HeliumUserTraits.forPaywall(
+            triggerName: "onboarding",
+            presentationTraits: HeliumUserTraits(["plan": "gold", "trigger": "custom"])
+        )
+        let dict = try combined.jsonObject()
+
+        XCTAssertEqual(dict["tier"] as? String, "free")       // carried from identity traits
+        XCTAssertEqual(dict["plan"] as? String, "gold")       // presentation wins over identity
+        XCTAssertEqual(dict["trigger"] as? String, "custom")  // presentation wins over the default trigger
     }
 
     func testBuildEnrichedCheckoutURL_appendsHeliumIosBundleIdQueryParam() async throws {

--- a/Tests/helium-swiftTests/CtxCompressionTests.swift
+++ b/Tests/helium-swiftTests/CtxCompressionTests.swift
@@ -226,61 +226,6 @@ final class CtxCompressionTests: XCTestCase {
         XCTAssertEqual(traits["tier"] as? String, "free")
     }
 
-    func testBuildEnrichedCheckoutURL_emitsMixedTypeCustomPaywallTraitsInCtx() async throws {
-        Helium.lastApiKeyUsed = "test_api_key_for_mixed_traits"
-        HeliumFetchedConfigManager.shared.setFeatureFlagsForTesting(JSON(["webCheckoutPaywallTraits": true]))
-        defer {
-            Helium.lastApiKeyUsed = nil
-            HeliumFetchedConfigManager.shared.setFeatureFlagsForTesting(nil)
-        }
-
-        let provider: PaymentProviderConfig = .paddle
-        let entitlements = HeliumPaymentEntitlementsSource(provider: provider)
-        let manager = ExternalWebCheckoutManager(provider: provider, entitlementsSource: entitlements)
-
-        let baseURL = URL(string: "https://bundles-staging.heliumpaywall.com/o/p/bundle.html")!
-        let templateEvent = PurchaseSucceededEvent(
-            productId: "", triggerName: "t", paywallName: "P",
-            storeKitTransactionId: nil, storeKitOriginalTransactionId: nil,
-            paymentProcessor: provider.kind
-        )
-        let analyticsEvent = HeliumAnalyticsManager.shared.buildLoggedEvent(
-            for: templateEvent,
-            paywallSession: PaywallSession(trigger: "t", paywallInfo: nil, fallbackType: .notFallback, presentationContext: .empty)
-        )
-
-        let url = try manager.buildEnrichedCheckoutURL(
-            baseURL: baseURL, analyticsEvent: analyticsEvent,
-            productKey: "pro_x:pri_y", triggerName: "onboarding",
-            successURL: "myapp://ok", cancelURL: "myapp://cancel",
-            introOfferEligible: true, paddleBootstraps: nil,
-            paywallTraits: HeliumUserTraits([
-                "plan": "gold",       // String
-                "isPro": true,        // Bool
-                "trialCount": 3,      // Int
-                "discountRatio": 0.25 // Double
-            ])
-        )
-
-        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
-        let fragment = try XCTUnwrap(components.fragment)
-        let compressed = try XCTUnwrap(base64URLDecode(String(fragment.dropFirst("ctx=".count))))
-        let decompressed = try decompressWithAppleZlib(compressed, originalSize: 8192)
-        let parsed = try XCTUnwrap(JSONSerialization.jsonObject(with: decompressed) as? [String: Any])
-
-        let traits = try XCTUnwrap(parsed["customPaywallTraits"] as? [String: Any],
-                                   "ctx must carry customPaywallTraits")
-        // Each JSON type must survive the freeze → jsonObject() → compress → decompress round-trip.
-        XCTAssertEqual(traits["plan"] as? String, "gold")
-        XCTAssertEqual(traits["isPro"] as? Bool, true)
-        XCTAssertEqual(traits["trialCount"] as? Int, 3)
-        XCTAssertEqual(traits["discountRatio"] as? Double, 0.25)
-        // `as? Int`/`as? Double` also accept a bool or the wrong numeric token, so pin the tokens.
-        XCTAssertTrue(isJSONNumber(traits["trialCount"]), "trialCount must be a number, not a bool")
-        XCTAssertFalse(isJSONFloatingPoint(traits["trialCount"]), "trialCount must stay an integer token")
-        XCTAssertTrue(isJSONFloatingPoint(traits["discountRatio"]), "discountRatio must stay a floating-point token")
-    }
-
     func testBuildEnrichedCheckoutURL_omitsCustomPaywallTraitsWhenFlagOff() async throws {
         Helium.lastApiKeyUsed = "test_api_key_for_traits_off"
         HeliumFetchedConfigManager.shared.setFeatureFlagsForTesting(JSON(["webCheckoutPaywallTraits": false]))
@@ -414,10 +359,6 @@ final class CtxCompressionTests: XCTestCase {
         XCTAssertEqual(dict["discountRatio"] as? Double, 0.25)
         XCTAssertEqual(dict["tags"] as? [String], ["a", "b"])
         XCTAssertEqual((dict["nested"] as? [String: Any])?["k"] as? Int, 1)
-        // `as? Int`/`as? Double` also accept a bool or the wrong numeric token, so pin the tokens.
-        XCTAssertTrue(isJSONNumber(dict["trialCount"]), "trialCount must be a number, not a bool")
-        XCTAssertFalse(isJSONFloatingPoint(dict["trialCount"]), "trialCount must stay an integer token")
-        XCTAssertTrue(isJSONFloatingPoint(dict["discountRatio"]), "discountRatio must stay a floating-point token")
     }
 
     func testBuildEnrichedCheckoutURL_appendsHeliumIosBundleIdQueryParam() async throws {
@@ -805,20 +746,6 @@ final class CtxCompressionTests: XCTestCase {
     }
 
     // MARK: - Helpers
-
-    /// True iff the value is a JSON number (NSNumber) rather than a bool. `JSONSerialization`
-    /// maps JSON `true`/`false` → CFBoolean and numeric tokens → plain NSNumber, so this
-    /// separates a real number from a bool that would still satisfy `as? Int`/`as? Double`.
-    private func isJSONNumber(_ value: Any?) -> Bool {
-        guard let n = value as? NSNumber else { return false }
-        return CFGetTypeID(n) != CFBooleanGetTypeID()
-    }
-
-    /// True iff the value is a JSON floating-point token (objCType "d"), not an integer token.
-    private func isJSONFloatingPoint(_ value: Any?) -> Bool {
-        guard isJSONNumber(value), let n = value as? NSNumber else { return false }
-        return String(cString: n.objCType) == "d"
-    }
 
     private func base64URLDecode(_ encoded: String) -> Data? {
         var s = encoded.replacingOccurrences(of: "-", with: "+")

--- a/Tests/helium-swiftTests/CtxCompressionTests.swift
+++ b/Tests/helium-swiftTests/CtxCompressionTests.swift
@@ -184,7 +184,11 @@ final class CtxCompressionTests: XCTestCase {
 
     func testBuildEnrichedCheckoutURL_emitsCustomPaywallTraitsInCtx() async throws {
         Helium.lastApiKeyUsed = "test_api_key_for_traits"
-        defer { Helium.lastApiKeyUsed = nil }
+        HeliumFetchedConfigManager.shared.setFeatureFlagsForTesting(JSON(["webCheckoutPaywallTraits": true]))
+        defer {
+            Helium.lastApiKeyUsed = nil
+            HeliumFetchedConfigManager.shared.setFeatureFlagsForTesting(nil)
+        }
 
         let provider: PaymentProviderConfig = .paddle
         let entitlements = HeliumPaymentEntitlementsSource(provider: provider)
@@ -220,6 +224,43 @@ final class CtxCompressionTests: XCTestCase {
         XCTAssertEqual(traits["plan"] as? String, "gold")
         // Presentation traits win on key conflicts, including the default "trigger".
         XCTAssertEqual(traits["trigger"] as? String, "overridden")
+    }
+
+    func testBuildEnrichedCheckoutURL_omitsCustomPaywallTraitsWhenFlagOff() async throws {
+        Helium.lastApiKeyUsed = "test_api_key_for_traits_off"
+        defer { Helium.lastApiKeyUsed = nil }
+
+        let provider: PaymentProviderConfig = .paddle
+        let entitlements = HeliumPaymentEntitlementsSource(provider: provider)
+        let manager = ExternalWebCheckoutManager(provider: provider, entitlementsSource: entitlements)
+
+        let baseURL = URL(string: "https://bundles-staging.heliumpaywall.com/o/p/bundle.html")!
+        let templateEvent = PurchaseSucceededEvent(
+            productId: "", triggerName: "t", paywallName: "P",
+            storeKitTransactionId: nil, storeKitOriginalTransactionId: nil,
+            paymentProcessor: provider.kind
+        )
+        let analyticsEvent = HeliumAnalyticsManager.shared.buildLoggedEvent(
+            for: templateEvent,
+            paywallSession: PaywallSession(trigger: "t", paywallInfo: nil, fallbackType: .notFallback, presentationContext: .empty)
+        )
+
+        let url = try manager.buildEnrichedCheckoutURL(
+            baseURL: baseURL, analyticsEvent: analyticsEvent,
+            productKey: "pro_x:pri_y", triggerName: "onboarding",
+            successURL: "myapp://ok", cancelURL: "myapp://cancel",
+            introOfferEligible: true, paddleBootstraps: nil,
+            presentationTraits: HeliumUserTraits(["plan": "gold"])
+        )
+
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let fragment = try XCTUnwrap(components.fragment)
+        let compressed = try XCTUnwrap(base64URLDecode(String(fragment.dropFirst("ctx=".count))))
+        let decompressed = try decompressWithAppleZlib(compressed, originalSize: 8192)
+        let parsed = try XCTUnwrap(JSONSerialization.jsonObject(with: decompressed) as? [String: Any])
+
+        XCTAssertNil(parsed["customPaywallTraits"],
+                     "ctx must omit customPaywallTraits when the flag is off")
     }
 
     func testBuildEnrichedCheckoutURL_appendsHeliumIosBundleIdQueryParam() async throws {

--- a/Tests/helium-swiftTests/CtxCompressionTests.swift
+++ b/Tests/helium-swiftTests/CtxCompressionTests.swift
@@ -226,6 +226,57 @@ final class CtxCompressionTests: XCTestCase {
         XCTAssertEqual(traits["tier"] as? String, "free")
     }
 
+    func testBuildEnrichedCheckoutURL_emitsMixedTypeCustomPaywallTraitsInCtx() async throws {
+        Helium.lastApiKeyUsed = "test_api_key_for_mixed_traits"
+        HeliumFetchedConfigManager.shared.setFeatureFlagsForTesting(JSON(["webCheckoutPaywallTraits": true]))
+        defer {
+            Helium.lastApiKeyUsed = nil
+            HeliumFetchedConfigManager.shared.setFeatureFlagsForTesting(nil)
+        }
+
+        let provider: PaymentProviderConfig = .paddle
+        let entitlements = HeliumPaymentEntitlementsSource(provider: provider)
+        let manager = ExternalWebCheckoutManager(provider: provider, entitlementsSource: entitlements)
+
+        let baseURL = URL(string: "https://bundles-staging.heliumpaywall.com/o/p/bundle.html")!
+        let templateEvent = PurchaseSucceededEvent(
+            productId: "", triggerName: "t", paywallName: "P",
+            storeKitTransactionId: nil, storeKitOriginalTransactionId: nil,
+            paymentProcessor: provider.kind
+        )
+        let analyticsEvent = HeliumAnalyticsManager.shared.buildLoggedEvent(
+            for: templateEvent,
+            paywallSession: PaywallSession(trigger: "t", paywallInfo: nil, fallbackType: .notFallback, presentationContext: .empty)
+        )
+
+        let url = try manager.buildEnrichedCheckoutURL(
+            baseURL: baseURL, analyticsEvent: analyticsEvent,
+            productKey: "pro_x:pri_y", triggerName: "onboarding",
+            successURL: "myapp://ok", cancelURL: "myapp://cancel",
+            introOfferEligible: true, paddleBootstraps: nil,
+            paywallTraits: HeliumUserTraits([
+                "plan": "gold",       // String
+                "isPro": true,        // Bool
+                "trialCount": 3,      // Int
+                "discountRatio": 0.25 // Double
+            ])
+        )
+
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let fragment = try XCTUnwrap(components.fragment)
+        let compressed = try XCTUnwrap(base64URLDecode(String(fragment.dropFirst("ctx=".count))))
+        let decompressed = try decompressWithAppleZlib(compressed, originalSize: 8192)
+        let parsed = try XCTUnwrap(JSONSerialization.jsonObject(with: decompressed) as? [String: Any])
+
+        let traits = try XCTUnwrap(parsed["customPaywallTraits"] as? [String: Any],
+                                   "ctx must carry customPaywallTraits")
+        // Each JSON type must survive the freeze → jsonObject() → compress → decompress round-trip.
+        XCTAssertEqual(traits["plan"] as? String, "gold")
+        XCTAssertEqual(traits["isPro"] as? Bool, true)
+        XCTAssertEqual(traits["trialCount"] as? Int, 3)
+        XCTAssertEqual(traits["discountRatio"] as? Double, 0.25)
+    }
+
     func testBuildEnrichedCheckoutURL_omitsCustomPaywallTraitsWhenFlagOff() async throws {
         Helium.lastApiKeyUsed = "test_api_key_for_traits_off"
         HeliumFetchedConfigManager.shared.setFeatureFlagsForTesting(JSON(["webCheckoutPaywallTraits": false]))
@@ -339,6 +390,26 @@ final class CtxCompressionTests: XCTestCase {
         XCTAssertEqual(dict["tier"] as? String, "free")       // carried from identity traits
         XCTAssertEqual(dict["plan"] as? String, "gold")       // presentation wins over identity
         XCTAssertEqual(dict["trigger"] as? String, "custom")  // presentation wins over the default trigger
+    }
+
+    func testJsonObject_preservesJSONValueTypes() throws {
+        let traits = HeliumUserTraits([
+            "plan": "gold",           // String
+            "isPro": true,            // Bool
+            "trialCount": 3,          // Int
+            "discountRatio": 0.25,    // Double
+            "tags": ["a", "b"],       // Array
+            "nested": ["k": 1]        // Dictionary
+        ])
+
+        let dict = try traits.jsonObject()
+
+        XCTAssertEqual(dict["plan"] as? String, "gold")
+        XCTAssertEqual(dict["isPro"] as? Bool, true)
+        XCTAssertEqual(dict["trialCount"] as? Int, 3)
+        XCTAssertEqual(dict["discountRatio"] as? Double, 0.25)
+        XCTAssertEqual(dict["tags"] as? [String], ["a", "b"])
+        XCTAssertEqual((dict["nested"] as? [String: Any])?["k"] as? Int, 1)
     }
 
     func testBuildEnrichedCheckoutURL_appendsHeliumIosBundleIdQueryParam() async throws {

--- a/Tests/helium-swiftTests/CtxCompressionTests.swift
+++ b/Tests/helium-swiftTests/CtxCompressionTests.swift
@@ -182,6 +182,46 @@ final class CtxCompressionTests: XCTestCase {
         XCTAssertNotNil(parsed["analytics"])
     }
 
+    func testBuildEnrichedCheckoutURL_emitsCustomPaywallTraitsInCtx() async throws {
+        Helium.lastApiKeyUsed = "test_api_key_for_traits"
+        defer { Helium.lastApiKeyUsed = nil }
+
+        let provider: PaymentProviderConfig = .paddle
+        let entitlements = HeliumPaymentEntitlementsSource(provider: provider)
+        let manager = ExternalWebCheckoutManager(provider: provider, entitlementsSource: entitlements)
+
+        let baseURL = URL(string: "https://bundles-staging.heliumpaywall.com/o/p/bundle.html")!
+        let templateEvent = PurchaseSucceededEvent(
+            productId: "", triggerName: "t", paywallName: "P",
+            storeKitTransactionId: nil, storeKitOriginalTransactionId: nil,
+            paymentProcessor: provider.kind
+        )
+        let analyticsEvent = HeliumAnalyticsManager.shared.buildLoggedEvent(
+            for: templateEvent,
+            paywallSession: PaywallSession(trigger: "t", paywallInfo: nil, fallbackType: .notFallback, presentationContext: .empty)
+        )
+
+        let url = try manager.buildEnrichedCheckoutURL(
+            baseURL: baseURL, analyticsEvent: analyticsEvent,
+            productKey: "pro_x:pri_y", triggerName: "onboarding",
+            successURL: "myapp://ok", cancelURL: "myapp://cancel",
+            introOfferEligible: true, paddleBootstraps: nil,
+            presentationTraits: HeliumUserTraits(["plan": "gold", "trigger": "overridden"])
+        )
+
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let fragment = try XCTUnwrap(components.fragment)
+        let compressed = try XCTUnwrap(base64URLDecode(String(fragment.dropFirst("ctx=".count))))
+        let decompressed = try decompressWithAppleZlib(compressed, originalSize: 8192)
+        let parsed = try XCTUnwrap(JSONSerialization.jsonObject(with: decompressed) as? [String: Any])
+
+        let traits = try XCTUnwrap(parsed["customPaywallTraits"] as? [String: Any],
+                                   "ctx must carry customPaywallTraits")
+        XCTAssertEqual(traits["plan"] as? String, "gold")
+        // Presentation traits win on key conflicts, including the default "trigger".
+        XCTAssertEqual(traits["trigger"] as? String, "overridden")
+    }
+
     func testBuildEnrichedCheckoutURL_appendsHeliumIosBundleIdQueryParam() async throws {
         Helium.lastApiKeyUsed = "test_api_key_for_bundle_id"
         defer { Helium.lastApiKeyUsed = nil }


### PR DESCRIPTION
## What

The in-app web bundle injects `customPaywallTraits` (trigger + identified user traits + presentation traits), but the external browser checkout ctx did not carry them. This adds them so a paywall opened in the external browser reads the exact same traits it would in-app.

Linear: [HEL-6790](https://linear.app/tryhelium/issue/HEL-6790/ios-a2w-paywall-traits)

## How

- **Shared assembly** — extracted `HeliumUserTraits.forPaywall(triggerName:presentationTraits:)` so the in-app path (`DynamicWebView`) and the checkout ctx (`ExternalWebCheckoutManager`) build the traits identically (trigger → user traits → presentation traits, latter wins on conflicts).
- **Display-time capture, sticky per session** — `DynamicWebView` resolves `dynamicPaywallTraits ?? session` at inject time (`onAppear`) and stores it on the per-session `HeliumActionsDelegate`. The purchase path threads that snapshot through `handlePurchase` → `startCheckoutFlow` → `buildEnrichedCheckoutURL`. This fixes the exact off-screen-construction case the `heliumDynamicPaywallTraits` environment key was created for (the frozen `PaywallSession` copy can lag), extending it to the checkout path. Not live-update: it's frozen at display and re-captured only on webview reload (where inject and checkout move together).
- **Feature flagged** — the ctx key is emitted only when the server-driven `webCheckoutPaywallTraits` flag is on (off by default). Lets the SDK ship ahead of the web checkout bundle's support and acts as a kill switch. The internal plumbing stays unconditional.

## Notes

- Purely additive: new params are all defaulted; when the flag is off, ctx is byte-for-byte unchanged. The delegate carries a `?? session` safety net for any path that never injects.
- ctx is deflate-compressed into the URL fragment, so overlap with the analytics traits compresses away.

## Tests

- `testBuildEnrichedCheckoutURL_emitsCustomPaywallTraitsInCtx` — traits present + presentation-wins-on-conflict, flag on.
- `testBuildEnrichedCheckoutURL_omitsCustomPaywallTraitsWhenFlagOff` — key absent when flag off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches purchase and external checkout context plumbing; behavior is additive and flag-gated, but wrong traits could affect personalized pricing/messaging in browser checkout.
> 
> **Overview**
> Aligns **external browser checkout** with in-app paywalls by carrying the same **`customPaywallTraits`** in the compressed checkout URL `ctx`, gated by the server flag **`webCheckoutPaywallTraits`** (off by default).
> 
> Trait assembly moves to **`HeliumUserTraits.forPaywall`**, used when the webview injects context and when checkout builds `ctx`. On paywall display, **`DynamicWebView`** resolves traits (including live `dynamicPaywallTraits`), injects them, and **freezes** the snapshot on **`HeliumActionsDelegate`** via **`setResolvedPaywallTraits`**. **`makePurchase`** passes that snapshot through **`handlePurchase`** into Stripe/Paddle **`startCheckoutFlow`** → **`buildEnrichedCheckoutURL`**. If the freeze is missing, the SDK **rebuilds** traits from the session and emits **`PaywallTraitsFreezeMissingAtMakePurchase`**.
> 
> Tests cover flag on/off, merge precedence, JSON typing, and display-time freeze vs later identity changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeb6868ebcff9c9f17741848ad85fa04f832e45d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External web checkout now receives the same paywall presentation traits shown in-app.
  * Custom paywall traits can be included in checkout context to keep personalized pricing and messaging consistent.
  * Presentation-specific trait values take precedence over default values.
  * Support can be enabled progressively as web checkout updates roll out.

* **Bug Fixes**
  * Improved consistency between in-app paywalls and browser-based checkout flows.
  * Ensured purchase processing uses the resolved traits displayed during paywall presentation.
  * Added monitoring for cases where checkout traits cannot be retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->