### PR TITLE
Attribute paywall previews to the previewed paywall identity

### DIFF
--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
@@ -17,6 +17,8 @@ struct HeliumControlPanelResponse: Codable {
 struct HeliumPaywallPreviewEntry: Codable, Identifiable {
     let paywallUuid: String
     let paywallName: String
+    let paywallTemplateName: String?
+    let paywallId: Int?
     let isWeb: Bool?
     let versions: [HeliumPaywallPreviewVersion]
     let secondTry: HeliumPaywallPreviewSecondTry?
@@ -44,6 +46,8 @@ struct HeliumPaywallPreviewEntry: Codable, Identifiable {
 struct HeliumPaywallPreviewSecondTry: Codable {
     let paywallUuid: String
     let paywallName: String
+    let paywallTemplateName: String?
+    let paywallId: Int?
     /// "published" when the second try paywall is live; "draft" when it has never been
     /// published, in which case real users do not see it until the paywall is published.
     /// Optional so a malformed entry can't fail decoding the whole preview list.

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
@@ -418,6 +418,11 @@ struct HeliumControlPanelView: View {
                     productIdsStripeWeb: version.webStripeProductIds ?? [],
                     webPaywallBundleUrl: version.webPaywallBundleUrl,
                     shouldEnableScroll: version.shouldEnableScroll,
+                    identity: HeliumFetchedConfigManager.PreviewPaywallIdentity(
+                        paywallId: paywall.paywallId,
+                        paywallUuid: paywall.paywallUuid,
+                        templateName: paywall.paywallTemplateName ?? paywall.paywallName
+                    ),
                     secondTry: secondTryBundle
                 )
 
@@ -457,7 +462,12 @@ struct HeliumControlPanelView: View {
                 productIds: secondTry.productIds ?? [],
                 productIdsStripe: secondTry.stripeProductIds ?? [],
                 productIdsPaddle: secondTry.paddleProductIds ?? [],
-                shouldEnableScroll: secondTry.shouldEnableScroll
+                shouldEnableScroll: secondTry.shouldEnableScroll,
+                identity: HeliumFetchedConfigManager.PreviewPaywallIdentity(
+                    paywallId: secondTry.paywallId,
+                    paywallUuid: secondTry.paywallUuid,
+                    templateName: secondTry.paywallTemplateName ?? secondTry.paywallName
+                )
             )
         } catch {
             HeliumLogger.log(.warn, category: .ui, "[HeliumControlPanel] Failed to load second try bundle for preview", metadata: [

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -1101,6 +1101,12 @@ public class HeliumFetchedConfigManager {
         trigger == HELIUM_PREVIEW_TRIGGER || trigger == HELIUM_PREVIEW_SECOND_TRY_TRIGGER
     }
 
+    struct PreviewPaywallIdentity {
+        let paywallId: Int?
+        let paywallUuid: String
+        let templateName: String
+    }
+
     /// The bundle and products for a preview's second try paywall, resolved by the control
     /// panel before the preview presents.
     struct PreviewSecondTryBundle {
@@ -1111,6 +1117,7 @@ public class HeliumFetchedConfigManager {
         let productIdsStripe: [String]
         let productIdsPaddle: [String]
         let shouldEnableScroll: Bool?
+        var identity: PreviewPaywallIdentity? = nil
     }
 
     /// True when a bundled default fallback paywall is available to preview on this device.
@@ -1158,6 +1165,7 @@ public class HeliumFetchedConfigManager {
         productIdsStripeWeb: [String],
         webPaywallBundleUrl: String? = nil,
         shouldEnableScroll: Bool? = nil,
+        identity: PreviewPaywallIdentity? = nil,
         secondTry: PreviewSecondTryBundle? = nil
     ) throws {
         // Read-modify-write under the lock, so a fetch landing mid-update is not clobbered by the
@@ -1178,6 +1186,7 @@ public class HeliumFetchedConfigManager {
                 productIdsStripeWeb: productIdsStripeWeb,
                 webPaywallBundleUrl: webPaywallBundleUrl,
                 shouldEnableScroll: shouldEnableScroll,
+                identity: identity,
                 secondTry: secondTry
             )
             stored = config
@@ -1191,6 +1200,7 @@ public class HeliumFetchedConfigManager {
                 clonedFrom: sourceTrigger,
                 bundleUrl: bundleUrl,
                 shouldEnableScroll: shouldEnableScroll,
+                identity: identity,
                 secondTry: secondTry
             )
         }
@@ -1212,6 +1222,7 @@ public class HeliumFetchedConfigManager {
         productIdsStripeWeb: [String],
         webPaywallBundleUrl: String?,
         shouldEnableScroll: Bool?,
+        identity: PreviewPaywallIdentity?,
         secondTry: PreviewSecondTryBundle?
     ) throws -> String {
         guard let sourceTrigger = config.triggerToPaywalls.keys
@@ -1231,7 +1242,8 @@ public class HeliumFetchedConfigManager {
             productIdsPaddleWeb: productIdsPaddleWeb,
             productIdsStripeWeb: productIdsStripeWeb,
             webPaywallBundleUrl: webPaywallBundleUrl,
-            shouldEnableScroll: shouldEnableScroll
+            shouldEnableScroll: shouldEnableScroll,
+            identity: identity
         )
 
         // A second try entry from an earlier preview must not survive into a preview of a
@@ -1246,7 +1258,8 @@ public class HeliumFetchedConfigManager {
                 productIdsPaddleWeb: [],
                 productIdsStripeWeb: [],
                 webPaywallBundleUrl: nil,
-                shouldEnableScroll: secondTry.shouldEnableScroll
+                shouldEnableScroll: secondTry.shouldEnableScroll,
+                identity: secondTry.identity
             )
         } else {
             config.triggerToPaywalls.removeValue(forKey: HELIUM_PREVIEW_SECOND_TRY_TRIGGER)
@@ -1274,9 +1287,16 @@ public class HeliumFetchedConfigManager {
         productIdsPaddleWeb: [String],
         productIdsStripeWeb: [String],
         webPaywallBundleUrl: String?,
-        shouldEnableScroll: Bool?
+        shouldEnableScroll: Bool?,
+        identity: PreviewPaywallIdentity?
     ) throws -> HeliumPaywallInfo {
         var previewPaywallInfo = donorPaywallInfo
+
+        if let identity {
+            previewPaywallInfo.paywallID = identity.paywallId ?? 0
+            previewPaywallInfo.paywallUUID = identity.paywallUuid
+            previewPaywallInfo.paywallTemplateName = identity.templateName
+        }
 
         // A paywall's bundle URL is resolved from this nested config before any other field, so a
         // donor URL left in place here would win over the preview's own.
@@ -1325,17 +1345,18 @@ public class HeliumFetchedConfigManager {
         clonedFrom sourceTrigger: String,
         bundleUrl: String,
         shouldEnableScroll: Bool?,
+        identity: PreviewPaywallIdentity?,
         secondTry: PreviewSecondTryBundle?
     ) -> JSON {
         var configJSON = configJSON
         let sourceJSON = configJSON["triggerToPaywalls"][sourceTrigger]
         configJSON["triggerToPaywalls"][HELIUM_PREVIEW_TRIGGER] = previewEntryJSON(
-            clonedFrom: sourceJSON, bundleUrl: bundleUrl, shouldEnableScroll: shouldEnableScroll
+            clonedFrom: sourceJSON, bundleUrl: bundleUrl, shouldEnableScroll: shouldEnableScroll, identity: identity
         )
 
         if let secondTry {
             configJSON["triggerToPaywalls"][HELIUM_PREVIEW_SECOND_TRY_TRIGGER] = previewEntryJSON(
-                clonedFrom: sourceJSON, bundleUrl: secondTry.bundleUrl, shouldEnableScroll: secondTry.shouldEnableScroll
+                clonedFrom: sourceJSON, bundleUrl: secondTry.bundleUrl, shouldEnableScroll: secondTry.shouldEnableScroll, identity: secondTry.identity
             )
         } else if var triggers = configJSON["triggerToPaywalls"].dictionaryObject,
                   triggers.removeValue(forKey: HELIUM_PREVIEW_SECOND_TRY_TRIGGER) != nil {
@@ -1344,10 +1365,20 @@ public class HeliumFetchedConfigManager {
         return configJSON
     }
 
-    private static func previewEntryJSON(clonedFrom sourceJSON: JSON, bundleUrl: String, shouldEnableScroll: Bool?) -> JSON {
+    private static func previewEntryJSON(
+        clonedFrom sourceJSON: JSON,
+        bundleUrl: String,
+        shouldEnableScroll: Bool?,
+        identity: PreviewPaywallIdentity?
+    ) -> JSON {
         var entryJSON = sourceJSON
         entryJSON["resolvedConfig"]["baseStack"]["componentProps"]["bundleURL"] = JSON(bundleUrl)
         entryJSON["resolvedConfig"]["baseStack"]["componentProps"]["shouldEnableScroll"] = JSON(shouldEnableScroll ?? true)
+        if let identity {
+            entryJSON["paywallID"] = JSON(identity.paywallId ?? 0)
+            entryJSON["paywallUUID"] = JSON(identity.paywallUuid)
+            entryJSON["paywallTemplateName"] = JSON(identity.templateName)
+        }
         return entryJSON
     }
 }

--- a/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
+++ b/Sources/Helium/HeliumCore/HeliumFetchedConfig.swift
@@ -1200,7 +1200,6 @@ public class HeliumFetchedConfigManager {
                 clonedFrom: sourceTrigger,
                 bundleUrl: bundleUrl,
                 shouldEnableScroll: shouldEnableScroll,
-                identity: identity,
                 secondTry: secondTry
             )
         }
@@ -1345,18 +1344,17 @@ public class HeliumFetchedConfigManager {
         clonedFrom sourceTrigger: String,
         bundleUrl: String,
         shouldEnableScroll: Bool?,
-        identity: PreviewPaywallIdentity?,
         secondTry: PreviewSecondTryBundle?
     ) -> JSON {
         var configJSON = configJSON
         let sourceJSON = configJSON["triggerToPaywalls"][sourceTrigger]
         configJSON["triggerToPaywalls"][HELIUM_PREVIEW_TRIGGER] = previewEntryJSON(
-            clonedFrom: sourceJSON, bundleUrl: bundleUrl, shouldEnableScroll: shouldEnableScroll, identity: identity
+            clonedFrom: sourceJSON, bundleUrl: bundleUrl, shouldEnableScroll: shouldEnableScroll
         )
 
         if let secondTry {
             configJSON["triggerToPaywalls"][HELIUM_PREVIEW_SECOND_TRY_TRIGGER] = previewEntryJSON(
-                clonedFrom: sourceJSON, bundleUrl: secondTry.bundleUrl, shouldEnableScroll: secondTry.shouldEnableScroll, identity: secondTry.identity
+                clonedFrom: sourceJSON, bundleUrl: secondTry.bundleUrl, shouldEnableScroll: secondTry.shouldEnableScroll
             )
         } else if var triggers = configJSON["triggerToPaywalls"].dictionaryObject,
                   triggers.removeValue(forKey: HELIUM_PREVIEW_SECOND_TRY_TRIGGER) != nil {
@@ -1365,20 +1363,10 @@ public class HeliumFetchedConfigManager {
         return configJSON
     }
 
-    private static func previewEntryJSON(
-        clonedFrom sourceJSON: JSON,
-        bundleUrl: String,
-        shouldEnableScroll: Bool?,
-        identity: PreviewPaywallIdentity?
-    ) -> JSON {
+    private static func previewEntryJSON(clonedFrom sourceJSON: JSON, bundleUrl: String, shouldEnableScroll: Bool?) -> JSON {
         var entryJSON = sourceJSON
         entryJSON["resolvedConfig"]["baseStack"]["componentProps"]["bundleURL"] = JSON(bundleUrl)
         entryJSON["resolvedConfig"]["baseStack"]["componentProps"]["shouldEnableScroll"] = JSON(shouldEnableScroll ?? true)
-        if let identity {
-            entryJSON["paywallID"] = JSON(identity.paywallId ?? 0)
-            entryJSON["paywallUUID"] = JSON(identity.paywallUuid)
-            entryJSON["paywallTemplateName"] = JSON(identity.templateName)
-        }
         return entryJSON
     }
 }

--- a/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
+++ b/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
@@ -52,6 +52,7 @@ final class PreviewTriggerConfigTests: XCTestCase {
         productIdsStripeWeb: [String] = [],
         webPaywallBundleUrl: String? = nil,
         shouldEnableScroll: Bool? = nil,
+        identity: HeliumFetchedConfigManager.PreviewPaywallIdentity? = nil,
         secondTry: HeliumFetchedConfigManager.PreviewSecondTryBundle? = nil
     ) throws {
         try HeliumFetchedConfigManager.shared.setPreviewTriggerConfig(
@@ -65,12 +66,14 @@ final class PreviewTriggerConfigTests: XCTestCase {
             productIdsStripeWeb: productIdsStripeWeb,
             webPaywallBundleUrl: webPaywallBundleUrl,
             shouldEnableScroll: shouldEnableScroll,
+            identity: identity,
             secondTry: secondTry
         )
     }
 
     private func makeSecondTryBundle(
-        shouldEnableScroll: Bool? = nil
+        shouldEnableScroll: Bool? = nil,
+        identity: HeliumFetchedConfigManager.PreviewPaywallIdentity? = nil
     ) -> HeliumFetchedConfigManager.PreviewSecondTryBundle {
         HeliumFetchedConfigManager.PreviewSecondTryBundle(
             bundleId: "secondtry789",
@@ -79,7 +82,8 @@ final class PreviewTriggerConfigTests: XCTestCase {
             productIds: ["secondtry.product"],
             productIdsStripe: ["secondtry_stripe:price_2"],
             productIdsPaddle: [],
-            shouldEnableScroll: shouldEnableScroll
+            shouldEnableScroll: shouldEnableScroll,
+            identity: identity
         )
     }
 
@@ -177,6 +181,79 @@ final class PreviewTriggerConfigTests: XCTestCase {
         let donorBaseStack = donorResolved?["baseStack"] as? [String: Any]
         let donorProps = donorBaseStack?["componentProps"] as? [String: Any]
         XCTAssertEqual(donorProps?["shouldEnableScroll"] as? Bool, false)
+    }
+
+    func testPreviewCarriesPreviewedPaywallIdentity() throws {
+        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
+
+        try setPreviewConfig(identity: HeliumFetchedConfigManager.PreviewPaywallIdentity(
+            paywallId: 42,
+            paywallUuid: "f3e96335-f7df-4f28-b439-9506d37c793e",
+            templateName: "Previewed Paywall"
+        ))
+
+        XCTAssertEqual(previewInfo?.paywallID, 42)
+        XCTAssertEqual(previewInfo?.paywallUUID, "f3e96335-f7df-4f28-b439-9506d37c793e")
+        XCTAssertEqual(previewInfo?.paywallTemplateName, "Previewed Paywall")
+    }
+
+    func testPreviewIdentityWithoutIntIdUsesZero() throws {
+        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
+
+        try setPreviewConfig(identity: HeliumFetchedConfigManager.PreviewPaywallIdentity(
+            paywallId: nil,
+            paywallUuid: "f3e96335-f7df-4f28-b439-9506d37c793e",
+            templateName: "Previewed Paywall"
+        ))
+
+        XCTAssertEqual(previewInfo?.paywallID, 0)
+    }
+
+    func testPreviewWithoutIdentityKeepsDonorIdentity() throws {
+        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
+
+        try setPreviewConfig()
+
+        XCTAssertEqual(previewInfo?.paywallID, 1)
+        XCTAssertEqual(previewInfo?.paywallTemplateName, "donor_paywall")
+    }
+
+    func testJsonMirrorCarriesPreviewedPaywallIdentity() throws {
+        let config = makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()])
+        let configJSON = try JSON(data: JSONEncoder().encode(config))
+        injectConfig(config, json: configJSON)
+
+        try setPreviewConfig(identity: HeliumFetchedConfigManager.PreviewPaywallIdentity(
+            paywallId: 42,
+            paywallUuid: "f3e96335-f7df-4f28-b439-9506d37c793e",
+            templateName: "Previewed Paywall"
+        ))
+
+        let entryJSON = HeliumFetchedConfigManager.shared.fetchedConfigJSON?["triggerToPaywalls"][previewTrigger]
+        XCTAssertEqual(entryJSON?["paywallID"].int, 42)
+        XCTAssertEqual(entryJSON?["paywallUUID"].string, "f3e96335-f7df-4f28-b439-9506d37c793e")
+        XCTAssertEqual(entryJSON?["paywallTemplateName"].string, "Previewed Paywall")
+    }
+
+    func testSecondTryCarriesItsOwnIdentity() throws {
+        injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
+
+        try setPreviewConfig(
+            identity: HeliumFetchedConfigManager.PreviewPaywallIdentity(
+                paywallId: 42,
+                paywallUuid: "f3e96335-f7df-4f28-b439-9506d37c793e",
+                templateName: "Previewed Paywall"
+            ),
+            secondTry: makeSecondTryBundle(identity: HeliumFetchedConfigManager.PreviewPaywallIdentity(
+                paywallId: 7,
+                paywallUuid: "aa11bb22-cc33-4444-9555-666677778888",
+                templateName: "Previewed Second Try"
+            ))
+        )
+
+        XCTAssertEqual(secondTryInfo?.paywallID, 7)
+        XCTAssertEqual(secondTryInfo?.paywallUUID, "aa11bb22-cc33-4444-9555-666677778888")
+        XCTAssertEqual(secondTryInfo?.paywallTemplateName, "Previewed Second Try")
     }
 
     func testPreviewClearsForceShowFallback() throws {
@@ -467,6 +544,56 @@ final class PreviewTriggerConfigTests: XCTestCase {
         XCTAssertNil(response.paywalls[0].versions[0].shouldEnableScroll)
         XCTAssertNil(response.paywalls[0].secondTry)
         XCTAssertFalse(response.paywalls[0].isWebPaywall)
+        XCTAssertNil(response.paywalls[0].paywallTemplateName)
+        XCTAssertNil(response.paywalls[0].paywallId)
+    }
+
+    func testDecodesPreviewedPaywallIdentityFields() throws {
+        let json = """
+        {
+          "productIds": [],
+          "paywalls": [
+            {
+              "paywallUuid": "f3e96335-f7df-4f28-b439-9506d37c793e",
+              "paywallName": "Premium",
+              "paywallTemplateName": "Premium",
+              "paywallId": 42,
+              "isWeb": false,
+              "versions": [],
+              "secondTry": {
+                "paywallUuid": "aa11bb22-cc33-4444-9555-666677778888",
+                "paywallName": "Premium Offer",
+                "paywallTemplateName": "Premium Offer",
+                "paywallId": 7,
+                "versionStatus": "published",
+                "bundleUrl": "https://bundles-staging.heliumpaywall.com/x/bundle_2nd.html",
+                "productIds": [],
+                "stripeProductIds": [],
+                "paddleProductIds": []
+              }
+            },
+            {
+              "paywallUuid": "1c8d6e2b-7777-4888-9999-000011112222",
+              "paywallName": "Legacy",
+              "paywallTemplateName": "Legacy",
+              "paywallId": null,
+              "isWeb": false,
+              "versions": []
+            }
+          ]
+        }
+        """
+        let response = try JSONDecoder().decode(
+            HeliumControlPanelResponse.self,
+            from: Data(json.utf8)
+        )
+
+        XCTAssertEqual(response.paywalls[0].paywallTemplateName, "Premium")
+        XCTAssertEqual(response.paywalls[0].paywallId, 42)
+        XCTAssertEqual(response.paywalls[0].secondTry?.paywallTemplateName, "Premium Offer")
+        XCTAssertEqual(response.paywalls[0].secondTry?.paywallId, 7)
+        XCTAssertEqual(response.paywalls[1].paywallTemplateName, "Legacy")
+        XCTAssertNil(response.paywalls[1].paywallId)
     }
 
     func testDecodesSecondTryEntry() throws {

--- a/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
+++ b/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
@@ -218,23 +218,6 @@ final class PreviewTriggerConfigTests: XCTestCase {
         XCTAssertEqual(previewInfo?.paywallTemplateName, "donor_paywall")
     }
 
-    func testJsonMirrorCarriesPreviewedPaywallIdentity() throws {
-        let config = makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()])
-        let configJSON = try JSON(data: JSONEncoder().encode(config))
-        injectConfig(config, json: configJSON)
-
-        try setPreviewConfig(identity: HeliumFetchedConfigManager.PreviewPaywallIdentity(
-            paywallId: 42,
-            paywallUuid: "f3e96335-f7df-4f28-b439-9506d37c793e",
-            templateName: "Previewed Paywall"
-        ))
-
-        let entryJSON = HeliumFetchedConfigManager.shared.fetchedConfigJSON?["triggerToPaywalls"][previewTrigger]
-        XCTAssertEqual(entryJSON?["paywallID"].int, 42)
-        XCTAssertEqual(entryJSON?["paywallUUID"].string, "f3e96335-f7df-4f28-b439-9506d37c793e")
-        XCTAssertEqual(entryJSON?["paywallTemplateName"].string, "Previewed Paywall")
-    }
-
     func testSecondTryCarriesItsOwnIdentity() throws {
         injectConfig(makeTestConfig(triggers: ["a_trigger": makeDonorPaywallInfo()]))
 


### PR DESCRIPTION
## What

Consumes the previewed paywall identity now exposed by the paywall previews response (bandit-server-lite-phoenix #147) so preview analytics attribute to the paywall actually being previewed.

The preview trigger config is built by cloning a donor trigger's paywall info, so preview events carried the donor's `paywallID`, `paywallUUID`, and `paywallTemplateName`. Now:

- `HeliumPaywallPreviewEntry` / `HeliumPaywallPreviewSecondTry` decode `paywallTemplateName` and `paywallId`.
- A new `PreviewPaywallIdentity` is threaded through `setPreviewTriggerConfig` and applied to the cloned entry in both the typed config and the JSON mirror. The second try entry carries its own identity.
- A null server `paywallId` becomes 0 rather than leaking the donor's ID. When no identity is provided (older server), behavior is unchanged.
- The control panel passes the entry's identity, using `paywallName` when the server omits the template name.

## Testing

- Six new tests in `PreviewTriggerConfigTests` (typed override, JSON mirror, second try identity, nil id, no identity, response decoding); `PreviewTriggerConfigTests` + `FallbackPreviewTests` pass on iPhone 17 Pro simulator (45/45).
- SDK-side manual test against a bandit running #147: pending device run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to dev preview trigger setup and analytics metadata; backward compatible when the server omits identity fields.
> 
> **Overview**
> **Paywall previews** no longer inherit the donor trigger’s `paywallID`, UUID, and template name when the control panel builds the synthetic preview config.
> 
> The previews API models now decode optional **`paywallTemplateName`** and **`paywallId`** on main and second-try entries. The control panel passes a new **`PreviewPaywallIdentity`** into `setPreviewTriggerConfig`, which **`previewEntry`** applies on the cloned `HeliumPaywallInfo` (main preview and separate second-try identity). Missing template name falls back to **`paywallName`**; a null server id becomes **`0`** instead of keeping the donor id. If no identity is supplied, behavior stays the same as before.
> 
> Tests cover identity override, nil id, donor fallback, second-try identity, and response decoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d8f5157cedb5b1239f25364be44bc300b22730f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Previewed paywalls now retain their ID, UUID, and template name across standard preview and second-try experiences.
  - Paywall identity details are displayed consistently when available, including previews without an assigned ID.

- **Bug Fixes**
  - Improved paywall identification throughout preview flows.
  - Preserved existing identity details when no replacement information is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->