### PR TITLE
Add isEntitledOverride to PaywallPresentationConfig

### DIFF
--- a/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
@@ -668,3 +668,12 @@ actor HeliumEntitlementsManager {
     }
 }
 
+
+extension PaywallPresentationConfig {
+    func resolveIsEntitled(trigger: String) async -> Bool? {
+        if let isEntitledOverride {
+            return await isEntitledOverride()
+        }
+        return await Helium.entitlements.hasEntitlementForPaywall(trigger: trigger)
+    }
+}

--- a/Sources/Helium/HeliumCore/HeliumPaywall.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywall.swift
@@ -127,7 +127,7 @@ public struct HeliumPaywall<PaywallNotShownView: View>: View {
         .task(id: state) {
             // Handle state-specific async work
             if case .checkingEntitlement = state {
-                isEntitled = await Helium.entitlements.hasEntitlementForPaywall(trigger: trigger)
+                isEntitled = await config.resolveIsEntitled(trigger: trigger)
                 // Check if task was cancelled (e.g. by loading budget timeout)
                 guard !Task.isCancelled else { return }
                 transitionState(allowLoadingState: !loadingBudgetExpired)

--- a/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
+++ b/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
@@ -43,7 +43,7 @@ class HeliumPaywallPresenter {
     
     private func paywallEntitlementsCheck(trigger: String, context: PaywallPresentationContext) async -> Bool {
         if context.config.dontShowIfAlreadyEntitled {
-            let skipIt = await Helium.entitlements.hasEntitlementForPaywall(trigger: trigger)
+            let skipIt = await context.config.resolveIsEntitled(trigger: trigger)
             if skipIt == true {
                 handleAlreadyEntitledSkip(trigger: trigger, context: context)
                 return true

--- a/Sources/Helium/HeliumPublic.swift
+++ b/Sources/Helium/HeliumPublic.swift
@@ -486,6 +486,7 @@ public struct PaywallPresentationConfig {
     var presentFromViewController: UIViewController?
     var customPaywallTraits: HeliumUserTraits?
     var dontShowIfAlreadyEntitled: Bool
+    var isEntitledOverride: (() async -> Bool)?
     var presentationStyle: HeliumPresentationStyle?
     var loadingBudget: TimeInterval?
 
@@ -503,12 +504,14 @@ public struct PaywallPresentationConfig {
         presentFromViewController: UIViewController? = nil,
         customPaywallTraits: HeliumUserTraits? = nil,
         dontShowIfAlreadyEntitled: Bool = false,
+        isEntitledOverride: (() async -> Bool)? = nil,
         presentationStyle: HeliumPresentationStyle? = nil,
         loadingBudget: TimeInterval? = nil
     ) {
         self.presentFromViewController = presentFromViewController
         self.customPaywallTraits = customPaywallTraits
         self.dontShowIfAlreadyEntitled = dontShowIfAlreadyEntitled
+        self.isEntitledOverride = isEntitledOverride
         self.presentationStyle = presentationStyle
         self.loadingBudget = loadingBudget
     }


### PR DESCRIPTION
## Summary

Adds an optional `isEntitledOverride` closure to `PaywallPresentationConfig`. When set, it is used in place of the SDK's built-in entitlement check wherever `dontShowIfAlreadyEntitled` applies, letting developers supply their own "is entitled" logic. Defaults to `nil` — zero behavior change when unset.

## Changes

- `PaywallPresentationConfig` gains `isEntitledOverride: (() async -> Bool)? = nil`.
- New internal `resolveIsEntitled(trigger:)` returns the override's result when set, otherwise the existing `Helium.entitlements.hasEntitlementForPaywall` check.
- Both entitlement-check sites go through it: the presenter path (`paywallEntitlementsCheck`) and the embedded view's `checkingEntitlement` state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Custom override logic can wrongly skip or show paywalls when dontShowIfAlreadyEntitled is on, but the feature is opt-in and defaults preserve existing SDK entitlement checks.
> 
> **Overview**
> Adds an optional **`isEntitledOverride`** async closure on **`PaywallPresentationConfig`** so apps can supply custom “already entitled?” logic when **`dontShowIfAlreadyEntitled`** is enabled. When unset (`nil`), behavior is unchanged.
> 
> A new internal **`resolveIsEntitled(trigger:)`** centralizes the decision: run the override if present, otherwise **`Helium.entitlements.hasEntitlementForPaywall`**. Both skip/show paths now use it—the modal presenter’s **`paywallEntitlementsCheck`** and the embedded **`HeliumPaywall`** **`checkingEntitlement`** state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 157d77492d36fbb85e3dfa73318ed289b9155b23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->