### PR TITLE
bump minor version 4.9.0

### DIFF
--- a/Sources/Helium/HeliumCore/BuildConstants.swift
+++ b/Sources/Helium/HeliumCore/BuildConstants.swift
@@ -8,5 +8,5 @@
  */
 public struct BuildConstants {
     /// Current SDK version
-    public static let version = "4.8.0"
+    public static let version = "4.9.0"
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single constant version bump with no logic changes; standard release housekeeping.
> 
> **Overview**
> Bumps the Helium SDK release version from **4.8.0** to **4.9.0** in `BuildConstants.version`, which is the source of truth for package/pod versioning and is expected to trigger the release GitHub Actions workflow described in that file.
> 
> Downstream callers that read `BuildConstants.version` (identity, paywall diagnostics, observability) will report **4.9.0** after this ships; no other code changes are in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7151ded37e132b86d0eef4a2e49dd44041816e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the SDK version to 4.9.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->