### PR TITLE
HEL-6834 Pre-warm entitlements on paywall open; instrument pre-purchase check

### DIFF
--- a/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
+++ b/Sources/Helium/HeliumCore/HeliumEntitlementsManager.swift
@@ -7,6 +7,16 @@
 
 import StoreKit
 
+/// Observability-only detail about how a pre-purchase entitlement check was serviced.
+/// Never affects the entitlement decision.
+struct EntitlementCheckTelemetry {
+    enum CacheState: String {
+        case cold, warm, staleReloaded
+    }
+    let cacheState: CacheState
+    let cacheAgeMs: Int?
+}
+
 actor HeliumEntitlementsManager {
     
     static let shared = HeliumEntitlementsManager()
@@ -79,6 +89,8 @@ actor HeliumEntitlementsManager {
 
     private let entitlementsFileName = "helium_entitlements.json"
     private var cache = EntitlementsCache()
+
+    private var prewarmedSessionIds: Set<String> = []
     private var updateListenerTask: Task<Void, Never>?
     private var debounceTask: Task<Void, Never>?
     private var configDownloadObserver: NSObjectProtocol?
@@ -249,6 +261,23 @@ actor HeliumEntitlementsManager {
     private func getCachedEntitlements() async -> [Transaction] {
         await loadEntitlementsIfNeeded()
         return cache.transactions
+    }
+
+    /// Warms the entitlements cache on paywall open so the pre-purchase check is an in-memory
+    /// read at buy time instead of a StoreKit load on the critical path. No-op when fresh.
+    func prewarmForPurchase(sessionId: String?) async {
+        if let sessionId {
+            if prewarmedSessionIds.count > 200 {
+                prewarmedSessionIds.removeAll(keepingCapacity: true)
+            }
+            prewarmedSessionIds.insert(sessionId)
+        }
+        await loadEntitlementsIfNeeded()
+    }
+
+    func wasPrewarmed(sessionId: String?) -> Bool {
+        guard let sessionId else { return false }
+        return prewarmedSessionIds.contains(sessionId)
     }
     
     // MARK: - Public Methods
@@ -470,7 +499,24 @@ actor HeliumEntitlementsManager {
     /// Note: This checks the exact productId only, not subscription group membership.
     /// Note: StoreKit-only — does not consult third-party payment sources (Stripe, Paddle).
     /// For web-checkout entitlement checks, use the provider's `entitlementsSource` directly.
-    func hasPersonallyPurchased(productId: String) async -> Bool {
+    /// Telemetry is captured before the read so it reflects the cache state the decision was based on.
+    func hasPersonallyPurchasedWithTelemetry(
+        productId: String
+    ) async -> (result: Bool, telemetry: EntitlementCheckTelemetry) {
+        let cacheState: EntitlementCheckTelemetry.CacheState
+        let cacheAgeMs: Int?
+        if let lastLoaded = cache.lastTransactionsLoadedTime {
+            cacheAgeMs = Int(Date().timeIntervalSince(lastLoaded) * 1000)
+            cacheState = cache.needsTransactionsSync(resetInterval: cacheResetInterval) ? .staleReloaded : .warm
+        } else {
+            cacheAgeMs = nil
+            cacheState = .cold
+        }
+        let result = await hasPersonallyPurchased(productId: productId)
+        return (result, EntitlementCheckTelemetry(cacheState: cacheState, cacheAgeMs: cacheAgeMs))
+    }
+
+    private func hasPersonallyPurchased(productId: String) async -> Bool {
         // If transactions haven't loaded yet, use persisted data immediately for faster response
         if cache.lastTransactionsLoadedTime == nil {
             if cache.persistedEntitlements.contains(where: { $0.productID == productId && $0.appearsValid() && $0.isPersonalPurchase }) {

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -65,15 +65,30 @@ class HeliumPaywallDelegateWrapper {
     }
     
     func handlePurchase(productKey: String, triggerName: String, paywallTemplateName: String, paywallSession: PaywallSession, paywallTraits: HeliumUserTraits? = nil) async -> HeliumPaywallTransactionStatus {
-        let hadEntitlementBeforePurchase = await withTimeoutOrNil(milliseconds: 500) {
-            await HeliumEntitlementsManager.shared.hasPersonallyPurchased(productId: productKey)
-        } ?? false
-        
+        let paymentProcessor = HeliumPaymentProcessor.resolve(for: productKey)
+
+        let entitlementCheckStart = Date()
+        let entitlementCheckOutcome = await withTimeoutOrNil(milliseconds: 500) {
+            await HeliumEntitlementsManager.shared.hasPersonallyPurchasedWithTelemetry(productId: productKey)
+        }
+        let hadEntitlementBeforePurchase = entitlementCheckOutcome?.result ?? false
+        HeliumObservabilityManager.shared.track(
+            PrePurchaseEntitlementCheck(
+                productId: productKey,
+                paymentProcessor: paymentProcessor.rawValue,
+                durationMs: msSince(entitlementCheckStart),
+                timedOut: entitlementCheckOutcome == nil,
+                result: hadEntitlementBeforePurchase,
+                cacheState: entitlementCheckOutcome?.telemetry.cacheState.rawValue,
+                cacheAgeMs: entitlementCheckOutcome?.telemetry.cacheAgeMs,
+                prewarmed: await HeliumEntitlementsManager.shared.wasPrewarmed(sessionId: paywallSession.sessionId)
+            ),
+            scope: paywallSession.observabilityScope
+        )
+
         StoreKit1Listener.ensureListening()
 
         let transactionStatus: HeliumPaywallTransactionStatus
-
-        let paymentProcessor = HeliumPaymentProcessor.resolve(for: productKey)
 
         if let simulated = await Helium.testing.simulatedPurchaseStatusIfActive(productId: productKey) {
             transactionStatus = simulated
@@ -287,7 +302,14 @@ class HeliumPaywallDelegateWrapper {
             metadata["fallback"] = "true"
         }
         HeliumLogger.log(.info, category: .events, "Helium event - \(event.eventName)", metadata: metadata)
-        
+
+        if event is PaywallOpenEvent {
+            let prewarmSessionId = overridePaywallSessionId ?? paywallSession?.sessionId
+            Task {
+                await HeliumEntitlementsManager.shared.prewarmForPurchase(sessionId: prewarmSessionId)
+            }
+        }
+
         if let openFailEvent = event as? PaywallOpenFailedEvent {
             logPaywallUnavailable(
                 trigger: openFailEvent.triggerName,

--- a/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
+++ b/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
@@ -84,6 +84,37 @@ struct EndpointCallTelemetry {
     }
 }
 
+// MARK: - Purchase flow
+
+/// Timing and cache state for the pre-purchase already-entitled check. `timedOut` matters
+/// most: it forces a default result that can mis-attribute a conversion.
+struct PrePurchaseEntitlementCheck: HeliumObservabilityEvent {
+    let productId: String
+    let paymentProcessor: String
+    let durationMs: Int
+    let timedOut: Bool
+    let result: Bool
+    /// nil when the check timed out before reporting.
+    let cacheState: String?
+    let cacheAgeMs: Int?
+    let prewarmed: Bool
+
+    var name: String { "pre_purchase_entitlement_check" }
+    var properties: [String: Any] {
+        var p: [String: Any] = [
+            "productId": productId,
+            "paymentProcessor": paymentProcessor,
+            "durationMs": durationMs,
+            "timedOut": timedOut,
+            "result": result,
+            "prewarmed": prewarmed,
+        ]
+        if let cacheState { p["cacheState"] = cacheState }
+        if let cacheAgeMs { p["cacheAgeMs"] = cacheAgeMs }
+        return p
+    }
+}
+
 // MARK: - Paddle prefetch
 
 struct PaddlePrefetchStarted: HeliumObservabilityEvent {


### PR DESCRIPTION
🤖 Drafted with Claude Code

## Summary

Two changes on the RevenueCat / App Store purchase path, both aimed at the pre-purchase already-entitled check that runs before `makePurchase`:

- **Pre-warm on paywall open** — when a paywall opens, warm the entitlements cache via the existing `loadEntitlementsIfNeeded()` (respects the freshness window, so it's a no-op when already fresh). This moves the potential StoreKit load off the buy-time critical path so the awaited pre-purchase check is a fast in-memory read. Ordering and the entitlement decision are unchanged.
- **Observability** — new `pre_purchase_entitlement_check` event capturing `durationMs`, `timedOut` (the 500ms guard firing, which forces a default and can mis-attribute a conversion), `result`, `cacheState`, `cacheAgeMs`, and `prewarmed`.

## Why

A customer reported latency between tapping buy and the Apple Pay sheet appearing. Tracing the flow: once the product is resolved, the RC delegate's `makePurchase` hands it straight to StoreKit with no extra network work, so the main SDK-owned cost before the sheet is the up-to-500ms already-entitled check on a cold/stale entitlements cache. This warms that cache ahead of time and instruments it so we can measure real durations and timeout rates — the timeout rate also surfaces potential conversion mis-attribution, since a timeout defaults the check to "not entitled".

## Notes

- No feature flag: the pre-warm is a subset of existing behavior moved earlier, with a natural kill-switch via the observability pipeline.
- No changes to customer-facing purchase events (`PurchaseSucceeded` / `PurchaseAlreadyEntitled` untouched).
- `hasPersonallyPurchased` is now `private` — its only caller is the new telemetry-returning variant.
- Build not run locally; worth a CI/Xcode build to confirm generic inference on the `withTimeoutOrNil` closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the purchase critical path and entitlement cache timing, though entitlement decisions and timeout fallback behavior are unchanged; mainly latency and observability.
> 
> **Overview**
> Reduces buy-time latency on the App Store path by **pre-warming** the StoreKit entitlements cache when a paywall opens (`prewarmForPurchase` → existing `loadEntitlementsIfNeeded`, no-op if already fresh), so the awaited “already entitled?” check at purchase is more often an in-memory read. Session IDs are tracked (capped set) so telemetry can report whether the session was prewarmed.
> 
> The pre-purchase check now emits **`pre_purchase_entitlement_check`** observability: duration, 500ms timeout, result, cache state (`cold` / `warm` / `staleReloaded`), cache age, payment processor, and prewarmed flag. Entitlement logic is unchanged—`hasPersonallyPurchased` is private; callers use `hasPersonallyPurchasedWithTelemetry`, which records cache metadata **before** the read without affecting the boolean outcome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 854440b6b90b78ee03c764d2ade7f4b2106c56df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pre-purchase entitlement checks with cache status, timing, timeout, and result details.
  * Added entitlement prewarming for paywall sessions to help prepare purchase-related information in advance.
  * Added observability data for tracking whether entitlement information was prewarmed and how checks performed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->