### PR TITLE
Block direct web paywall previews in the control panel

### DIFF
--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
@@ -16,13 +16,14 @@ struct HeliumControlPanelResponse: Codable {
     func linkedInAppPaywall(for webPaywall: HeliumPaywallPreviewEntry) -> HeliumPaywallPreviewEntry? {
         let webBundleUrls = Set(webPaywall.versions.compactMap(\.bundleUrl))
         guard !webBundleUrls.isEmpty else { return nil }
-        return paywalls.first { candidate in
+        let candidates = paywalls.filter { candidate in
             !candidate.isWebPaywall
                 && candidate.versions.contains { version in
                     version.isApp2webCapable
                         && (version.webPaywallBundleUrl.map(webBundleUrls.contains) ?? false)
                 }
         }
+        return candidates.count == 1 ? candidates.first : nil
     }
 }
 

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
@@ -12,6 +12,18 @@ struct HeliumControlPanelResponse: Codable {
     /// A verified US-California device: real checkout is allowed, but showing the CA
     /// consent modal is a hard precondition for a Paddle purchase. Absent reads false.
     let forcePaddleCaConsentModal: Bool?
+
+    func linkedInAppPaywall(for webPaywall: HeliumPaywallPreviewEntry) -> HeliumPaywallPreviewEntry? {
+        let webBundleUrls = Set(webPaywall.versions.compactMap(\.bundleUrl))
+        guard !webBundleUrls.isEmpty else { return nil }
+        return paywalls.first { candidate in
+            !candidate.isWebPaywall
+                && candidate.versions.contains { version in
+                    version.isApp2webCapable
+                        && (version.webPaywallBundleUrl.map(webBundleUrls.contains) ?? false)
+                }
+        }
+    }
 }
 
 struct HeliumPaywallPreviewEntry: Codable, Identifiable {
@@ -24,7 +36,7 @@ struct HeliumPaywallPreviewEntry: Codable, Identifiable {
     let secondTry: HeliumPaywallPreviewSecondTry?
     var id: String { paywallUuid }
 
-    /// Web paywalls render in a browser, not in-app; previews open them there.
+    /// Web paywalls render in a browser, not in-app.
     var isWebPaywall: Bool {
         if let isWeb { return isWeb }
         return versions.contains { version in
@@ -39,6 +51,11 @@ struct HeliumPaywallPreviewEntry: Codable, Identifiable {
         "bundles.clickthrough.to",
         "bundles-staging.clickthrough.to",
     ]
+
+    static func directPreviewBlockedMessage(linkedPaywallName: String?) -> String {
+        let target = linkedPaywallName.map { "\"\($0)\"" } ?? "the in-app paywall linked to it"
+        return "Web paywalls can't be previewed directly. Open \(target) instead; its purchase action kicks out to this web paywall so you can test the full App2Web flow."
+    }
 }
 
 /// The resolved second try paywall served with a preview entry. Paywall-level, not per-version:
@@ -96,6 +113,11 @@ enum HeliumControlPanelState {
     var isLoading: Bool {
         if case .loading = self { return true }
         return false
+    }
+
+    var loadedResponse: HeliumControlPanelResponse? {
+        if case .loaded(let response) = self { return response }
+        return nil
     }
 }
 

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
@@ -8,7 +8,7 @@ struct HeliumControlPanelView: View {
     @State private var previewTask: Task<Void, Never>?
     @State private var searchText: String = ""
     @State private var paywallLoadError: String? = nil
-    @State private var pendingWebPreviewURL: URL? = nil
+    @State private var webPreviewNotice: String? = nil
     @State private var pendingConfiguration: HeliumPreviewConfigurationRequest? = nil
     /// Launch deferred until the configuration sheet has finished dismissing, so a preview is never
     /// presented on top of a sheet that is still on its way out.
@@ -75,20 +75,13 @@ struct HeliumControlPanelView: View {
         } message: {
             Text(paywallLoadError ?? "")
         }
-        .alert("Open Web Paywall?", isPresented: Binding(
-            get: { pendingWebPreviewURL != nil },
-            set: { if !$0 { pendingWebPreviewURL = nil } }
-        ), presenting: pendingWebPreviewURL) { url in
-            Button("Cancel", role: .cancel) { }
-            Button("Open in Browser") {
-                UIApplication.shared.open(url, options: [:]) { opened in
-                    if !opened {
-                        paywallLoadError = "Failed to open web preview."
-                    }
-                }
-            }
-        } message: { _ in
-            Text("Web paywalls open in your default browser for a display-only preview. Purchases won't work from this preview.")
+        .alert("Web Paywall", isPresented: Binding(
+            get: { webPreviewNotice != nil },
+            set: { if !$0 { webPreviewNotice = nil } }
+        )) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(webPreviewNotice ?? "")
         }
         .fullScreenCover(item: $pendingConfiguration, onDismiss: {
             let launch = queuedLaunch
@@ -166,10 +159,7 @@ struct HeliumControlPanelView: View {
     /// The settings entry only appears once the loaded list actually contains an
     /// app2web-capable paywall.
     private var hasApp2webPaywalls: Bool {
-        if case .loaded(let response) = state {
-            return response.paywalls.contains { $0.isApp2webCapable }
-        }
-        return false
+        state.loadedResponse?.paywalls.contains(where: { $0.isApp2webCapable }) ?? false
     }
 
     @ViewBuilder
@@ -296,7 +286,7 @@ struct HeliumControlPanelView: View {
                         if isLoading {
                             ProgressView()
                         } else if version.bundleUrl != nil {
-                            Image(systemName: paywall.isWebPaywall ? "safari" : "magnifyingglass")
+                            Image(systemName: paywall.isWebPaywall ? "info.circle" : "magnifyingglass")
                                 .font(.subheadline)
                                 .foregroundColor(.accentColor)
                         }
@@ -365,10 +355,15 @@ struct HeliumControlPanelView: View {
         }
     }
 
-    /// Non-app2web paywalls present directly; app2web paywalls stop at the configuration
-    /// screen first only when the tester has turned that step on.
+    /// Web paywalls only raise a notice. Non-app2web paywalls present directly; app2web
+    /// paywalls stop at the configuration screen first only when the tester has turned that step on.
     private func configurePreview(for version: HeliumPaywallPreviewVersion, paywall: HeliumPaywallPreviewEntry) {
         guard activity == .idle else { return }
+        if paywall.isWebPaywall {
+            let linked = state.loadedResponse?.linkedInAppPaywall(for: paywall)
+            webPreviewNotice = HeliumPaywallPreviewEntry.directPreviewBlockedMessage(linkedPaywallName: linked?.paywallName)
+            return
+        }
         if version.isApp2webCapable && !version.isApp2webBundleFresh {
             paywallLoadError = "Your paywall needs an update. Re-save it in your Helium dashboard, then reload."
             return
@@ -383,19 +378,6 @@ struct HeliumControlPanelView: View {
     private func selectVersion(_ version: HeliumPaywallPreviewVersion, paywall: HeliumPaywallPreviewEntry) {
         guard activity == .idle else { return }
         guard let bundleUrl = version.bundleUrl else { return }
-
-        // Web paywalls aren't renderable in-app — preview them in the browser
-        // after the user confirms, since payments won't work from a preview.
-        if paywall.isWebPaywall {
-            guard HeliumFetchedConfigManager.shared.isValidURL(bundleUrl),
-                  let url = URL(string: bundleUrl) else {
-                paywallLoadError = "Invalid web paywall URL."
-                return
-            }
-            HeliumLogger.log(.debug, category: .ui, "[HeliumControlPanel] Selected web paywall: \(paywall.paywallName) version: \(version.versionId)")
-            pendingWebPreviewURL = url
-            return
-        }
 
         activity = .loadingVersion(id: version.id)
         HeliumLogger.log(.debug, category: .ui, "[HeliumControlPanel] Selected paywall: \(paywall.paywallName) version: \(version.versionId)")

--- a/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
+++ b/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
@@ -736,4 +736,169 @@ final class PreviewTriggerConfigTests: XCTestCase {
         XCTAssertFalse(response.paywalls[1].isWebPaywall)
         XCTAssertFalse(response.paywalls[2].isWebPaywall)
     }
+
+    private static let webCheckoutPaywallJSON = """
+    {
+      "paywallUuid": "0b7f5c1a-1111-4222-8333-444455556666",
+      "paywallName": "Web Checkout Paywall",
+      "isWeb": true,
+      "versions": [
+        {
+          "versionId": "9d8c7b6a-aaaa-4bbb-8ccc-dddeeefff000",
+          "versionStatus": "published",
+          "versionNumber": 3,
+          "bundleUrl": "https://bundles-staging.clickthrough.to/x/bundle_1778610753360.html",
+          "previewUrl": null,
+          "productIds": [],
+          "lastSavedAt": null
+        }
+      ]
+    }
+    """
+
+    private func makeWebPaywallResponse(alongside otherPaywallsJSON: String) throws -> HeliumControlPanelResponse {
+        let json = """
+        {
+          "productIds": [],
+          "paywalls": [
+            \(Self.webCheckoutPaywallJSON),
+            \(otherPaywallsJSON)
+          ]
+        }
+        """
+        return try JSONDecoder().decode(HeliumControlPanelResponse.self, from: Data(json.utf8))
+    }
+
+    func testLinkedInAppPaywallReturnsEntryWhoseVersionLinksToWebBundle() throws {
+        let response = try makeWebPaywallResponse(alongside: """
+        {
+          "paywallUuid": "1c8d6e2b-7777-4888-9999-000011112222",
+          "paywallName": "Unrelated Native Paywall",
+          "isWeb": false,
+          "versions": [
+            {
+              "versionId": "32a1d295-60e1-425a-a4f7-c566e31a9f9c",
+              "versionStatus": "published",
+              "versionNumber": 1,
+              "bundleUrl": "https://bundles.heliumpaywall.com/x/bundle_1.html",
+              "previewUrl": null,
+              "productIds": [],
+              "webPaywallBundleUrl": null,
+              "lastSavedAt": null
+            }
+          ]
+        },
+        {
+          "paywallUuid": "2d9e7f3c-8888-4999-aaaa-bbbbccccdddd",
+          "paywallName": "Linked Native Paywall",
+          "isWeb": false,
+          "versions": [
+            {
+              "versionId": "43b2e3a6-71f2-4b36-b5c8-d77f42c0a1b2",
+              "versionStatus": "published",
+              "versionNumber": 2,
+              "bundleUrl": "https://bundles.heliumpaywall.com/x/bundle_2.html",
+              "previewUrl": null,
+              "productIds": [],
+              "webPaddleProductIds": ["pro_web:pri_web"],
+              "webPaywallBundleUrl": "https://bundles-staging.clickthrough.to/x/bundle_1778610753360.html",
+              "lastSavedAt": null
+            }
+          ]
+        }
+        """)
+
+        let linked = response.linkedInAppPaywall(for: response.paywalls[0])
+        XCTAssertEqual(linked?.paywallName, "Linked Native Paywall")
+    }
+
+    func testLinkedInAppPaywallReturnsNilWhenNothingLinksToIt() throws {
+        let response = try makeWebPaywallResponse(alongside: """
+        {
+          "paywallUuid": "1c8d6e2b-7777-4888-9999-000011112222",
+          "paywallName": "Native Paywall",
+          "isWeb": false,
+          "versions": [
+            {
+              "versionId": "32a1d295-60e1-425a-a4f7-c566e31a9f9c",
+              "versionStatus": "published",
+              "versionNumber": 1,
+              "bundleUrl": "https://bundles.heliumpaywall.com/x/bundle_1.html",
+              "previewUrl": null,
+              "productIds": [],
+              "webPaddleProductIds": ["pro_web:pri_web"],
+              "webPaywallBundleUrl": "https://bundles-staging.clickthrough.to/x/bundle_other.html",
+              "lastSavedAt": null
+            }
+          ]
+        }
+        """)
+
+        XCTAssertNil(response.linkedInAppPaywall(for: response.paywalls[0]))
+    }
+
+    func testLinkedInAppPaywallNeverReturnsAWebEntry() throws {
+        let response = try makeWebPaywallResponse(alongside: """
+        {
+          "paywallUuid": "1c8d6e2b-7777-4888-9999-000011112222",
+          "paywallName": "Sibling Web Paywall",
+          "isWeb": true,
+          "versions": [
+            {
+              "versionId": "32a1d295-60e1-425a-a4f7-c566e31a9f9c",
+              "versionStatus": "published",
+              "versionNumber": 1,
+              "bundleUrl": "https://bundles-staging.clickthrough.to/x/bundle_sibling.html",
+              "previewUrl": null,
+              "productIds": [],
+              "webPaddleProductIds": ["pro_web:pri_web"],
+              "webPaywallBundleUrl": "https://bundles-staging.clickthrough.to/x/bundle_1778610753360.html",
+              "lastSavedAt": null
+            }
+          ]
+        }
+        """)
+
+        XCTAssertNil(response.linkedInAppPaywall(for: response.paywalls[0]))
+    }
+
+    func testLinkedInAppPaywallSkipsLinkedEntryWithoutWebProducts() throws {
+        let response = try makeWebPaywallResponse(alongside: """
+        {
+          "paywallUuid": "1c8d6e2b-7777-4888-9999-000011112222",
+          "paywallName": "Linked But Not App2Web",
+          "isWeb": false,
+          "versions": [
+            {
+              "versionId": "32a1d295-60e1-425a-a4f7-c566e31a9f9c",
+              "versionStatus": "published",
+              "versionNumber": 1,
+              "bundleUrl": "https://bundles.heliumpaywall.com/x/bundle_1.html",
+              "previewUrl": null,
+              "productIds": ["yearly_2999"],
+              "webPaddleProductIds": [],
+              "webStripeProductIds": [],
+              "webPaywallBundleUrl": "https://bundles-staging.clickthrough.to/x/bundle_1778610753360.html",
+              "lastSavedAt": null
+            }
+          ]
+        }
+        """)
+
+        XCTAssertNil(response.linkedInAppPaywall(for: response.paywalls[0]))
+    }
+
+    func testDirectPreviewBlockedMessageQuotesLinkedPaywallName() {
+        let named = HeliumPaywallPreviewEntry.directPreviewBlockedMessage(linkedPaywallName: "Premium")
+        XCTAssertEqual(
+            named,
+            "Web paywalls can't be previewed directly. Open \"Premium\" instead; its purchase action kicks out to this web paywall so you can test the full App2Web flow."
+        )
+
+        let generic = HeliumPaywallPreviewEntry.directPreviewBlockedMessage(linkedPaywallName: nil)
+        XCTAssertEqual(
+            generic,
+            "Web paywalls can't be previewed directly. Open the in-app paywall linked to it instead; its purchase action kicks out to this web paywall so you can test the full App2Web flow."
+        )
+    }
 }

--- a/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
+++ b/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
@@ -888,6 +888,105 @@ final class PreviewTriggerConfigTests: XCTestCase {
         XCTAssertNil(response.linkedInAppPaywall(for: response.paywalls[0]))
     }
 
+    func testLinkedInAppPaywallReturnsNilWhenSeveralPaywallsLinkToIt() throws {
+        let response = try makeWebPaywallResponse(alongside: """
+        {
+          "paywallUuid": "1c8d6e2b-7777-4888-9999-000011112222",
+          "paywallName": "Onboarding Paywall",
+          "isWeb": false,
+          "versions": [
+            {
+              "versionId": "32a1d295-60e1-425a-a4f7-c566e31a9f9c",
+              "versionStatus": "published",
+              "versionNumber": 1,
+              "bundleUrl": "https://bundles.heliumpaywall.com/x/bundle_1.html",
+              "previewUrl": null,
+              "productIds": [],
+              "webPaddleProductIds": ["pro_web:pri_web"],
+              "webPaywallBundleUrl": "https://bundles-staging.clickthrough.to/x/bundle_1778610753360.html",
+              "lastSavedAt": null
+            }
+          ]
+        },
+        {
+          "paywallUuid": "2d9e7f3c-8888-4999-aaaa-bbbbccccdddd",
+          "paywallName": "Settings Paywall",
+          "isWeb": false,
+          "versions": [
+            {
+              "versionId": "43b2e3a6-71f2-4b36-b5c8-d77f42c0a1b2",
+              "versionStatus": "published",
+              "versionNumber": 2,
+              "bundleUrl": "https://bundles.heliumpaywall.com/x/bundle_2.html",
+              "previewUrl": null,
+              "productIds": [],
+              "webPaddleProductIds": ["pro_web:pri_web"],
+              "webPaywallBundleUrl": "https://bundles-staging.clickthrough.to/x/bundle_1778610753360.html",
+              "lastSavedAt": null
+            }
+          ]
+        }
+        """)
+
+        XCTAssertNil(response.linkedInAppPaywall(for: response.paywalls[0]))
+    }
+
+    func testLinkedInAppPaywallMatchesAnyVersionOfTheWebPaywall() throws {
+        let json = """
+        {
+          "productIds": [],
+          "paywalls": [
+            {
+              "paywallUuid": "0b7f5c1a-1111-4222-8333-444455556666",
+              "paywallName": "Web Checkout Paywall",
+              "isWeb": true,
+              "versions": [
+                {
+                  "versionId": "9d8c7b6a-aaaa-4bbb-8ccc-dddeeefff001",
+                  "versionStatus": "draft",
+                  "versionNumber": 4,
+                  "bundleUrl": "https://bundles-staging.clickthrough.to/x/bundle_1778700000000.html",
+                  "previewUrl": null,
+                  "productIds": [],
+                  "lastSavedAt": null
+                },
+                {
+                  "versionId": "9d8c7b6a-aaaa-4bbb-8ccc-dddeeefff000",
+                  "versionStatus": "published",
+                  "versionNumber": 3,
+                  "bundleUrl": "https://bundles-staging.clickthrough.to/x/bundle_1778610753360.html",
+                  "previewUrl": null,
+                  "productIds": [],
+                  "lastSavedAt": null
+                }
+              ]
+            },
+            {
+              "paywallUuid": "2d9e7f3c-8888-4999-aaaa-bbbbccccdddd",
+              "paywallName": "Linked Native Paywall",
+              "isWeb": false,
+              "versions": [
+                {
+                  "versionId": "43b2e3a6-71f2-4b36-b5c8-d77f42c0a1b2",
+                  "versionStatus": "published",
+                  "versionNumber": 2,
+                  "bundleUrl": "https://bundles.heliumpaywall.com/x/bundle_2.html",
+                  "previewUrl": null,
+                  "productIds": [],
+                  "webPaddleProductIds": ["pro_web:pri_web"],
+                  "webPaywallBundleUrl": "https://bundles-staging.clickthrough.to/x/bundle_1778610753360.html",
+                  "lastSavedAt": null
+                }
+              ]
+            }
+          ]
+        }
+        """
+        let response = try JSONDecoder().decode(HeliumControlPanelResponse.self, from: Data(json.utf8))
+
+        XCTAssertEqual(response.linkedInAppPaywall(for: response.paywalls[0])?.paywallName, "Linked Native Paywall")
+    }
+
     func testDirectPreviewBlockedMessageQuotesLinkedPaywallName() {
         let named = HeliumPaywallPreviewEntry.directPreviewBlockedMessage(linkedPaywallName: "Premium")
         XCTAssertEqual(


### PR DESCRIPTION
## Summary

Testers using triple-tap Paywall Previews could open a web paywall's hosted page directly in the browser after clicking through a warning dialog. Opened that way the page has no app context and shows an error, which reads as a broken paywall. This change removes the browser hand-off: tapping a web paywall version now shows a single-button alert explaining that web paywalls can't be previewed directly and naming the linked in-app paywall to preview instead, whose purchase action kicks out to the web paywall.

## Changes

- `HeliumControlPanelResponse.linkedInAppPaywall(for:)` resolves the in-app paywall that links to a web paywall by matching each version's `webPaywallBundleUrl` against the web entry's bundle URLs. Only app2web-capable versions count, so the alert never names a paywall whose purchase would not kick out to web. No new API fields; bandit already serves `webPaywallBundleUrl`.
- `HeliumPaywallPreviewEntry.directPreviewBlockedMessage(linkedPaywallName:)` builds the alert copy, with and without a resolved name.
- `HeliumControlPanelView`: the "Open Web Paywall?" alert and the `UIApplication.open` path are gone. Web entries are intercepted in `configurePreview` before the freshness gate and the configuration sheet. Web rows show `info.circle` instead of `safari` so the row no longer reads as a launch.
- `HeliumControlPanelState.loadedResponse` replaces two `if case .loaded` matches in the view.

## Tests

- Five new cases in `PreviewTriggerConfigTests`: linked paywall found, none linked, a web entry is never returned, a linked entry without web products is skipped, and both alert copy variants.
- `PreviewTriggerConfigTests` passes on the iPhone 17 Pro simulator, 36 of 36.

## Docs

Companion paragraph update in cloudcaptainai/docs#51, `guides/app2web-previews.mdx`, "Web paywalls" section.

Linear: HEL-6866

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Preview-only control panel UX; no checkout, auth, or production paywall presentation paths change beyond blocking mistaken browser opens.
> 
> **Overview**
> **Stops opening web paywalls in Safari from the triple-tap preview control panel**, which looked broken without app context. Tapping a web paywall version now shows a single **OK** alert instead of the old “Open in Browser?” flow.
> 
> The alert explains that previews must go through the **App2Web** path: when exactly one **app2web-capable** in-app paywall shares a `webPaywallBundleUrl` with the web entry’s bundle URLs, the copy names that paywall; otherwise it uses generic wording. Resolution lives on `HeliumControlPanelResponse.linkedInAppPaywall(for:)`; web rows use an **info** icon instead of **safari**.
> 
> Web taps are intercepted in `configurePreview` before bundle load or the pre-preview configuration sheet. `HeliumControlPanelState.loadedResponse` is a small helper for reading the loaded payload in the view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43d3eddc3f6df336e2b347a844935faec3d096b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Web paywall previews now display an informational notice instead of opening the paywall URL in a browser.
  * Notices can identify a related in-app paywall when one is available.
  * Web paywalls are blocked before preview configuration begins.
  * Updated preview indicators provide clearer visual guidance when browser-based previews are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->