### PR TITLE
Name the linked web paywall in the stale preview bundle dialog

### DIFF
--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelModels.swift
@@ -25,6 +25,13 @@ struct HeliumControlPanelResponse: Codable {
         }
         return candidates.count == 1 ? candidates.first : nil
     }
+
+    func linkedWebPaywall(for version: HeliumPaywallPreviewVersion) -> HeliumPaywallPreviewEntry? {
+        guard let webBundleUrl = version.webPaywallBundleUrl else { return nil }
+        return paywalls.first { candidate in
+            candidate.isWebPaywall && candidate.versions.contains { $0.bundleUrl == webBundleUrl }
+        }
+    }
 }
 
 struct HeliumPaywallPreviewEntry: Codable, Identifiable {

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumControlPanelView.swift
@@ -365,7 +365,8 @@ struct HeliumControlPanelView: View {
             return
         }
         if version.isApp2webCapable && !version.isApp2webBundleFresh {
-            paywallLoadError = "Your paywall needs an update. Re-save it in your Helium dashboard, then reload."
+            let web = state.loadedResponse?.linkedWebPaywall(for: version)
+            paywallLoadError = HeliumPreviewBundleFreshness.staleBundleMessage(webPaywallName: web?.paywallName)
             return
         }
         if version.isApp2webCapable && previewSettings.configureBeforeEachPreview {

--- a/Sources/Helium/HeliumCore/ControlPanel/HeliumPreviewConfigurationModels.swift
+++ b/Sources/Helium/HeliumCore/ControlPanel/HeliumPreviewConfigurationModels.swift
@@ -141,6 +141,11 @@ struct HeliumPreviewConfigurationRequest: Identifiable {
 /// (stamped in its filename) being at or after this cutoff, in epoch ms.
 enum HeliumPreviewBundleFreshness {
     static let app2webCutoffMs: Int64 = 1787881704000
+
+    static func staleBundleMessage(webPaywallName: String?) -> String {
+        let target = webPaywallName.map { "The linked web paywall \"\($0)\"" } ?? "The web paywall linked to this paywall"
+        return "\(target) needs an update. Re-save and publish it in your Helium dashboard, then reload."
+    }
 }
 
 extension HeliumPaywallPreviewVersion {

--- a/Tests/helium-swiftTests/PreviewBundleFreshnessTests.swift
+++ b/Tests/helium-swiftTests/PreviewBundleFreshnessTests.swift
@@ -37,6 +37,17 @@ final class PreviewBundleFreshnessTests: XCTestCase {
         XCTAssertFalse(version.isApp2webBundleFresh)
     }
 
+    func testStaleBundleMessageQuotesWebPaywallName() {
+        XCTAssertEqual(
+            HeliumPreviewBundleFreshness.staleBundleMessage(webPaywallName: "Web Checkout Paywall"),
+            "The linked web paywall \"Web Checkout Paywall\" needs an update. Re-save and publish it in your Helium dashboard, then reload."
+        )
+        XCTAssertEqual(
+            HeliumPreviewBundleFreshness.staleBundleMessage(webPaywallName: nil),
+            "The web paywall linked to this paywall needs an update. Re-save and publish it in your Helium dashboard, then reload."
+        )
+    }
+
     func testStaleWhenTimestampUnparseable() throws {
         let version = try makeVersion(
             webPaywallBundleUrl: "https://bundles.t3.storage.dev/org/paywall/bundle_draft.html"

--- a/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
+++ b/Tests/helium-swiftTests/PreviewTriggerConfigTests.swift
@@ -987,6 +987,128 @@ final class PreviewTriggerConfigTests: XCTestCase {
         XCTAssertEqual(response.linkedInAppPaywall(for: response.paywalls[0])?.paywallName, "Linked Native Paywall")
     }
 
+    func testLinkedWebPaywallReturnsWebEntryWhoseBundleTheVersionLinksTo() throws {
+        let response = try makeWebPaywallResponse(alongside: """
+        {
+          "paywallUuid": "2d9e7f3c-8888-4999-aaaa-bbbbccccdddd",
+          "paywallName": "Linked Native Paywall",
+          "isWeb": false,
+          "versions": [
+            {
+              "versionId": "43b2e3a6-71f2-4b36-b5c8-d77f42c0a1b2",
+              "versionStatus": "published",
+              "versionNumber": 2,
+              "bundleUrl": "https://bundles.heliumpaywall.com/x/bundle_2.html",
+              "previewUrl": null,
+              "productIds": [],
+              "webPaddleProductIds": ["pro_web:pri_web"],
+              "webPaywallBundleUrl": "https://bundles-staging.clickthrough.to/x/bundle_1778610753360.html",
+              "lastSavedAt": null
+            }
+          ]
+        }
+        """)
+
+        let linked = response.linkedWebPaywall(for: response.paywalls[1].versions[0])
+        XCTAssertEqual(linked?.paywallName, "Web Checkout Paywall")
+    }
+
+    func testLinkedWebPaywallReturnsNilWhenVersionHasNoWebBundle() throws {
+        let response = try makeWebPaywallResponse(alongside: """
+        {
+          "paywallUuid": "1c8d6e2b-7777-4888-9999-000011112222",
+          "paywallName": "Native Only Paywall",
+          "isWeb": false,
+          "versions": [
+            {
+              "versionId": "32a1d295-60e1-425a-a4f7-c566e31a9f9c",
+              "versionStatus": "published",
+              "versionNumber": 1,
+              "bundleUrl": "https://bundles.heliumpaywall.com/x/bundle_1.html",
+              "previewUrl": null,
+              "productIds": [],
+              "webPaywallBundleUrl": null,
+              "lastSavedAt": null
+            }
+          ]
+        }
+        """)
+
+        XCTAssertNil(response.linkedWebPaywall(for: response.paywalls[1].versions[0]))
+    }
+
+    func testLinkedWebPaywallReturnsNilWhenNoWebEntryServesThatBundle() throws {
+        let response = try makeWebPaywallResponse(alongside: """
+        {
+          "paywallUuid": "2d9e7f3c-8888-4999-aaaa-bbbbccccdddd",
+          "paywallName": "Linked Native Paywall",
+          "isWeb": false,
+          "versions": [
+            {
+              "versionId": "43b2e3a6-71f2-4b36-b5c8-d77f42c0a1b2",
+              "versionStatus": "published",
+              "versionNumber": 2,
+              "bundleUrl": "https://bundles.heliumpaywall.com/x/bundle_2.html",
+              "previewUrl": null,
+              "productIds": [],
+              "webPaddleProductIds": ["pro_web:pri_web"],
+              "webPaywallBundleUrl": "https://bundles-staging.clickthrough.to/x/bundle_1778700000000.html",
+              "lastSavedAt": null
+            }
+          ]
+        }
+        """)
+
+        XCTAssertNil(response.linkedWebPaywall(for: response.paywalls[1].versions[0]))
+    }
+
+    func testLinkedWebPaywallNeverReturnsANativeEntry() throws {
+        let json = """
+        {
+          "productIds": [],
+          "paywalls": [
+            {
+              "paywallUuid": "1c8d6e2b-7777-4888-9999-000011112222",
+              "paywallName": "Native Paywall Sharing The Url",
+              "isWeb": false,
+              "versions": [
+                {
+                  "versionId": "32a1d295-60e1-425a-a4f7-c566e31a9f9c",
+                  "versionStatus": "published",
+                  "versionNumber": 1,
+                  "bundleUrl": "https://bundles.heliumpaywall.com/x/bundle_1.html",
+                  "previewUrl": null,
+                  "productIds": [],
+                  "lastSavedAt": null
+                }
+              ]
+            },
+            {
+              "paywallUuid": "2d9e7f3c-8888-4999-aaaa-bbbbccccdddd",
+              "paywallName": "Linked Native Paywall",
+              "isWeb": false,
+              "versions": [
+                {
+                  "versionId": "43b2e3a6-71f2-4b36-b5c8-d77f42c0a1b2",
+                  "versionStatus": "published",
+                  "versionNumber": 2,
+                  "bundleUrl": "https://bundles.heliumpaywall.com/x/bundle_2.html",
+                  "previewUrl": null,
+                  "productIds": [],
+                  "webPaddleProductIds": ["pro_web:pri_web"],
+                  "webPaywallBundleUrl": "https://bundles.heliumpaywall.com/x/bundle_1.html",
+                  "lastSavedAt": null
+                }
+              ]
+            }
+          ]
+        }
+        """
+        let response = try JSONDecoder().decode(HeliumControlPanelResponse.self, from: Data(json.utf8))
+
+        XCTAssertNil(response.linkedWebPaywall(for: response.paywalls[1].versions[0]))
+    }
+
     func testDirectPreviewBlockedMessageQuotesLinkedPaywallName() {
         let named = HeliumPaywallPreviewEntry.directPreviewBlockedMessage(linkedPaywallName: "Premium")
         XCTAssertEqual(


### PR DESCRIPTION
## Problem

The app2web preview freshness gate checks the bundle stamp of `webPaywallBundleUrl`, which is the linked web paywall's published bundle, not the paywall the tester tapped. The dialog said "Your paywall needs an update. Re-save it", so a customer's tester re-saved and re-published the in-app paywall three times with no effect. It only worked once the linked web paywall was re-saved and published.

## Fix

- `HeliumControlPanelResponse.linkedWebPaywall(for:)` resolves the web entry whose bundle URL the tapped version links to. Exact URL match with `first`, since bundle URLs embed the paywall id and are unique, unlike the many-to-one `linkedInAppPaywall(for:)` from #348.
- `HeliumPreviewBundleFreshness.staleBundleMessage(webPaywallName:)` names that paywall and asks for a re-save **and publish**, because bandit reads the web paywall's published version and a save alone does not change it.
- Fallback copy when the web entry is not in the list: "The web paywall linked to this paywall needs an update."

## Tests

5 new tests. PreviewTriggerConfigTests (42) and PreviewBundleFreshnessTests (6) green on iPhone 17 Pro.

## Related

Linear HEL-6869. Companion bandit PR reports the real save time as `lastSavedAt`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Preview-only UX and copy in the debug control panel; no production checkout or auth paths change.
> 
> **Overview**
> When an **app2web** preview is blocked because the linked checkout bundle is too old, the alert no longer tells testers to re-save the in-app paywall they tapped. It resolves the **linked web paywall** from `webPaywallBundleUrl` via new `HeliumControlPanelResponse.linkedWebPaywall(for:)` and shows `HeliumPreviewBundleFreshness.staleBundleMessage`, which names that paywall and instructs **re-save and publish** in the dashboard (with generic fallback if the web entry is missing).
> 
> Tests cover the resolver (match, nil cases, web-only) and the new message copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8739fbc6e98b67e2c16cc3f48548d4cc83370b55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->