### PR TITLE
HEL-6886 Add host-owned dismissal opt-out for embedded paywalls

### DIFF
--- a/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
+++ b/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
@@ -50,20 +50,23 @@ public struct DynamicBaseTemplateView: View {
             // Embedded-only: with manual dismissal, suppress SDK-initiated dismissal so the host removes
             // the view itself. Presented and triggered paywalls keep SDK-owned dismissal.
             let manualDismissal = dismissBehavior == .manual && presentationState.viewType == .embedded
-
-            actionsDelegate.setDismissAction {
+            let dismissUnlessManual: () -> Void = {
                 guard !manualDismissal else { return }
                 dismiss()
             }
+
+            actionsDelegate.setDismissAction(dismissUnlessManual)
             if presentationState.viewType != .presented {
-                if !manualDismissal {
-                    InlinePaywallDismissRegistry.register(sessionId: actionsDelegate.paywallSession.sessionId) {
-                        dismiss()
-                    }
-                }
+                InlinePaywallDismissRegistry.register(sessionId: actionsDelegate.paywallSession.sessionId, dismissUnlessManual)
                 if !presentationState.isOpen {
                     presentationState.isOpen = true
                     actionsDelegateWrapper.logImpression(viewType: presentationState.viewType, fallbackReason: fallbackReason, loadTimeTakenMS: loadTimeTakenMS)
+                    if manualDismissal {
+                        HeliumObservabilityManager.shared.track(
+                            EmbeddedPaywallManualDismissalEnabled(),
+                            scope: actionsDelegate.paywallSession.observabilityScope
+                        )
+                    }
                 }
             }
         }

--- a/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
+++ b/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
@@ -47,22 +47,16 @@ public struct DynamicBaseTemplateView: View {
     public var body: some View {
         paywallContent
         .onAppear {
-            // Host-owned dismissal applies only to the embedded view; the SDK still owns presented and
-            // triggered paywalls. When enabled, every SDK-initiated dismiss (purchase, restore, close
-            // button, external web checkout) is suppressed here so the host can remove the view itself.
-            //
-            // The behavior is read once, when the paywall appears. Flipping `.heliumDismissBehavior(_:)`
-            // on an already-mounted paywall is intentionally not honored — dismissal is wired imperatively
-            // into the actions delegate here rather than tracked reactively. This is fine for the intended
-            // static usage; a future dismissal-signal refactor would make it live without an API change.
-            let hostOwnsDismissal = dismissBehavior == .hostOwned && presentationState.viewType == .embedded
+            // Embedded-only: with manual dismissal, suppress SDK-initiated dismissal so the host removes
+            // the view itself. Presented and triggered paywalls keep SDK-owned dismissal.
+            let manualDismissal = dismissBehavior == .manual && presentationState.viewType == .embedded
 
             actionsDelegate.setDismissAction {
-                guard !hostOwnsDismissal else { return }
+                guard !manualDismissal else { return }
                 dismiss()
             }
             if presentationState.viewType != .presented {
-                if !hostOwnsDismissal {
+                if !manualDismissal {
                     InlinePaywallDismissRegistry.register(sessionId: actionsDelegate.paywallSession.sessionId) {
                         dismiss()
                     }

--- a/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
+++ b/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
@@ -47,18 +47,31 @@ public struct DynamicBaseTemplateView: View {
     public var body: some View {
         paywallContent
         .onAppear {
-            configureDismissalOwnership()
+            // Host-owned dismissal applies only to the embedded view; the SDK still owns presented and
+            // triggered paywalls. When enabled, every SDK-initiated dismiss (purchase, restore, close
+            // button, external web checkout) is suppressed here so the host can remove the view itself.
+            //
+            // The behavior is read once, when the paywall appears. Flipping `.heliumDismissBehavior(_:)`
+            // on an already-mounted paywall is intentionally not honored — dismissal is wired imperatively
+            // into the actions delegate here rather than tracked reactively. This is fine for the intended
+            // static usage; a future dismissal-signal refactor would make it live without an API change.
+            let hostOwnsDismissal = dismissBehavior == .hostOwned && presentationState.viewType == .embedded
+
+            actionsDelegate.setDismissAction {
+                guard !hostOwnsDismissal else { return }
+                dismiss()
+            }
             if presentationState.viewType != .presented {
+                if !hostOwnsDismissal {
+                    InlinePaywallDismissRegistry.register(sessionId: actionsDelegate.paywallSession.sessionId) {
+                        dismiss()
+                    }
+                }
                 if !presentationState.isOpen {
                     presentationState.isOpen = true
                     actionsDelegateWrapper.logImpression(viewType: presentationState.viewType, fallbackReason: fallbackReason, loadTimeTakenMS: loadTimeTakenMS)
                 }
             }
-        }
-        .onChange(of: dismissBehavior) { _ in
-            // A host may bind the behavior to state and flip it while the paywall is mounted, so
-            // rewire the dismiss action and registry rather than leaving the .onAppear snapshot stale.
-            configureDismissalOwnership()
         }
         .onDisappear {
             if presentationState.viewType != .presented {
@@ -67,28 +80,6 @@ public struct DynamicBaseTemplateView: View {
                     presentationState.isOpen = false
                     actionsDelegateWrapper.logClosure()
                 }
-            }
-        }
-    }
-
-    // Host-owned dismissal applies only to the embedded view; the SDK still owns presented and
-    // triggered paywalls. When enabled, every SDK-initiated dismiss (purchase, restore, close button,
-    // external web checkout) is suppressed so the host can remove the view itself.
-    private func configureDismissalOwnership() {
-        let hostOwnsDismissal = dismissBehavior == .hostOwned && presentationState.viewType == .embedded
-
-        actionsDelegate.setDismissAction {
-            guard !hostOwnsDismissal else { return }
-            dismiss()
-        }
-
-        guard presentationState.viewType != .presented else { return }
-        let sessionId = actionsDelegate.paywallSession.sessionId
-        if hostOwnsDismissal {
-            InlinePaywallDismissRegistry.unregister(sessionId: sessionId)
-        } else {
-            InlinePaywallDismissRegistry.register(sessionId: sessionId) {
-                dismiss()
             }
         }
     }

--- a/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
+++ b/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
@@ -47,26 +47,18 @@ public struct DynamicBaseTemplateView: View {
     public var body: some View {
         paywallContent
         .onAppear {
-            // Host-owned dismissal applies only to the embedded view; the SDK still owns presented and
-            // triggered paywalls. When enabled, every SDK-initiated dismiss (purchase, restore, close
-            // button, external web checkout) is suppressed here so the host can remove the view itself.
-            let hostOwnsDismissal = dismissBehavior == .hostOwned && presentationState.viewType == .embedded
-
-            actionsDelegate.setDismissAction {
-                guard !hostOwnsDismissal else { return }
-                dismiss()
-            }
+            configureDismissalOwnership()
             if presentationState.viewType != .presented {
-                if !hostOwnsDismissal {
-                    InlinePaywallDismissRegistry.register(sessionId: actionsDelegate.paywallSession.sessionId) {
-                        dismiss()
-                    }
-                }
                 if !presentationState.isOpen {
                     presentationState.isOpen = true
                     actionsDelegateWrapper.logImpression(viewType: presentationState.viewType, fallbackReason: fallbackReason, loadTimeTakenMS: loadTimeTakenMS)
                 }
             }
+        }
+        .onChange(of: dismissBehavior) { _ in
+            // A host may bind the behavior to state and flip it while the paywall is mounted, so
+            // rewire the dismiss action and registry rather than leaving the .onAppear snapshot stale.
+            configureDismissalOwnership()
         }
         .onDisappear {
             if presentationState.viewType != .presented {
@@ -75,6 +67,28 @@ public struct DynamicBaseTemplateView: View {
                     presentationState.isOpen = false
                     actionsDelegateWrapper.logClosure()
                 }
+            }
+        }
+    }
+
+    // Host-owned dismissal applies only to the embedded view; the SDK still owns presented and
+    // triggered paywalls. When enabled, every SDK-initiated dismiss (purchase, restore, close button,
+    // external web checkout) is suppressed so the host can remove the view itself.
+    private func configureDismissalOwnership() {
+        let hostOwnsDismissal = dismissBehavior == .hostOwned && presentationState.viewType == .embedded
+
+        actionsDelegate.setDismissAction {
+            guard !hostOwnsDismissal else { return }
+            dismiss()
+        }
+
+        guard presentationState.viewType != .presented else { return }
+        let sessionId = actionsDelegate.paywallSession.sessionId
+        if hostOwnsDismissal {
+            InlinePaywallDismissRegistry.unregister(sessionId: sessionId)
+        } else {
+            InlinePaywallDismissRegistry.register(sessionId: sessionId) {
+                dismiss()
             }
         }
     }

--- a/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
+++ b/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
@@ -8,6 +8,7 @@ enum TemplateError: Error {
 public struct DynamicBaseTemplateView: View {
     
     @Environment(\.dismiss) var dismiss
+    @Environment(\.heliumDismissBehavior) var dismissBehavior
     @Environment(\.paywallPresentationState) var presentationState: HeliumPaywallPresentationState
     @Environment(\.heliumLoadTimeTakenMS) var loadTimeTakenMS: UInt64?
     @StateObject private var actionsDelegate: HeliumActionsDelegate
@@ -46,12 +47,20 @@ public struct DynamicBaseTemplateView: View {
     public var body: some View {
         paywallContent
         .onAppear {
+            // Host-owned dismissal applies only to the embedded view; the SDK still owns presented and
+            // triggered paywalls. When enabled, every SDK-initiated dismiss (purchase, restore, close
+            // button, external web checkout) is suppressed here so the host can remove the view itself.
+            let hostOwnsDismissal = dismissBehavior == .hostOwned && presentationState.viewType == .embedded
+
             actionsDelegate.setDismissAction {
+                guard !hostOwnsDismissal else { return }
                 dismiss()
             }
             if presentationState.viewType != .presented {
-                InlinePaywallDismissRegistry.register(sessionId: actionsDelegate.paywallSession.sessionId) {
-                    dismiss()
+                if !hostOwnsDismissal {
+                    InlinePaywallDismissRegistry.register(sessionId: actionsDelegate.paywallSession.sessionId) {
+                        dismiss()
+                    }
                 }
                 if !presentationState.isOpen {
                     presentationState.isOpen = true

--- a/Sources/Helium/HeliumCore/HeliumPaywall.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywall.swift
@@ -317,7 +317,7 @@ extension EnvironmentValues {
 }
 
 /// Controls who dismisses an embedded ``HeliumPaywall`` after an SDK-initiated close.
-public enum HeliumPaywallDismissBehavior {
+public enum HeliumPaywallDismissBehavior: Equatable {
     /// The SDK dismisses the paywall itself on purchase, restore, and the close button. Default.
     case automatic
 

--- a/Sources/Helium/HeliumCore/HeliumPaywall.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywall.swift
@@ -316,33 +316,29 @@ extension EnvironmentValues {
     }
 }
 
-/// Controls who dismisses an embedded ``HeliumPaywall`` after an SDK-initiated close.
+/// Controls who dismisses an embedded ``HeliumPaywall``.
 public enum HeliumPaywallDismissBehavior {
-    /// The SDK dismisses the paywall itself on purchase, restore, and the close button. Default.
+    /// The SDK dismisses the paywall upon purchase, restore, and user-initiated close.
     case automatic
 
-    /// The host owns dismissal. On purchase, restore, and the close button the SDK still emits the
-    /// corresponding events, but leaves the view in place for you to remove yourself. Applies only to
-    /// the embedded `HeliumPaywall` view; ignored for presented and `.heliumPaywall`-triggered paywalls.
-    case hostOwned
+    /// You dismiss the paywall yourself. On purchase, restore, and user-initiated close the SDK emits the
+    /// corresponding events but leaves the view in place — its close button is a no-op until you remove
+    /// the view. Embedded `HeliumPaywall` only; ignored for presented and `.heliumPaywall`-triggered
+    /// paywalls.
+    case manual
 }
 
 public extension View {
-    /// Sets how an embedded ``HeliumPaywall`` in this view tree is dismissed. Defaults to `.automatic`.
+    /// Sets how an embedded ``HeliumPaywall`` in this view tree is dismissed; see
+    /// ``HeliumPaywallDismissBehavior`` for what each case does. Defaults to `.automatic`.
     ///
-    /// Use `.hostOwned` when the paywall lives in navigation you control (e.g. a step in a
-    /// `NavigationStack`) and you don't want the SDK removing it out from under you. Observe purchase,
-    /// restore, and close through ``PaywallEventHandlers`` and remove the view yourself in response.
-    ///
-    /// - Important: With `.hostOwned` the paywall's close button becomes a no-op unless you dismiss the
-    ///   view yourself from the `onDismissed` handler.
+    /// - Note: This value is read when the paywall first appears; changing it on an already-visible
+    ///   paywall is not honored.
     func heliumDismissBehavior(_ behavior: HeliumPaywallDismissBehavior) -> some View {
         environment(\.heliumDismissBehavior, behavior)
     }
 }
 
-// Set by the public `.heliumDismissBehavior(_:)` modifier and read by the embedded paywall's base
-// template to decide whether the SDK or the host owns dismissal.
 private struct HeliumDismissBehaviorKey: EnvironmentKey {
     static let defaultValue: HeliumPaywallDismissBehavior = .automatic
 }

--- a/Sources/Helium/HeliumCore/HeliumPaywall.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywall.swift
@@ -317,7 +317,7 @@ extension EnvironmentValues {
 }
 
 /// Controls who dismisses an embedded ``HeliumPaywall`` after an SDK-initiated close.
-public enum HeliumPaywallDismissBehavior: Equatable {
+public enum HeliumPaywallDismissBehavior {
     /// The SDK dismisses the paywall itself on purchase, restore, and the close button. Default.
     case automatic
 

--- a/Sources/Helium/HeliumCore/HeliumPaywall.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywall.swift
@@ -315,3 +315,41 @@ extension EnvironmentValues {
         set { self[HeliumDynamicPaywallTraitsKey.self] = newValue }
     }
 }
+
+/// Controls who dismisses an embedded ``HeliumPaywall`` after an SDK-initiated close.
+public enum HeliumPaywallDismissBehavior {
+    /// The SDK dismisses the paywall itself on purchase, restore, and the close button. Default.
+    case automatic
+
+    /// The host owns dismissal. On purchase, restore, and the close button the SDK still emits the
+    /// corresponding events, but leaves the view in place for you to remove yourself. Applies only to
+    /// the embedded `HeliumPaywall` view; ignored for presented and `.heliumPaywall`-triggered paywalls.
+    case hostOwned
+}
+
+public extension View {
+    /// Sets how an embedded ``HeliumPaywall`` in this view tree is dismissed. Defaults to `.automatic`.
+    ///
+    /// Use `.hostOwned` when the paywall lives in navigation you control (e.g. a step in a
+    /// `NavigationStack`) and you don't want the SDK removing it out from under you. Observe purchase,
+    /// restore, and close through ``PaywallEventHandlers`` and remove the view yourself in response.
+    ///
+    /// - Important: With `.hostOwned` the paywall's close button becomes a no-op unless you dismiss the
+    ///   view yourself from the `onDismissed` handler.
+    func heliumDismissBehavior(_ behavior: HeliumPaywallDismissBehavior) -> some View {
+        environment(\.heliumDismissBehavior, behavior)
+    }
+}
+
+// Set by the public `.heliumDismissBehavior(_:)` modifier and read by the embedded paywall's base
+// template to decide whether the SDK or the host owns dismissal.
+private struct HeliumDismissBehaviorKey: EnvironmentKey {
+    static let defaultValue: HeliumPaywallDismissBehavior = .automatic
+}
+
+extension EnvironmentValues {
+    var heliumDismissBehavior: HeliumPaywallDismissBehavior {
+        get { self[HeliumDismissBehaviorKey.self] }
+        set { self[HeliumDismissBehaviorKey.self] = newValue }
+    }
+}

--- a/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
+++ b/Sources/Helium/HeliumCore/Observability/HeliumObservabilityEvents.swift
@@ -383,6 +383,13 @@ struct PaywallTraitsFreezeMissingAtMakePurchase: HeliumObservabilityEvent {
     }
 }
 
+/// Emitted when an embedded `HeliumPaywall` opens with `.manual` dismissal; its presence is the
+/// signal, as automatic opens emit nothing.
+struct EmbeddedPaywallManualDismissalEnabled: HeliumObservabilityEvent {
+    var name: String { "embedded_paywall_manual_dismissal_enabled" }
+    var properties: [String: Any] { [:] }
+}
+
 /// Reports the fallback bundle an app ships. The event's presence in the stream is
 /// itself the "this app has fallbacks configured" signal, so it is only emitted when
 /// a bundle was found and parsed.


### PR DESCRIPTION
## What

Adds an opt-out so an app hosting the embedded `HeliumPaywall` view can own dismissal instead of the SDK.

```swift
HeliumPaywall(trigger: "onboarding", eventHandlers: .withHandlers(
    onPurchaseSucceeded: { _ in /* advance yourself */ },
    onDismissed: { _ in /* pop yourself */ }
)) { reason in
    Text("no show: \(reason.description)")
}
.heliumDismissBehavior(.manual)
```

## Why

When the embedded paywall is placed in host-owned navigation (e.g. a real step in a `NavigationStack`), the SDK's post-purchase dismiss (`presentationMode.dismiss()`) pops that step out from under the host. There was no way to keep the paywall in place and drive navigation from the app. This is the natural counterpart to the embedded API — the host already owns presentation, so it can now own dismissal too (matching the Flutter embedded behavior).

## What changed

- New public `HeliumPaywallDismissBehavior` enum (`.automatic` default / `.manual`) and `View.heliumDismissBehavior(_:)` modifier, backed by an internal environment value — co-located with the embedded view in `HeliumPaywall.swift`.
- `DynamicBaseTemplateView` reads the behavior and, when `.manual`, suppresses both embedded dismiss channels: the `dismissAction` (purchase / restore / close button) and the `InlinePaywallDismissRegistry` registration (external Stripe/Paddle web checkout).

## Scope & behavior

- **Embedded only.** Gated on `viewType == .embedded`, so presented and `.heliumPaywall`-triggered paywalls keep their existing SDK-owned dismissal even if the modifier is set higher in the view tree.
- **Events still fire.** Only the dismiss action is suppressed — `onPurchaseSucceeded`, restore, and `onDismissed`/`PaywallDismissedEvent` all still emit, so the host has the signals it needs.
- **Close button caveat.** With `.manual`, the paywall's close button becomes a no-op unless the host dismisses the view from `onDismissed`. This is intended and documented on the modifier.

## Testing

Manually verified against an embedded paywall pushed as a `NavigationStack` step (example intentionally not included in this PR): on purchase the paywall stays put and a host "thank you" renders over it; close routes through `onDismissed`. Default (`.automatic`) behavior is unchanged.

## Follow-up

`.manual` is read once when the paywall appears (documented on the modifier); honoring live changes requires refactoring the inline dismissal seam — tracked in **SDK-77**. Related: **SDK-76** (onEntitled for embedded) and **SDK-75** (second-try + `.manual` test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes embedded paywall dismissal timing on an opt-in path; default automatic behavior is unchanged, but manual mode can leave paywalls visible if hosts do not handle events.
> 
> **Overview**
> Adds an opt-in **`HeliumPaywallDismissBehavior`** (default **`.automatic`**) and **`heliumDismissBehavior(_:)`** so apps embedding **`HeliumPaywall`** can keep the view on screen after purchase, restore, or close and drive navigation themselves.
> 
> **`DynamicBaseTemplateView`** reads the environment value on appear and, only when behavior is **`.manual`** and the paywall is **embedded**, wraps dismissal so the SDK does not call **`dismiss()`** for the actions delegate or **`InlinePaywallDismissRegistry`** (including external web checkout). **Presented** and **triggered** paywalls are unchanged. Events still fire; with **`.manual`**, the in-paywall close button does nothing until the host removes the view (documented on the modifier).
> 
> A one-time observability event **`embedded_paywall_manual_dismissal_enabled`** is tracked when manual mode is active at open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b628f7e6379db3c6f71676ac298a85616cfece57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable dismissal behavior for embedded paywalls.
  * Embedded paywalls can use automatic SDK-managed dismissal or host-managed dismissal.
  * Added a view modifier for selecting the dismissal behavior; automatic dismissal remains the default.
  * Dismissal behavior can be updated while an embedded paywall is displayed.
  * Manual dismissal allows the host application to control when the paywall closes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
