### PR TITLE
Add onEntitled to embedded HeliumPaywall and heliumPaywall modifier

### DIFF
--- a/HeliumExample/HeliumExample/ContentView.swift
+++ b/HeliumExample/HeliumExample/ContentView.swift
@@ -73,7 +73,12 @@ struct ContentView: View {
                 .accessibilityIdentifier("showPaywallEmbedded")
                 .fullScreenCover(isPresented: $showEmbeddedPaywall) {
                     HeliumPaywall(
-                        trigger: trigger, config: PaywallPresentationConfig(dontShowIfAlreadyEntitled: dontShowIfAlreadyEntitled)
+                        trigger: trigger,
+                        config: PaywallPresentationConfig(dontShowIfAlreadyEntitled: dontShowIfAlreadyEntitled),
+                        onEntitled: { event in
+                            print("[Helium Example] embedded onEntitled: \(event)")
+                            showEmbeddedPaywall = false
+                        }
                     ) { reason in
                         Text("no show embedded! \(reason.description)")
                     }

--- a/HeliumExample/HeliumExample/ContentView.swift
+++ b/HeliumExample/HeliumExample/ContentView.swift
@@ -77,7 +77,6 @@ struct ContentView: View {
                         config: PaywallPresentationConfig(dontShowIfAlreadyEntitled: dontShowIfAlreadyEntitled),
                         onEntitled: { event in
                             print("[Helium Example] embedded onEntitled: \(event)")
-                            showEmbeddedPaywall = false
                         }
                     ) { reason in
                         Text("no show embedded! \(reason.description)")

--- a/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
+++ b/Sources/Helium/HeliumCore/HeliumBaseTemplateView.swift
@@ -51,12 +51,19 @@ public struct DynamicBaseTemplateView: View {
             // the view itself. Presented and triggered paywalls keep SDK-owned dismissal.
             let manualDismissal = dismissBehavior == .manual && presentationState.viewType == .embedded
             let dismissUnlessManual: () -> Void = {
+                if presentationState.isInline {
+                    let session = actionsDelegate.paywallSession
+                    HeliumPaywallPresenter.shared.dispatchEntitledEvent(
+                        forSessionId: session.sessionId,
+                        presentationContext: session.presentationContext
+                    )
+                }
                 guard !manualDismissal else { return }
                 dismiss()
             }
 
             actionsDelegate.setDismissAction(dismissUnlessManual)
-            if presentationState.viewType != .presented {
+            if presentationState.isInline {
                 InlinePaywallDismissRegistry.register(sessionId: actionsDelegate.paywallSession.sessionId, dismissUnlessManual)
                 if !presentationState.isOpen {
                     presentationState.isOpen = true
@@ -71,7 +78,7 @@ public struct DynamicBaseTemplateView: View {
             }
         }
         .onDisappear {
-            if presentationState.viewType != .presented {
+            if presentationState.isInline {
                 InlinePaywallDismissRegistry.unregister(sessionId: actionsDelegate.paywallSession.sessionId)
                 if presentationState.isOpen {
                     presentationState.isOpen = false

--- a/Sources/Helium/HeliumCore/HeliumPaywall.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywall.swift
@@ -43,8 +43,8 @@ public struct HeliumPaywall<PaywallNotShownView: View>: View {
     ///   - trigger: The trigger name to display a paywall for
     ///   - config: Additional configuration options
     ///   - eventHandlers: Optional event handlers for paywall lifecycle events
-    ///   - onEntitled: Called with the entitling event on purchase, restore, or an already-entitled purchase, regardless of `.heliumDismissBehavior`.
-    ///    With `config.dontShowIfAlreadyEntitled`, also called with `.skipped` when the paywall is skipped for an entitled user.
+    ///   - onEntitled: Called with the entitling event on purchase, restore, or an already-entitled purchase.
+    ///    Also called with `.skipped` when the paywall is skipped because `config.dontShowIfAlreadyEntitled` is true and the user is already entitled.
     ///   - whenPaywallNotShown: View to show when paywall is unavailable or skipped due to targeting/already-entitled
     public init(
         trigger: String,
@@ -74,8 +74,8 @@ public struct HeliumPaywall<PaywallNotShownView: View>: View {
     ///   - trigger: The trigger name to display a paywall for
     ///   - config: Additional configuration options
     ///   - eventHandlers: Optional event handlers for paywall lifecycle events
-    ///   - onEntitled: Called with the entitling event on purchase, restore, or an already-entitled purchase, regardless of `.heliumDismissBehavior`.
-    ///    With `config.dontShowIfAlreadyEntitled`, also called with `.skipped` when the paywall is skipped for an entitled user.
+    ///   - onEntitled: Called with the entitling event on purchase, restore, or an already-entitled purchase.
+    ///    Also called with `.skipped` when the paywall is skipped because `config.dontShowIfAlreadyEntitled` is true and the user is already entitled.
     ///   - loadingView: Custom view to show while paywall is loading
     ///   - whenPaywallNotShown: View to show when paywall is unavailable or skipped due to targeting/already-entitled
     public init<LoadingView: View>(

--- a/Sources/Helium/HeliumCore/HeliumPaywall.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywall.swift
@@ -44,7 +44,7 @@ public struct HeliumPaywall<PaywallNotShownView: View>: View {
     ///   - config: Additional configuration options
     ///   - eventHandlers: Optional event handlers for paywall lifecycle events
     ///   - onEntitled: Called with the entitling event on purchase, restore, or an already-entitled purchase, regardless of `.heliumDismissBehavior`.
-    ///    With `config.dontShowIfAlreadyEntitled`, called with `.skipped` in place of `whenPaywallNotShown(.alreadyEntitled)`.
+    ///    With `config.dontShowIfAlreadyEntitled`, also called with `.skipped` when the paywall is skipped for an entitled user.
     ///   - whenPaywallNotShown: View to show when paywall is unavailable or skipped due to targeting/already-entitled
     public init(
         trigger: String,
@@ -75,7 +75,7 @@ public struct HeliumPaywall<PaywallNotShownView: View>: View {
     ///   - config: Additional configuration options
     ///   - eventHandlers: Optional event handlers for paywall lifecycle events
     ///   - onEntitled: Called with the entitling event on purchase, restore, or an already-entitled purchase, regardless of `.heliumDismissBehavior`.
-    ///    With `config.dontShowIfAlreadyEntitled`, called with `.skipped` in place of `whenPaywallNotShown(.alreadyEntitled)`.
+    ///    With `config.dontShowIfAlreadyEntitled`, also called with `.skipped` when the paywall is skipped for an entitled user.
     ///   - loadingView: Custom view to show while paywall is loading
     ///   - whenPaywallNotShown: View to show when paywall is unavailable or skipped due to targeting/already-entitled
     public init<LoadingView: View>(
@@ -111,19 +111,11 @@ public struct HeliumPaywall<PaywallNotShownView: View>: View {
                     .environment(\.heliumLoadTimeTakenMS, resolvedLoadTimeTakenMS)
                     .environment(\.heliumDynamicPaywallTraits, config.customPaywallTraits)
             case .noShow(let reason):
-                if reason == .alreadyEntitled && handlesAlreadyEntitledSkip {
-                    EmptyView()
-                } else {
-                    paywallNotShownView(reason)
-                        .onAppear {
-                            onPaywallUnavailable(reason: reason)
-                        }
-                }
+                paywallNotShownView(reason)
+                    .onAppear {
+                        onPaywallUnavailable(reason: reason)
+                    }
             }
-        }
-        .onChange(of: state) { newState in
-            guard case .noShow(.alreadyEntitled) = newState, handlesAlreadyEntitledSkip else { return }
-            HeliumPaywallPresenter.shared.handleAlreadyEntitledSkip(trigger: trigger, context: presentationContext)
         }
         .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("HeliumConfigDownloadComplete"))) { _ in
             if case .waitingForPaywallsDownload = state, !loadingBudgetExpired {
@@ -185,10 +177,6 @@ public struct HeliumPaywall<PaywallNotShownView: View>: View {
             resolvedLoadTimeTakenMS = dispatchTimeDifferenceInMS(from: loadingStartTime)
         }
         state = newState
-    }
-
-    private var handlesAlreadyEntitledSkip: Bool {
-        presentationContext.onEntitled != nil
     }
     
     private func onPaywallUnavailable(reason: PaywallNotShownReason) {

--- a/Sources/Helium/HeliumCore/HeliumPaywall.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywall.swift
@@ -43,11 +43,14 @@ public struct HeliumPaywall<PaywallNotShownView: View>: View {
     ///   - trigger: The trigger name to display a paywall for
     ///   - config: Additional configuration options
     ///   - eventHandlers: Optional event handlers for paywall lifecycle events
-    ///   - whenPaywallNotShown: View to show when paywall is unavailable or skipped due to targeting
+    ///   - onEntitled: Called with the entitling event on purchase, restore, or an already-entitled purchase, regardless of `.heliumDismissBehavior`.
+    ///    With `config.dontShowIfAlreadyEntitled`, called with `.skipped` in place of `whenPaywallNotShown(.alreadyEntitled)`.
+    ///   - whenPaywallNotShown: View to show when paywall is unavailable or skipped due to targeting/already-entitled
     public init(
         trigger: String,
         config: PaywallPresentationConfig = PaywallPresentationConfig(),
         eventHandlers: PaywallEventHandlers? = nil,
+        onEntitled: ((PaywallEntitledEvent) -> Void)? = nil,
         @ViewBuilder whenPaywallNotShown: @escaping (PaywallNotShownReason) -> PaywallNotShownView
     ) {
         self.trigger = trigger
@@ -58,7 +61,7 @@ public struct HeliumPaywall<PaywallNotShownView: View>: View {
         self.presentationContext = PaywallPresentationContext(
             config: config,
             eventHandlers: eventHandlers,
-            onEntitled: nil,
+            onEntitled: onEntitled,
             onPaywallNotShown: nil
         )
         
@@ -71,12 +74,15 @@ public struct HeliumPaywall<PaywallNotShownView: View>: View {
     ///   - trigger: The trigger name to display a paywall for
     ///   - config: Additional configuration options
     ///   - eventHandlers: Optional event handlers for paywall lifecycle events
+    ///   - onEntitled: Called with the entitling event on purchase, restore, or an already-entitled purchase, regardless of `.heliumDismissBehavior`.
+    ///    With `config.dontShowIfAlreadyEntitled`, called with `.skipped` in place of `whenPaywallNotShown(.alreadyEntitled)`.
     ///   - loadingView: Custom view to show while paywall is loading
     ///   - whenPaywallNotShown: View to show when paywall is unavailable or skipped due to targeting/already-entitled
     public init<LoadingView: View>(
         trigger: String,
         config: PaywallPresentationConfig = PaywallPresentationConfig(),
         eventHandlers: PaywallEventHandlers? = nil,
+        onEntitled: ((PaywallEntitledEvent) -> Void)? = nil,
         @ViewBuilder loadingView: @escaping () -> LoadingView,
         @ViewBuilder whenPaywallNotShown: @escaping (PaywallNotShownReason) -> PaywallNotShownView
     ) {
@@ -88,7 +94,7 @@ public struct HeliumPaywall<PaywallNotShownView: View>: View {
         self.presentationContext = PaywallPresentationContext(
             config: config,
             eventHandlers: eventHandlers,
-            onEntitled: nil,
+            onEntitled: onEntitled,
             onPaywallNotShown: nil
         )
         
@@ -105,11 +111,19 @@ public struct HeliumPaywall<PaywallNotShownView: View>: View {
                     .environment(\.heliumLoadTimeTakenMS, resolvedLoadTimeTakenMS)
                     .environment(\.heliumDynamicPaywallTraits, config.customPaywallTraits)
             case .noShow(let reason):
-                paywallNotShownView(reason)
-                    .onAppear {
-                        onPaywallUnavailable(reason: reason)
-                    }
+                if reason == .alreadyEntitled && handlesAlreadyEntitledSkip {
+                    EmptyView()
+                } else {
+                    paywallNotShownView(reason)
+                        .onAppear {
+                            onPaywallUnavailable(reason: reason)
+                        }
+                }
             }
+        }
+        .onChange(of: state) { newState in
+            guard case .noShow(.alreadyEntitled) = newState, handlesAlreadyEntitledSkip else { return }
+            HeliumPaywallPresenter.shared.handleAlreadyEntitledSkip(trigger: trigger, context: presentationContext)
         }
         .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("HeliumConfigDownloadComplete"))) { _ in
             if case .waitingForPaywallsDownload = state, !loadingBudgetExpired {
@@ -172,14 +186,15 @@ public struct HeliumPaywall<PaywallNotShownView: View>: View {
         }
         state = newState
     }
+
+    private var handlesAlreadyEntitledSkip: Bool {
+        presentationContext.onEntitled != nil
+    }
     
     private func onPaywallUnavailable(reason: PaywallNotShownReason) {
         switch reason {
         case .alreadyEntitled:
-            HeliumPaywallDelegateWrapper.shared.fireEvent(
-                PaywallSkippedEvent(triggerName: trigger, skipReason: .alreadyEntitled),
-                paywallSession: nil
-            )
+            HeliumPaywallPresenter.shared.handleAlreadyEntitledSkip(trigger: trigger, context: presentationContext)
         case .targetingHoldout:
             HeliumPaywallPresenter.shared.handlePaywallSkip(trigger: trigger)
         case .error(unavailableReason: let unavailableReason):

--- a/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
+++ b/Sources/Helium/HeliumCore/HeliumPaywallDelegate.swift
@@ -313,6 +313,7 @@ class HeliumPaywallDelegateWrapper {
         
         // Mark session for onEntitled callback on purchase/restore success
         if let sessionId = overridePaywallSessionId ?? paywallSession?.sessionId,
+           (overridePresentationContext ?? paywallSession?.presentationContext)?.onEntitled != nil,
            let entitledEvent = PaywallEntitledEvent(entitlingEvent: event) {
             HeliumPaywallPresenter.shared.markSessionAsEntitled(sessionId: sessionId, event: entitledEvent)
         }

--- a/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
+++ b/Sources/Helium/HeliumPaywallPresentation/HeliumPaywallPresenter.swift
@@ -40,6 +40,13 @@ class HeliumPaywallPresenter {
     func consumeEntitledEvent(forSessionId sessionId: String) -> PaywallEntitledEvent? {
         return _sessionsWithEntitlement.withValue { $0.removeValue(forKey: sessionId) }
     }
+
+    func dispatchEntitledEvent(forSessionId sessionId: String, presentationContext: PaywallPresentationContext) {
+        guard let entitledEvent = consumeEntitledEvent(forSessionId: sessionId) else { return }
+        Task { @MainActor in
+            presentationContext.onEntitled?(entitledEvent)
+        }
+    }
     
     private func paywallEntitlementsCheck(trigger: String, context: PaywallPresentationContext) async -> Bool {
         if context.config.dontShowIfAlreadyEntitled {
@@ -483,14 +490,7 @@ class HeliumPaywallPresenter {
 
     private func dispatchCloseEvent(paywallVC: HeliumViewController) {
         dispatchOpenOrCloseEvent(openEvent: false, paywallVC: paywallVC)
-
-        // Call onEntitled if this session had a successful purchase/restore
-        let sessionId = paywallVC.paywallSession.sessionId
-        if let entitledEvent = consumeEntitledEvent(forSessionId: sessionId) {
-            Task { @MainActor in
-                paywallVC.presentationContext.onEntitled?(entitledEvent)
-            }
-        }
+        dispatchEntitledEvent(forSessionId: paywallVC.paywallSession.sessionId, presentationContext: paywallVC.presentationContext)
     }
     
     private func dispatchOpenOrCloseEvent(openEvent: Bool, paywallVC: HeliumViewController) {

--- a/Sources/Helium/HeliumPaywallViewModifier.swift
+++ b/Sources/Helium/HeliumPaywallViewModifier.swift
@@ -14,6 +14,7 @@ struct DynamicPaywallModifier<LoadingView: View, FallbackView: View>: ViewModifi
     let trigger: String
     let config: PaywallPresentationConfig
     let eventHandlers: PaywallEventHandlers?
+    let onEntitled: ((PaywallEntitledEvent) -> Void)?
     let loadingView: (() -> LoadingView)?
     let fallbackView: (PaywallNotShownReason) -> FallbackView
     
@@ -33,6 +34,7 @@ struct DynamicPaywallModifier<LoadingView: View, FallbackView: View>: ViewModifi
                 trigger: trigger,
                 config: config,
                 eventHandlers: eventHandlers,
+                onEntitled: onEntitled,
                 loadingView: loadingView,
                 whenPaywallNotShown: fallbackView
             )
@@ -41,6 +43,7 @@ struct DynamicPaywallModifier<LoadingView: View, FallbackView: View>: ViewModifi
                 trigger: trigger,
                 config: config,
                 eventHandlers: eventHandlers,
+                onEntitled: onEntitled,
                 whenPaywallNotShown: fallbackView
             )
         }
@@ -55,6 +58,7 @@ public extension View {
           trigger: String,
           config: PaywallPresentationConfig = PaywallPresentationConfig(),
           eventHandlers: PaywallEventHandlers? = nil,
+          onEntitled: ((PaywallEntitledEvent) -> Void)? = nil,
           @ViewBuilder loadingView: @escaping () -> LoadingView,
           @ViewBuilder fallbackView: @escaping (PaywallNotShownReason) -> PaywallNotShownView
       ) -> some View {
@@ -63,6 +67,7 @@ public extension View {
                trigger: trigger,
                config: config,
                eventHandlers: eventHandlers,
+               onEntitled: onEntitled,
                loadingView: loadingView,
                fallbackView: fallbackView
            ))
@@ -74,6 +79,7 @@ public extension View {
            trigger: String,
            config: PaywallPresentationConfig = PaywallPresentationConfig(),
            eventHandlers: PaywallEventHandlers? = nil,
+           onEntitled: ((PaywallEntitledEvent) -> Void)? = nil,
            @ViewBuilder fallbackView: @escaping (PaywallNotShownReason) -> PaywallNotShownView
        ) -> some View {
            self.modifier(DynamicPaywallModifier(
@@ -81,6 +87,7 @@ public extension View {
                trigger: trigger,
                config: config,
                eventHandlers: eventHandlers,
+               onEntitled: onEntitled,
                loadingView: nil as (() -> EmptyView)?,
                fallbackView: fallbackView
            ))

--- a/Sources/Helium/HeliumUIKitViewController.swift
+++ b/Sources/Helium/HeliumUIKitViewController.swift
@@ -14,6 +14,7 @@ public class HeliumPaywallPresentationState: ObservableObject {
     let viewType: PaywallOpenViewType
     weak var heliumViewController: HeliumViewController? = nil
     var isOpen: Bool = false // only used by .embedded and .triggered
+    var isInline: Bool { viewType != .presented }
     
     private let useAppearanceToSetIsOpen: Bool
     init(viewType: PaywallOpenViewType, useAppearanceToSetIsOpen: Bool = false) {

--- a/Tests/helium-swiftTests/Helpers/TestHelpers.swift
+++ b/Tests/helium-swiftTests/Helpers/TestHelpers.swift
@@ -100,7 +100,7 @@ class HeliumTestCase: XCTestCase {
     }
 
     /// Performs a quick RunLoop drain to flush pending MainActor tasks between tests.
-    private func drainMainActor() {
+    func drainMainActor() {
         let exp = XCTestExpectation(description: "MainActor drain")
         Task { @MainActor in
             Task { @MainActor in
@@ -213,22 +213,31 @@ func injectConfig(_ config: HeliumFetchedConfig, json: JSON? = nil) {
     HeliumFetchedConfigManager.shared.injectConfigForTesting(config, json: json)
 }
 
+func makeTestContext(
+    config: PaywallPresentationConfig = PaywallPresentationConfig(),
+    eventHandlers: PaywallEventHandlers? = nil,
+    onEntitled: ((PaywallEntitledEvent) -> Void)? = nil,
+    onPaywallNotShown: ((PaywallNotShownReason) -> Void)? = nil
+) -> PaywallPresentationContext {
+    PaywallPresentationContext(
+        config: config,
+        eventHandlers: eventHandlers,
+        onEntitled: onEntitled,
+        onPaywallNotShown: onPaywallNotShown
+    )
+}
+
 func makeTestSession(
     trigger: String = "test_trigger",
     eventHandlers: PaywallEventHandlers? = nil,
+    onEntitled: ((PaywallEntitledEvent) -> Void)? = nil,
     paywallInfo: HeliumPaywallInfo? = nil
 ) -> PaywallSession {
-    let context = PaywallPresentationContext(
-        config: PaywallPresentationConfig(),
-        eventHandlers: eventHandlers,
-        onEntitled: nil,
-        onPaywallNotShown: nil
-    )
     let info = paywallInfo ?? makeTestPaywallInfo(trigger: trigger)
     return PaywallSession(
         trigger: trigger,
         paywallInfo: info,
         fallbackType: .notFallback,
-        presentationContext: context
+        presentationContext: makeTestContext(eventHandlers: eventHandlers, onEntitled: onEntitled)
     )
 }

--- a/Tests/helium-swiftTests/PaywallEntitledEventTests.swift
+++ b/Tests/helium-swiftTests/PaywallEntitledEventTests.swift
@@ -49,7 +49,7 @@ final class PaywallEntitledEventTests: HeliumTestCase {
     // MARK: - fireEvent marks the session with the matching event
 
     func testFireEventMarksSessionForPurchaseSucceeded() {
-        let session = makeTestSession(trigger: "t")
+        let session = makeTestSession(trigger: "t", onEntitled: { _ in })
         let event = PurchaseSucceededEvent(
             productId: "com.test.product", triggerName: "t", paywallName: "p",
             storeKitTransactionId: "txn_1", storeKitOriginalTransactionId: nil
@@ -66,7 +66,7 @@ final class PaywallEntitledEventTests: HeliumTestCase {
     }
 
     func testFireEventMarksSessionForPurchaseRestored() {
-        let session = makeTestSession(trigger: "t")
+        let session = makeTestSession(trigger: "t", onEntitled: { _ in })
         let event = PurchaseRestoredEvent(
             productId: "com.test.product", triggerName: "t", paywallName: "p",
             restoreOrigin: .duringPurchase, paymentProcessor: .appStore
@@ -82,7 +82,7 @@ final class PaywallEntitledEventTests: HeliumTestCase {
     }
 
     func testFireEventMarksSessionForPurchaseAlreadyEntitled() {
-        let session = makeTestSession(trigger: "t")
+        let session = makeTestSession(trigger: "t", onEntitled: { _ in })
         let event = PurchaseAlreadyEntitledEvent(
             productId: "com.test.product", triggerName: "t", paywallName: "p",
             storeKitTransactionId: nil, storeKitOriginalTransactionId: nil
@@ -97,10 +97,22 @@ final class PaywallEntitledEventTests: HeliumTestCase {
     }
 
     func testFireEventDoesNotMarkSessionForNonEntitlingEvent() {
-        let session = makeTestSession(trigger: "t")
+        let session = makeTestSession(trigger: "t", onEntitled: { _ in })
         let event = PurchaseFailedEvent(productId: "com.test.product", triggerName: "t", paywallName: "p", paymentProcessor: .appStore)
         HeliumPaywallDelegateWrapper.shared.fireEvent(event, paywallSession: session)
         waitForEventDispatch { self.listener.eventsOfType(PurchaseFailedEvent.self).count == 1 }
+
+        XCTAssertNil(HeliumPaywallPresenter.shared.consumeEntitledEvent(forSessionId: session.sessionId))
+    }
+
+    func testFireEventDoesNotMarkSessionWithoutOnEntitled() {
+        let session = makeTestSession(trigger: "t")
+        let event = PurchaseSucceededEvent(
+            productId: "com.test.product", triggerName: "t", paywallName: "p",
+            storeKitTransactionId: nil, storeKitOriginalTransactionId: nil
+        )
+        HeliumPaywallDelegateWrapper.shared.fireEvent(event, paywallSession: session)
+        waitForEventDispatch { self.listener.eventsOfType(PurchaseSucceededEvent.self).count == 1 }
 
         XCTAssertNil(HeliumPaywallPresenter.shared.consumeEntitledEvent(forSessionId: session.sessionId))
     }
@@ -110,9 +122,8 @@ final class PaywallEntitledEventTests: HeliumTestCase {
     func testAlreadyEntitledSkipCallsOnEntitledWithSkippedEvent() {
         var received: PaywallEntitledEvent?
         var notShownReason: PaywallNotShownReason?
-        let context = PaywallPresentationContext(
+        let context = makeTestContext(
             config: PaywallPresentationConfig(dontShowIfAlreadyEntitled: true),
-            eventHandlers: nil,
             onEntitled: { received = $0 },
             onPaywallNotShown: { notShownReason = $0 }
         )
@@ -135,10 +146,8 @@ final class PaywallEntitledEventTests: HeliumTestCase {
 
     func testAlreadyEntitledSkipWithoutOnEntitledCallsOnPaywallNotShown() {
         var notShownReason: PaywallNotShownReason?
-        let context = PaywallPresentationContext(
+        let context = makeTestContext(
             config: PaywallPresentationConfig(dontShowIfAlreadyEntitled: true),
-            eventHandlers: nil,
-            onEntitled: nil,
             onPaywallNotShown: { notShownReason = $0 }
         )
 
@@ -146,6 +155,49 @@ final class PaywallEntitledEventTests: HeliumTestCase {
         waitForEventDispatch { notShownReason != nil }
 
         XCTAssertEqual(notShownReason, .alreadyEntitled)
+    }
+
+    func testDispatchEntitledEventCallsOnEntitledOnceAndConsumes() {
+        let purchased = PurchaseSucceededEvent(
+            productId: "com.test.product", triggerName: "t", paywallName: "p",
+            storeKitTransactionId: nil, storeKitOriginalTransactionId: nil
+        )
+        let sessionId = UUID().uuidString
+        var received: [PaywallEntitledEvent] = []
+        let context = makeTestContext(onEntitled: { received.append($0) })
+        HeliumPaywallPresenter.shared.markSessionAsEntitled(sessionId: sessionId, event: .purchased(purchased))
+
+        HeliumPaywallPresenter.shared.dispatchEntitledEvent(forSessionId: sessionId, presentationContext: context)
+        waitForEventDispatch { !received.isEmpty }
+        HeliumPaywallPresenter.shared.dispatchEntitledEvent(forSessionId: sessionId, presentationContext: context)
+        drainMainActor()
+
+        XCTAssertEqual(received.count, 1)
+        XCTAssertEqual(received.first?.productId, "com.test.product")
+        XCTAssertNil(HeliumPaywallPresenter.shared.consumeEntitledEvent(forSessionId: sessionId))
+    }
+
+    func testDispatchEntitledEventWithoutHandlerStillConsumesMark() {
+        let purchased = PurchaseSucceededEvent(
+            productId: "com.test.product", triggerName: "t", paywallName: "p",
+            storeKitTransactionId: nil, storeKitOriginalTransactionId: nil
+        )
+        let sessionId = UUID().uuidString
+        HeliumPaywallPresenter.shared.markSessionAsEntitled(sessionId: sessionId, event: .purchased(purchased))
+
+        HeliumPaywallPresenter.shared.dispatchEntitledEvent(forSessionId: sessionId, presentationContext: .empty)
+
+        XCTAssertNil(HeliumPaywallPresenter.shared.consumeEntitledEvent(forSessionId: sessionId))
+    }
+
+    func testDispatchEntitledEventWithoutMarkDoesNotCallOnEntitled() {
+        var received: PaywallEntitledEvent?
+        let context = makeTestContext(onEntitled: { received = $0 })
+
+        HeliumPaywallPresenter.shared.dispatchEntitledEvent(forSessionId: UUID().uuidString, presentationContext: context)
+        drainMainActor()
+
+        XCTAssertNil(received)
     }
 
     // MARK: - Accessors


### PR DESCRIPTION
## What

Adds an `onEntitled` handler to the embedded `HeliumPaywall` view and the `.heliumPaywall` modifier, matching `presentPaywall` and the Android embedded API.

```swift
HeliumPaywall(
    trigger: "onboarding",
    config: PaywallPresentationConfig(dontShowIfAlreadyEntitled: true),
    onEntitled: { event in /* advance yourself */ }
) { reason in
    Text("no show: \(reason.description)")
}
```

## Why

Hosts of the embedded view had to reconstruct "user is now entitled" from `onPurchaseSucceeded` / `onPurchaseRestored` and handle the already-entitled skip separately through `whenPaywallNotShown(.alreadyEntitled)`. With host-owned dismissal (#350) the host drives navigation after purchase, and `onEntitled` is the signal for that. The SDK already marked embedded sessions entitled on purchase, but only the presented close path consumed the mark, so those entries leaked.

## What changed

- `HeliumPaywall` inits and both `heliumPaywall(...)` overloads take `onEntitled: ((PaywallEntitledEvent) -> Void)? = nil`, passed through `PaywallPresentationContext`.
- `HeliumPaywallPresenter.dispatchEntitledEvent(forSessionId:presentationContext:)` consumes the marked event and calls the handler on the main actor. The presented close path uses it, and the inline SDK dismiss closure in `DynamicBaseTemplateView` calls it for embedded and triggered paywalls before the `.manual` guard, so it fires at the point the SDK would dismiss whether or not the view is removed. That closure is the single path for webview purchase and restore, already-entitled purchase, and external web checkout completion.
- With `dontShowIfAlreadyEntitled` and an entitled user, `whenPaywallNotShown(.alreadyEntitled)` renders as before and a provided `onEntitled` also receives `.skipped` with the same `PaywallSkippedEvent` sent to analytics, through the same `handleAlreadyEntitledSkip` path the presented flow uses.
- `fireEvent` only marks a session entitled when the context has an `onEntitled` handler. That removes the leak for handler-less sessions and for the detached pending-purchase session on every surface.
- `HeliumPaywallPresentationState.isInline` replaces the repeated `viewType != .presented` checks.

## Scope & behavior

- Presented paywalls: unchanged, `onEntitled` on close.
- Embedded and triggered: `onEntitled` is scheduled on the main actor at completion, before the view's `PaywallCloseEvent`.
- Pending (Ask to Buy) purchases that resolve after the paywall is gone still do not deliver `onEntitled`, as before, and no longer leave a mark behind.

## Testing

- Unit suite on the iPhone 17 simulator, 485 tests passing. New coverage: dispatch fires once and consumes, consumes without a handler, no call without a mark, no mark without a handler.
- Example app's embedded paywall wires `onEntitled`, ready for device testing of purchase, restore, and the already-entitled skip under `.automatic` and `.heliumDismissBehavior(.manual)`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches purchase/entitlement callback timing across embedded, triggered, and presented paywalls; behavior is well tested but hosts may depend on the new callback firing at dismiss time.
> 
> **Overview**
> Adds an optional **`onEntitled`** callback to embedded **`HeliumPaywall`** and the **`.heliumPaywall`** modifier so hosts get one signal after purchase, restore, already-entitled purchase, or an already-entitled skip when **`dontShowIfAlreadyEntitled`** is on—aligned with **`presentPaywall`** and host-owned dismissal.
> 
> Entitlement delivery is centralized in **`HeliumPaywallPresenter.dispatchEntitledEvent`**, used on presented close and in the inline dismiss path (**`HeliumBaseTemplateView`**) before the manual-dismiss guard, so embedded/triggered paywalls fire **`onEntitled`** even when the host keeps the view visible. **`fireEvent`** only marks sessions entitled when a handler is registered, fixing leaked marks for handler-less and pending-purchase sessions. The embedded **`.alreadyEntitled`** path now routes through **`handleAlreadyEntitledSkip`** instead of firing analytics only.
> 
> Tests cover dispatch-once/consume behavior and no-mark-without-handler; the example app logs **`onEntitled`** for the embedded paywall.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 697ce55dc53e2385516dade0e0e2421e222fea85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional entitlement callbacks to paywall views and modifiers.
  * Entitlement events now trigger the callback for inline and presented paywalls.
  * Added entitlement handling for already-entitled users.

* **Bug Fixes**
  * Sessions without an entitlement callback are no longer incorrectly marked as entitled.
  * Inline paywall registration and dismissal behavior is now handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->