### PR TITLE
Release 4.10.0

### DIFF
--- a/Sources/Helium/HeliumCore/BuildConstants.swift
+++ b/Sources/Helium/HeliumCore/BuildConstants.swift
@@ -8,5 +8,5 @@
  */
 public struct BuildConstants {
     /// Current SDK version
-    public static let version = "4.9.0"
+    public static let version = "4.10.0"
 }


### PR DESCRIPTION
Version bump to 4.10.0.

Included since 4.9.0:

- #346 dontShowIfAlreadyEntitled docstring
- #348 Block direct web paywall previews
- #349 Stale web bundle preview dialog
- #350 Manual dismissal for embedded paywalls
- #351 onEntitled for embedded HeliumPaywall and heliumPaywall modifier

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change with no runtime logic; it only advances the published SDK version and release automation.
> 
> **Overview**
> **Bumps the Helium SDK release version** from `4.9.0` to `4.10.0` by updating `BuildConstants.version` in `BuildConstants.swift`.
> 
> That file is the package/pod version source of truth and is wired into GitHub Actions, so this change is what triggers the **4.10.0 release** flow described in `CONTRIBUTING.md` (including pre-release behavior when the version ends in `-pre`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abb62389e7e8b04ddd74c520c16637752d10a665. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->